### PR TITLE
fix: handle links going multi to single line when single line length under lineWidth / 2

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -55,7 +55,7 @@ impl<'a> EventIterator<'a> {
 
   fn move_iterator_next(&mut self) -> Option<(Event<'a>, Range)> {
     let next = self.iterator.next();
-    // println!("Raw event: {:?}", next);
+    // eprintln!("Raw event: {:?}", next);
 
     match next {
       Some((Event::Start(Tag::Table(_)), _)) => self.in_table_count += 1,

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -2,7 +2,8 @@ use dprint_core::plugins::FormatResult;
 use regex::Regex;
 
 use super::utils::*;
-use crate::{configuration::Configuration, format_text};
+use crate::configuration::Configuration;
+use crate::format_text;
 
 pub struct Context<'a> {
   pub file_text: &'a str,
@@ -65,10 +66,10 @@ impl<'a> Context<'a> {
     let line_width = std::cmp::max(10, self.configuration.line_width as i32 - self.indent_level as i32) as u32;
 
     match tag {
-      "markdown" | "md" => format_text(text, self.configuration, |tag, file_text, line_width | {
+      "markdown" | "md" => format_text(text, self.configuration, |tag, file_text, line_width| {
         (self.format_code_block_text)(tag, file_text, line_width)
       }),
-      _ => (self.format_code_block_text)(tag, text, line_width)
+      _ => (self.format_code_block_text)(tag, text, line_width),
     }
   }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -908,7 +908,19 @@ fn get_newline_wrapping_based_on_config(context: &Context) -> PrintItems {
   match context.configuration.text_wrap {
     TextWrap::Always => Signal::SpaceOrNewLine.into(),
     TextWrap::Never => " ".into(),
-    TextWrap::Maintain => Signal::NewLine.into(),
+    TextWrap::Maintain => {
+      if context.is_text_wrap_disabled() {
+        if_true_or(
+          "newLineOrSpaceIfNewlinesDisabled",
+          condition_resolvers::is_forcing_no_newlines(),
+          " ".into(),
+          Signal::NewLine.into(),
+        )
+        .into()
+      } else {
+        Signal::NewLine.into()
+      }
+    }
   }
 }
 

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -62,3 +62,10 @@ Testing <https://google.com> this.
 
 [expect]
 [![CI](image.svg)](https://github.com)
+
+!! should handle going multi-line to single line within a link !!
+Test [this
+out](/test) test
+
+[expect]
+Test [this out](/test) test


### PR DESCRIPTION
Fixes this scenario...

Input:

```md
Test [this
out](/test) test
```

Expected/now output:

```md
Test [this out](/test) test
```

Actual/previous output:

```md
Test [thisout](/test) test
```