### PR TITLE
documentation: Extend README on how to build `.wasm` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@
 Markdown formatting plugin for dprint.
 
 This uses the [pulldown-cmark](https://github.com/raphlinus/pulldown-cmark) parser for markdown.
+
+## Building `.wasm` File as Plugin for `dprint`
+
+If you want to build a `.wasm` file to be used as a plugin for `dprint` the following command can be used:
+
+```
+cargo build --release --target=wasm32-unknown-unknown --features="wasm"
+```
+
+The `--release` parameter is optional. The generated `.wasm` file can then be found in the target directory.
+
+Note that this requires adding `wasm32` as a Rust target. This can be done using the following command:
+
+```
+rustup target add wasm32-unknown-unknown
+```


### PR DESCRIPTION
It might not be obvious for everyone how to build a `.wasm` file to be used as a plugin for `dprint`. Thus, extending the `README.md` with a brief section.