### PR TITLE
fix: regression formatting inline math

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -207,8 +207,8 @@ fn parse_event(event: Event, iterator: &mut EventIterator) -> Result<Node, Parse
       }
       .into(),
     ),
-    Event::InlineMath(text) => parse_math(text, iterator).map(|n| n.into()),
-    Event::DisplayMath(text) => parse_math(text, iterator).map(|n| n.into()),
+    Event::InlineMath(text) => parse_inline_math(text, iterator).map(|n| n.into()),
+    Event::DisplayMath(text) => parse_display_math(text, iterator).map(|n| n.into()),
   }
 }
 
@@ -422,8 +422,14 @@ fn parse_html(text: CowStr, iterator: &mut EventIterator) -> Result<Html, ParseE
   })
 }
 
-fn parse_math(_text: CowStr, iterator: &mut EventIterator) -> Result<Math, ParseError> {
-  Ok(Math {
+fn parse_display_math(_text: CowStr, iterator: &mut EventIterator) -> Result<DisplayMath, ParseError> {
+  Ok(DisplayMath {
+    range: iterator.get_last_range(),
+  })
+}
+
+fn parse_inline_math(_text: CowStr, iterator: &mut EventIterator) -> Result<InlineMath, ParseError> {
+  Ok(InlineMath {
     range: iterator.get_last_range(),
   })
 }

--- a/src/generation/common/ast_nodes.rs
+++ b/src/generation/common/ast_nodes.rs
@@ -58,7 +58,11 @@ pub struct Html {
   pub range: Range,
 }
 
-pub struct Math {
+pub struct DisplayMath {
+  pub range: Range,
+}
+
+pub struct InlineMath {
   pub range: Range,
 }
 
@@ -336,5 +340,6 @@ generate_node![
   TableRow,
   TableCell,
   MetadataBlock,
-  Math
+  DisplayMath,
+  InlineMath
 ];

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -27,7 +27,8 @@ pub fn generate(node: &Node, context: &mut Context) -> PrintItems {
     Node::Text(node) => gen_text(node, context),
     Node::TextDecoration(node) => gen_text_decoration(node, context),
     Node::Html(node) => gen_html(node, context),
-    Node::Math(node) => gen_math(node, context),
+    Node::DisplayMath(node) => gen_display_math(node, context),
+    Node::InlineMath(node) => gen_inline_math(node, context),
     Node::FootnoteReference(node) => gen_footnote_reference(node, context),
     Node::FootnoteDefinition(node) => gen_footnote_definition(node, context),
     Node::InlineLink(node) => gen_inline_link(node, context),
@@ -116,7 +117,8 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
           | Node::List(_)
           | Node::Table(_)
           | Node::MetadataBlock(_)
-          | Node::BlockQuote(_) => {
+          | Node::BlockQuote(_)
+          | Node::DisplayMath(_) => {
             items.extend(get_conditional_blank_line(node.range(), context));
           }
           Node::Code(_)
@@ -130,7 +132,8 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
           | Node::Text(_)
           | Node::Html(_)
           | Node::InlineImage(_)
-          | Node::ReferenceImage(_) => {
+          | Node::ReferenceImage(_)
+          | Node::InlineMath(_) => {
             let between_range = (last_node.range().end, node.range().start);
             let new_line_count = context.get_new_lines_in_range(between_range.0, between_range.1);
 
@@ -195,8 +198,7 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
           | Node::HardBreak(_)
           | Node::TableHead(_)
           | Node::TableRow(_)
-          | Node::TableCell(_)
-          | Node::Math(_) => {}
+          | Node::TableCell(_) => {}
         }
       }
     }
@@ -582,7 +584,11 @@ fn gen_html(node: &Html, ctx: &mut Context) -> PrintItems {
   gen_range(node.range.clone(), ctx)
 }
 
-fn gen_math(node: &Math, ctx: &mut Context) -> PrintItems {
+fn gen_display_math(node: &DisplayMath, ctx: &mut Context) -> PrintItems {
+  gen_range(node.range.clone(), ctx)
+}
+
+fn gen_inline_math(node: &InlineMath, ctx: &mut Context) -> PrintItems {
   gen_range(node.range.clone(), ctx)
 }
 

--- a/tests/specs/MathBlocks/MathBlocks_Spacing.txt
+++ b/tests/specs/MathBlocks/MathBlocks_Spacing.txt
@@ -1,0 +1,43 @@
+!! should maintain spacing in this example !!
+## Math rendering
+
+We support code blocks with the "math" type!
+
+```math
+G_{\mu v} = \frac{8 \pi G}{c^4} T_{\mu v}
+```
+
+We also support math blocks and inline math blocks as well!
+
+When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
+
+$$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
+
+You can even typeset individual letters or whole sentences inline just like $x$
+or $Quadratic \; formula$. You can also use math blocks to typeset whole
+equations with $\LaTeX$:
+
+$$ \begin{aligned} \dot{x} & = \sigma(y-x) \\ \dot{y} & = \rho x - y - xz \\
+\dot{z} & = -\beta z + xy \end{aligned} $$
+
+[expect]
+## Math rendering
+
+We support code blocks with the "math" type!
+
+```math
+G_{\mu v} = \frac{8 \pi G}{c^4} T_{\mu v}
+```
+
+We also support math blocks and inline math blocks as well!
+
+When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
+
+$$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
+
+You can even typeset individual letters or whole sentences inline just like $x$
+or $Quadratic \; formula$. You can also use math blocks to typeset whole
+equations with $\LaTeX$:
+
+$$ \begin{aligned} \dot{x} & = \sigma(y-x) \\ \dot{y} & = \rho x - y - xz \\
+\dot{z} & = -\beta z + xy \end{aligned} $$


### PR DESCRIPTION
There were a lot of updates to the parser that broke how the formatter worked (they were good updates overall, just the code wasn't handling it properly now).