### PR TITLE
fix: make links always a single line

### DIFF
--- a/src/parsing/parse.rs
+++ b/src/parsing/parse.rs
@@ -479,6 +479,7 @@ fn parse_footnote_definition(footnote_definition: &FootnoteDefinition, context: 
 
 fn parse_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
+  context.is_in_link = true;
   let parsed_children = parse_nodes(&link.children, context);
   items.push_str("[");
 
@@ -499,6 +500,7 @@ fn parse_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
   }
   items.push_str(")");
 
+  context.is_in_link = false;
   parser_helpers::new_line_group(items)
 }
 
@@ -838,6 +840,9 @@ fn get_items_text(items: PrintItems) -> String {
 }
 
 fn get_space_or_newline_based_on_config(context: &Context) -> PrintItems {
+  if context.is_in_link {
+    return " ".into();
+  }
   match context.configuration.text_wrap {
     TextWrap::Always => Signal::SpaceOrNewLine.into(),
     TextWrap::Never | TextWrap::Maintain => " ".into(),

--- a/src/parsing/parser_types.rs
+++ b/src/parsing/parser_types.rs
@@ -12,6 +12,7 @@ pub struct Context<'a> {
   /** The current indentation level within the file being formatted. */
   pub raw_indent_level: u32,
   pub is_in_list_count: u32,
+  pub is_in_link: bool,
   pub format_code_block_text: Box<dyn FnMut(&str, &str, u32) -> Result<String, ErrBox> + 'a>,
   pub ignore_regex: Regex,
   pub ignore_start_regex: Regex,
@@ -30,6 +31,7 @@ impl<'a> Context<'a> {
       indent_level: 0,
       raw_indent_level: 0,
       is_in_list_count: 0,
+      is_in_link: false,
       format_code_block_text: Box::new(format_code_block_text),
       ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
       ignore_start_regex: get_ignore_comment_regex(&configuration.ignore_start_directive),

--- a/tests/specs/Links/Links_TextWrap_Always.txt
+++ b/tests/specs/Links/Links_TextWrap_Always.txt
@@ -6,22 +6,8 @@
 - [test](https://github.com) - Testing
   this out
 
-!! should stay on same line when text is half below line width !!
-[Style Guide](https://github.com/testing_this_out_with_some_link)
-
-[expect]
-[Style Guide](https://github.com/testing_this_out_with_some_link)
-
-!! should wrap once the children expand past half the width !!
+!! should always stay on same line !!
 [Style Guide testing this](https://github.com/testing_this_out_with_some_link)
 
 [expect]
-[Style Guide testing
-this](https://github.com/testing_this_out_with_some_link)
-
-!! should wrap before link !!
-Testing this out [test](https://google.com)
-
-[expect]
-Testing this out
-[test](https://google.com)
+[Style Guide testing this](https://github.com/testing_this_out_with_some_link)


### PR DESCRIPTION
This matches the behavior of Prettier, which never introduces newlines into the link title.

resolves #53 