### PR TITLE
feat: allow configuration of unordered list character

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -60,8 +60,8 @@
         "description": "Uses underscores (__) for strong emphasis."
       }]
     },
-    "primaryListKind": {
-      "description": "The character to use primarily for lists.",
+    "unorderedListKind": {
+      "description": "The character to use for unordered lists.",
       "type": "string",
       "default": "dashes",
       "oneOf": [{

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -60,6 +60,18 @@
         "description": "Uses underscores (__) for strong emphasis."
       }]
     },
+    "primaryListKind": {
+      "description": "The character to use primarily for lists.",
+      "type": "string",
+      "default": "dashes",
+      "oneOf": [{
+        "const": "dashes",
+        "description": "Uses dashes (-) as primary character for lists."
+      }, {
+        "const": "asterisks",
+        "description": "Uses asterisks (*) as primary character for lists."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -73,6 +73,12 @@ impl ConfigurationBuilder {
     self.insert("strongKind", value.to_string().into())
   }
 
+  /// The character to use for lists.
+  /// Default: `UnorderedListKind::Dashes`
+  pub fn unordered_list_kind(&mut self, value: UnorderedListKind) -> &mut Self {
+    self.insert("unorderedListKind", value.to_string().into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -133,13 +139,14 @@ mod tests {
       .text_wrap(TextWrap::Always)
       .emphasis_kind(EmphasisKind::Asterisks)
       .strong_kind(StrongKind::Underscores)
+      .unordered_list_kind(UnorderedListKind::Asterisks)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 9);
+    assert_eq!(inner_config.len(), 10);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -54,10 +54,10 @@ pub fn resolve_config(
     text_wrap: get_value(&mut config, "textWrap", TextWrap::Maintain, &mut diagnostics),
     emphasis_kind: get_value(&mut config, "emphasisKind", EmphasisKind::Underscores, &mut diagnostics),
     strong_kind: get_value(&mut config, "strongKind", StrongKind::Asterisks, &mut diagnostics),
-    primary_list_kind: get_value(
+    unordered_list_kind: get_value(
       &mut config,
-      "primaryListKind",
-      PrimaryListKind::Dashes,
+      "unorderedListKind",
+      UnorderedListKind::Dashes,
       &mut diagnostics,
     ),
     ignore_directive: get_value(

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -54,6 +54,12 @@ pub fn resolve_config(
     text_wrap: get_value(&mut config, "textWrap", TextWrap::Maintain, &mut diagnostics),
     emphasis_kind: get_value(&mut config, "emphasisKind", EmphasisKind::Underscores, &mut diagnostics),
     strong_kind: get_value(&mut config, "strongKind", StrongKind::Asterisks, &mut diagnostics),
+    primary_list_kind: get_value(
+      &mut config,
+      "primaryListKind",
+      PrimaryListKind::Dashes,
+      &mut diagnostics,
+    ),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -12,7 +12,7 @@ pub struct Configuration {
   pub text_wrap: TextWrap,
   pub emphasis_kind: EmphasisKind,
   pub strong_kind: StrongKind,
-  pub primary_list_kind: PrimaryListKind,
+  pub unordered_list_kind: UnorderedListKind,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,
@@ -66,7 +66,7 @@ generate_str_to_from![StrongKind, [Asterisks, "asterisks"], [Underscores, "under
 /// which is _not_ primary.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum PrimaryListKind {
+pub enum UnorderedListKind {
   /// Uses dashes (-) as primary character for lists (default).
   ///
   /// In this case, asterisks are used as alternate list chracters.
@@ -77,7 +77,7 @@ pub enum PrimaryListKind {
   Asterisks,
 }
 
-impl PrimaryListKind {
+impl UnorderedListKind {
   /// Determine the character to use for a list, i.e., '-' or '*'.
   ///
   /// The result depends on the configuration and whether the primary or alternate character is
@@ -90,4 +90,4 @@ impl PrimaryListKind {
   }
 }
 
-generate_str_to_from![PrimaryListKind, [Dashes, "dashes"], [Asterisks, "asterisks"]];
+generate_str_to_from![UnorderedListKind, [Dashes, "dashes"], [Asterisks, "asterisks"]];

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -12,6 +12,7 @@ pub struct Configuration {
   pub text_wrap: TextWrap,
   pub emphasis_kind: EmphasisKind,
   pub strong_kind: StrongKind,
+  pub primary_list_kind: PrimaryListKind,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,
@@ -55,3 +56,38 @@ pub enum StrongKind {
 }
 
 generate_str_to_from![StrongKind, [Asterisks, "asterisks"], [Underscores, "underscores"]];
+
+/// The character to use primarily for lists.
+///
+/// Unnumbered lists will be formatted to use a common list character, i.e., the primary list
+/// character. Additionally, an alternate list character is used to separate lists which are not
+/// separated by other paragraphs. This parameter defines which character should be used as primary
+/// list character, i.e., either '-' (default) or '*'. The alternate list character will be the one
+/// which is _not_ primary.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PrimaryListKind {
+  /// Uses dashes (-) as primary character for lists (default).
+  ///
+  /// In this case, asterisks are used as alternate list chracters.
+  Dashes,
+  /// Uses asterisks (*) as primary character for lists.
+  ///
+  /// In this case, dashes are used as alternate list chracters.
+  Asterisks,
+}
+
+impl PrimaryListKind {
+  /// Determine the character to use for a list, i.e., '-' or '*'.
+  ///
+  /// The result depends on the configuration and whether the primary or alternate character is
+  /// requested. See [`Self`].
+  pub fn list_char(&self, is_alternate: bool) -> char {
+    match (self, is_alternate) {
+      (Self::Dashes, true) | (Self::Asterisks, false) => '*',
+      _ => '-',
+    }
+  }
+}
+
+generate_str_to_from![PrimaryListKind, [Dashes, "dashes"], [Asterisks, "asterisks"]];

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -282,7 +282,7 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
           {
             let mut items = PrintItems::new();
             items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::FinishIndent(indent_level)));
-            items.push_str("> ");
+            items.push_sc(sc!("> "));
             items.push_optional_path(
               context.get_memoized_rc_path(MemoizedRcPathKind::StartWithSingleIndent(indent_level)),
             );
@@ -298,7 +298,7 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
           {
             let mut items = PrintItems::new();
             items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::FinishIndent(indent_level)));
-            items.push_str(">");
+            items.push_sc(sc!(">"));
             items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::StartIndent(indent_level)));
             items
           },
@@ -661,7 +661,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         };
         format!("{}{}", display_index, end_char)
       } else {
-        String::from(context.configuration.primary_list_kind.list_char(is_alternate))
+        String::from(context.configuration.unordered_list_kind.list_char(is_alternate))
       };
       let indent_increment = (prefix_text.chars().count() + 1) as u32;
       context.indent_level += indent_increment;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -637,7 +637,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         };
         format!("{}{}", display_index, end_char)
       } else {
-        String::from(if is_alternate { "*" } else { "-" })
+        String::from(context.configuration.primary_list_kind.list_char(is_alternate))
       };
       let indent_increment = (prefix_text.chars().count() + 1) as u32;
       context.indent_level += indent_increment;

--- a/tests/specs/Lists/Lists_ListKind_Asterisks.txt
+++ b/tests/specs/Lists/Lists_ListKind_Asterisks.txt
@@ -1,0 +1,38 @@
+~~ lineWidth: 40, unorderedListKind: asterisks ~~
+!! should format an unordered list with asterisks !!
+- A
+- B
+-   C
+
+[expect]
+* A
+* B
+* C
+
+!! should format an unordered list with plus signs !!
++ A
++ B
++   C
+
+[expect]
+* A
+* B
+* C
+
+!! should handle multiple lists one after the other !!
+* test
+* test
+
+- test
+- test
+
+* test
+
+[expect]
+* test
+* test
+
+- test
+- test
+
+* test


### PR DESCRIPTION
Various characters can be used for unnumbered lists. The default are dashes. However, in some projects asterisks are preferred. As of now, there was no way to configure the primary list character.

This is now added with a configuration parameter `primaryListKind`.

Btw, I didn't find any description for contribution. Let me know if you have preferences of any kind.