### PR TITLE
fix(regression): handle escaping | in code blocks in tables

### DIFF
--- a/tests/specs/Issues/Issue0117.txt
+++ b/tests/specs/Issues/Issue0117.txt
@@ -1,0 +1,15 @@
+!! should format !!
+| f\|oo  |
+| ------ |
+| b `\|` az |
+| b **\|** im |
+| test \| test |
+| `command \| filter` |
+
+[expect]
+| f\|oo               |
+| ------------------- |
+| b `\|` az           |
+| b **\|** im         |
+| test \| test        |
+| `command \| filter` |


### PR DESCRIPTION
Closes https://github.com/dprint/dprint-plugin-markdown/issues/117