### PR TITLE
fix: support block quote callouts

### DIFF
--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -108,6 +108,10 @@ impl<'a> Context<'a> {
     self.is_in_list_count > 0
   }
 
+  pub fn is_in_block_quote(&self) -> bool {
+    self.is_in_block_quote_count > 0
+  }
+
   pub fn with_no_text_wrap<T>(&mut self, func: impl FnOnce(&mut Context) -> T) -> T {
     self.text_wrap_disabled_count += 1;
     let items = func(self);

--- a/tests/specs/BlockQuotes/Callouts.txt
+++ b/tests/specs/BlockQuotes/Callouts.txt
@@ -1,0 +1,24 @@
+~~ textWrap: always ~~
+!! should format !!
+> [!NOTE]
+> Some sort of note
+
+[expect]
+> [!NOTE]
+> Some sort of note
+
+!! should format when just a callout !!
+> [!NOTE]
+
+[expect]
+> [!NOTE]
+
+!! should format when has blank line !!
+> [!NOTE]
+>
+> Some sort of note
+
+[expect]
+> [!NOTE]
+>
+> Some sort of note


### PR DESCRIPTION
Makes this work when text wrapping is enabled:

```
> [!NOTE]
> Some note goes here.
```