### PR TITLE
fix: handle formatting file with only link reference definitions

### DIFF
--- a/src/generation/common/ast_nodes.rs
+++ b/src/generation/common/ast_nodes.rs
@@ -274,7 +274,7 @@ impl Node {
     if range.start == 0 {
       false
     } else {
-      file_text.as_bytes().get(range.start - 1) == " ".as_bytes().get(0)
+      file_text.as_bytes().get(range.start - 1) == " ".as_bytes().first()
     }
   }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -72,7 +72,7 @@ fn gen_source_file(source_file: &SourceFile, context: &mut Context) -> PrintItem
 
 fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
-  if nodes.len() == 0 {
+  if nodes.is_empty() {
     return items;
   }
 

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -69,3 +69,9 @@ out](/test) test
 
 [expect]
 Test [this out](/test) test
+
+!! handle when file only has link reference directive !!
+[Some reference]: https://github.com
+
+[expect]
+[Some reference]: https://github.com


### PR DESCRIPTION
Also part of https://github.com/dprint/dprint-plugin-markdown/issues/72