### PR TITLE
fix: table formatting for cells containing double-width characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "unicode-width",
 ]
 
 [[package]]
@@ -268,9 +269,9 @@ checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pulldown-cmark = { version = "0.9.2", default-features = false }
 regex = "1"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+unicode-width = "0.1.10"
 
 [dev-dependencies]
 dprint-development = "0.9.1"

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -8,6 +8,7 @@ use dprint_core::formatting::ir_helpers::*;
 use dprint_core::formatting::*;
 use std::borrow::Cow;
 use std::rc::Rc;
+use unicode_width::UnicodeWidthStr;
 
 pub fn generate(node: &Node, context: &mut Context) -> PrintItems {
   // println!("Kind: {:?}", node.kind());
@@ -878,8 +879,7 @@ fn clone_items(items: PrintItems) -> (PrintItems, PrintItems) {
 }
 
 fn measure_single_line_width(items: PrintItems) -> usize {
-  // this doesn't seem ideal, but good enough for now
-  get_items_text(items).chars().count()
+  get_items_text(items).width()
 }
 
 fn get_items_text(items: PrintItems) -> String {

--- a/tests/specs/Tables/Tables_All.txt
+++ b/tests/specs/Tables/Tables_All.txt
@@ -35,3 +35,14 @@ test
 | :---: |
 | testd |
 | test  |
+
+!! Should correctly determine column width for cells containing double-width characters like emoji !!
+
+| Name             | Required |
+| ---------------- | :------: |
+| test             |    ❌    |
+
+[expect]
+| Name | Required |
+| ---- | :------: |
+| test |    ❌    |


### PR DESCRIPTION
I noticed that dprint was formatting tables containing double-width unicode characters (such as emoji) incorrectly, causing the column divider to shift to the right. This can be fixed by correctly determining the width of unicode characters instead of simply counting the number of characters in a cell.
I also added a test for it.

Not sure if there's a performance penalty or if this should be optimized further.
