### PR TITLE
fix: line wrapping within inline code

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -13,8 +13,8 @@ struct EventIterator<'a> {
   last_range: Range,
   next: Option<(Event<'a>, Range)>,
   allow_empty_text_events: bool,
-  in_table_count: i8,
-  in_block_quote_count: i8,
+  in_table_count: usize,
+  in_block_quote_count: usize,
 }
 
 impl<'a> EventIterator<'a> {
@@ -63,20 +63,22 @@ impl<'a> EventIterator<'a> {
 
     match next {
       Some((Event::Start(Tag::Table(_)), _)) => self.in_table_count += 1,
-      Some((Event::End(TagEnd::Table), _)) => self.in_table_count -= 1,
+      Some((Event::End(TagEnd::Table), _)) => self.in_table_count = self.in_table_count.saturating_sub(1),
       Some((Event::Start(Tag::BlockQuote(_)), _)) => self.in_block_quote_count += 1,
-      Some((Event::End(TagEnd::BlockQuote), _)) => self.in_block_quote_count -= 1,
+      Some((Event::End(TagEnd::BlockQuote), _)) => {
+        self.in_block_quote_count = self.in_block_quote_count.saturating_sub(1)
+      }
       _ => {}
     }
 
     next
   }
 
-  pub fn in_table_count(&self) -> i8 {
+  pub fn in_table_count(&self) -> usize {
     self.in_table_count
   }
 
-  pub fn in_block_quote_count(&self) -> i8 {
+  pub fn in_block_quote_count(&self) -> usize {
     self.in_block_quote_count
   }
 
@@ -378,8 +380,8 @@ fn parse_code(iterator: &mut EventIterator) -> Result<Code, ParseError> {
 
 /// A code span may span multiple lines, in which case the raw text of the
 /// continuation lines still contains the block quote markers they're within.
-fn strip_block_quote_markers(text: &str, block_quote_count: i8) -> String {
-  if block_quote_count <= 0 || !text.contains('\n') {
+fn strip_block_quote_markers(text: &str, block_quote_count: usize) -> String {
+  if block_quote_count == 0 || !text.contains('\n') {
     return text.to_string();
   }
 
@@ -394,12 +396,20 @@ fn strip_block_quote_markers(text: &str, block_quote_count: i8) -> String {
   }
   return result;
 
-  fn strip_line_block_quote_markers(line: &str, block_quote_count: i8) -> &str {
+  fn strip_line_block_quote_markers(line: &str, block_quote_count: usize) -> &str {
+    // a marker may be indented up to three spaces. Any further and it's part
+    // of the code span's text rather than a marker
+    const MAX_MARKER_INDENT: usize = 3;
+
     let mut line = line;
     for _ in 0..block_quote_count {
-      let trimmed = line.trim_start();
-      match trimmed.strip_prefix('>') {
-        Some(text) => line = text,
+      let indent = line.len() - line.trim_start_matches(' ').len();
+      if indent > MAX_MARKER_INDENT {
+        break;
+      }
+      match line[indent..].strip_prefix('>') {
+        // a single space following the marker is part of the marker
+        Some(text) => line = text.strip_prefix(' ').unwrap_or(text),
         None => break,
       }
     }

--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -14,21 +14,24 @@ struct EventIterator<'a> {
   next: Option<(Event<'a>, Range)>,
   allow_empty_text_events: bool,
   in_table_count: i8,
+  in_block_quote_count: i8,
 }
 
 impl<'a> EventIterator<'a> {
   pub fn new(file_text: &'a str, iterator: OffsetIter<'a, DefaultBrokenLinkCallback>) -> EventIterator<'a> {
-    let mut iterator = iterator;
-    let next = iterator.next();
-    // eprintln!("Raw event: {:?}", next);
-    EventIterator {
+    let mut event_iterator = EventIterator {
       file_text,
       iterator,
       last_range: Range { start: 0, end: 0 },
-      next,
+      next: None,
       allow_empty_text_events: false,
       in_table_count: 0,
-    }
+      in_block_quote_count: 0,
+    };
+    // get the first event through the same code path as the rest
+    // so that the nesting counts are kept up to date
+    event_iterator.next = event_iterator.move_iterator_next();
+    event_iterator
   }
 
   pub fn next(&mut self) -> Option<Event<'a>> {
@@ -61,6 +64,8 @@ impl<'a> EventIterator<'a> {
     match next {
       Some((Event::Start(Tag::Table(_)), _)) => self.in_table_count += 1,
       Some((Event::End(TagEnd::Table), _)) => self.in_table_count -= 1,
+      Some((Event::Start(Tag::BlockQuote(_)), _)) => self.in_block_quote_count += 1,
+      Some((Event::End(TagEnd::BlockQuote), _)) => self.in_block_quote_count -= 1,
       _ => {}
     }
 
@@ -69,6 +74,10 @@ impl<'a> EventIterator<'a> {
 
   pub fn in_table_count(&self) -> i8 {
     self.in_table_count
+  }
+
+  pub fn in_block_quote_count(&self) -> i8 {
+    self.in_block_quote_count
   }
 
   pub fn start(&self) -> usize {
@@ -363,8 +372,39 @@ fn parse_code(iterator: &mut EventIterator) -> Result<Code, ParseError> {
   }
   Ok(Code {
     range: iterator.get_last_range(),
-    code: raw_text.to_string(),
+    code: strip_block_quote_markers(&raw_text.replace("\r\n", "\n"), iterator.in_block_quote_count()),
   })
+}
+
+/// A code span may span multiple lines, in which case the raw text of the
+/// continuation lines still contains the block quote markers they're within.
+fn strip_block_quote_markers(text: &str, block_quote_count: i8) -> String {
+  if block_quote_count <= 0 || !text.contains('\n') {
+    return text.to_string();
+  }
+
+  let mut result = String::with_capacity(text.len());
+  for (i, line) in text.split('\n').enumerate() {
+    if i > 0 {
+      result.push('\n');
+      result.push_str(strip_line_block_quote_markers(line, block_quote_count));
+    } else {
+      result.push_str(line);
+    }
+  }
+  return result;
+
+  fn strip_line_block_quote_markers(line: &str, block_quote_count: i8) -> &str {
+    let mut line = line;
+    for _ in 0..block_quote_count {
+      let trimmed = line.trim_start();
+      match trimmed.strip_prefix('>') {
+        Some(text) => line = text,
+        None => break,
+      }
+    }
+    line
+  }
 }
 
 fn parse_text(iterator: &mut EventIterator) -> Result<Text, ParseError> {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -494,9 +494,66 @@ fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   // always stay attached to it when the text is wrapped
   let mut items = PrintItems::new();
   items.push_string(format!("{}{}", backtick_text, separator));
-  items.extend(gen_str(text, context));
+  items.extend(gen_code_str(text, context));
   items.push_string(format!("{}{}", separator, backtick_text));
   items
+}
+
+/// Generates the text of a code span.
+///
+/// This can't use `gen_str` because a code span renders its content verbatim
+/// apart from line endings, which render as a single space. So a run of a
+/// single space or line ending is a place the text may be wrapped, but any
+/// longer run of whitespace has to be kept at its original width.
+fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  let mut current_word = String::new();
+  let mut was_last_newline = false;
+  let mut chars = text.chars().peekable();
+
+  while let Some(c) = chars.next() {
+    if c != ' ' && c != '\n' {
+      current_word.push(c);
+      continue;
+    }
+
+    let mut whitespace_count = 1;
+    while chars.peek().map(|c| *c == ' ' || *c == '\n').unwrap_or(false) {
+      whitespace_count += 1;
+      chars.next();
+    }
+
+    if whitespace_count == 1 && chars.peek().is_some() {
+      push_word(&mut items, &mut current_word, was_last_newline, context);
+      was_last_newline = c == '\n' && context.configuration.text_wrap == TextWrap::Maintain;
+    } else {
+      // keep the width the same because a line ending renders as a space
+      current_word.push_str(&" ".repeat(whitespace_count));
+    }
+  }
+
+  push_word(&mut items, &mut current_word, was_last_newline, context);
+
+  return items;
+
+  fn push_word(items: &mut PrintItems, word: &mut String, was_last_newline: bool, context: &Context) {
+    if word.is_empty() {
+      return;
+    }
+    if !items.is_empty() {
+      // a chunk may have significant whitespace merged into it, so only the
+      // leading token decides whether it could start a block
+      let leading_token = word.split(' ').next().unwrap_or(word);
+      if utils::is_block_start_word(leading_token) {
+        items.push_space();
+      } else if was_last_newline {
+        items.push_signal(Signal::NewLine);
+      } else {
+        items.extend(get_space_or_newline_based_on_config(context));
+      }
+    }
+    items.push_string(std::mem::take(word));
+  }
 }
 
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {
@@ -570,7 +627,7 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     fn flush_current_word(&mut self) {
       if let Some(current_word) = self.current_word.take() {
         if !self.items.is_empty() {
-          if utils::is_list_word(&current_word) {
+          if utils::is_block_start_word(&current_word) {
             self.items.push_space();
           } else if self.was_last_newline {
             self.items.push_signal(Signal::NewLine)

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -490,8 +490,13 @@ fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
     }
   }
 
-  let full_string = format!("{0}{1}{2}{1}{0}", backtick_text, separator, text);
-  gen_str(&full_string, context)
+  // only the text is run through the text builder so that the backticks
+  // always stay attached to it when the text is wrapped
+  let mut items = PrintItems::new();
+  items.push_string(format!("{}{}", backtick_text, separator));
+  items.extend(gen_str(text, context));
+  items.push_string(format!("{}{}", separator, backtick_text));
+  items
 }
 
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -479,7 +479,7 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
   }
 }
 
-fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
+fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   let text = code.code.trim();
   let mut backtick_text = "`";
   let mut separator = "";
@@ -490,7 +490,8 @@ fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
     }
   }
 
-  format!("{0}{1}{2}{1}{0}", backtick_text, separator, text).into()
+  let full_string = format!("{0}{1}{2}{1}{0}", backtick_text, separator, text);
+  gen_str(&full_string, context)
 }
 
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -2,6 +2,43 @@ use std::borrow::Cow;
 
 use regex::Regex;
 
+/// Checks if the provided word would start a new block when it appears at the
+/// start of a line (ex. a list item, block quote, heading, thematic break, or
+/// code fence). Such a word can't be moved to the start of a line by wrapping
+/// without changing the meaning of the document.
+/// Assumes the provided string is one word and doesn't have whitespace.
+pub fn is_block_start_word(word: &str) -> bool {
+  if is_list_word(word) {
+    return true;
+  }
+
+  // block quote (ex. >, >>, >text)
+  if word.starts_with('>') {
+    return true;
+  }
+
+  // atx heading (ex. #, ###) -- only when nothing follows the hashes,
+  // since #text isn't a heading
+  let hash_count = word.chars().take_while(|c| *c == '#').count();
+  if hash_count > 0 && hash_count <= 6 && word.len() == hash_count {
+    return true;
+  }
+
+  // setext heading underline (ex. =, ===), which would turn the previous
+  // line into a heading
+  if !word.is_empty() && word.chars().all(|c| c == '=') {
+    return true;
+  }
+
+  // thematic break or code fence (ex. ---, ***, ___, ~~~ and three backticks)
+  match word.chars().next() {
+    Some(c) if matches!(c, '-' | '*' | '_' | '`' | '~') => {
+      word.chars().count() >= 3 && word.chars().all(|other| other == c)
+    }
+    _ => false,
+  }
+}
+
 /// Checks if the provided word is a word that could be a list.
 /// Assumes the provided string is one word and doesn't have whitespace.
 pub fn is_list_word(word: &str) -> bool {
@@ -169,6 +206,30 @@ mod test {
     assert_eq!(is_list_word("10)"), true);
     assert_eq!(is_list_word("9999)"), true);
     assert_eq!(is_list_word("9999)."), false);
+  }
+
+  #[test]
+  fn it_should_find_block_start_words() {
+    assert_eq!(is_block_start_word("test"), false);
+    assert_eq!(is_block_start_word("-"), true);
+    assert_eq!(is_block_start_word("1."), true);
+    assert_eq!(is_block_start_word(">"), true);
+    assert_eq!(is_block_start_word(">text"), true);
+    assert_eq!(is_block_start_word("#"), true);
+    assert_eq!(is_block_start_word("######"), true);
+    assert_eq!(is_block_start_word("#######"), false);
+    assert_eq!(is_block_start_word("#text"), false);
+    assert_eq!(is_block_start_word("="), true);
+    assert_eq!(is_block_start_word("==="), true);
+    assert_eq!(is_block_start_word("=text"), false);
+    assert_eq!(is_block_start_word("---"), true);
+    assert_eq!(is_block_start_word("***"), true);
+    assert_eq!(is_block_start_word("___"), true);
+    assert_eq!(is_block_start_word("~~~"), true);
+    assert_eq!(is_block_start_word("```"), true);
+    assert_eq!(is_block_start_word("--"), false);
+    assert_eq!(is_block_start_word("~~"), false);
+    assert_eq!(is_block_start_word("---a"), false);
   }
 
   #[test]

--- a/tests/specs/Code/Code_Inline.txt
+++ b/tests/specs/Code/Code_Inline.txt
@@ -49,3 +49,11 @@ Testing
 [expect]
 > Testing `this
 > out`.
+
+!! inline code newlines !!
+`Inline code can
+include newlines.`
+
+[expect]
+`Inline code can
+include newlines.`

--- a/tests/specs/Code/Code_Inline.txt
+++ b/tests/specs/Code/Code_Inline.txt
@@ -57,3 +57,20 @@ include newlines.`
 [expect]
 `Inline code can
 include newlines.`
+
+!! should keep interior whitespace in inline code !!
+`a    b`
+
+Testing `a    b` out.
+
+[expect]
+`a    b`
+
+Testing `a    b` out.
+
+!! should keep an indented angle bracket in inline code in a block quote !!
+> `a
+>     > b` c
+
+[expect]
+> `a     > b` c

--- a/tests/specs/Code/Code_Inline.txt
+++ b/tests/specs/Code/Code_Inline.txt
@@ -41,3 +41,11 @@ Testing
 `` `test` ``
 `` `test` test ``
 `` test `test` ``
+
+!! should maintain newlines in inline code in a block quote !!
+> Testing `this
+> out`.
+
+[expect]
+> Testing `this
+> out`.

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -18,3 +18,10 @@ Testing
 
 [expect]
 Testing `this` out.
+
+!! should wrap inline code across lines !!
+Testing `this
+out`.
+
+[expect]
+Testing `this out`.

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -25,3 +25,17 @@ out`.
 
 [expect]
 Testing `this out`.
+
+!! should rewrap inline code across lines in blockquote !!
+> Testing `this
+> out`.
+
+[expect]
+> Testing `this out`.
+
+!! should rewrap inline code across lines which are too long in blockquote !!
+> This is some long text, which will have a bit of inline code across the `80 character limit` and then more after that.
+
+[expect]
+> This is some long text, which will have a bit of inline code across the `80
+> character limit` and then more after that.

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -53,3 +53,20 @@ Testing `this out`.
 [expect]
 `This is a long inline code span that should have its text wrapped when it
 exceeds the line width.`
+
+!! should not wrap a block marker in inline code to the start of a line !!
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn `oooooooo # pppp` qqqq
+
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn `oooooooo > pppp` qqqq
+
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn `oooooooo --- pppp` qqqq
+
+[expect]
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn
+`oooooooo # pppp` qqqq
+
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn
+`oooooooo > pppp` qqqq
+
+aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn
+`oooooooo --- pppp` qqqq

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -39,3 +39,10 @@ Testing `this out`.
 [expect]
 > This is some long text, which will have a bit of inline code across the `80
 > character limit` and then more after that.
+
+!! should rewrap inline code across lines in a nested blockquote !!
+>> Testing `this
+>> out`.
+
+[expect]
+>> Testing `this out`.

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -46,3 +46,10 @@ Testing `this out`.
 
 [expect]
 >> Testing `this out`.
+
+!! wrapping within inline code blocks !!
+`This is a long inline code span that should have its text wrapped when it exceeds the line width.`
+
+[expect]
+`This is a long inline code span that should have its text wrapped when it
+exceeds the line width.`


### PR DESCRIPTION
- Adds a failing test.
- Fixes the issue by having `gen_code` call `gen_str` with the string it builds, before returning it.

Fixes #129.

Note that the failing test results in a timeout after the panic, rather than failing the test suite:

<details><summary>Test output</summary>

```sh
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/dprint_plugin_markdown-bb4603beba64faa3)

running 13 tests
test generation::cmark::parsing::parse_link_reference_definitions::tests::it_finds_link_reference_with_new_line_after ... ok
test generation::cmark::parsing::parse_link_reference_definitions::tests::it_finds_multiple_link_references ... ok
test generation::cmark::parsing::parse_link_reference_definitions::tests::it_finds_link_reference ... ok
test generation::cmark::parsing::parse_link_reference_definitions::tests::it_parses_empty_string ... ok
test configuration::builder::tests::use_markdown_defaults_when_global_not_set ... ok
test configuration::builder::tests::handle_global_config ... ok
test generation::cmark::parsing::parse_image::test::it_should_parse_image ... ok
test generation::metadata::test::it_should_strip_plus_plus_plus_header ... ok
test generation::metadata::test::it_should_strip_yaml_header ... ok
test configuration::builder::tests::check_all_values_set ... ok
test generation::utils::test::it_should_find_list_words ... ok
test generation::utils::test::should_unindent ... ok
test format_text::test::strips_bom ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/newline_test.rs (target/debug/deps/newline_test-2293c22b8eb4ea3a)

running 4 tests
test test_issue35_convert_two_spaces_end_of_line_to_hard_break ... ok
test test_issue35_ignore_two_spaces_before_hard_break ... ok
test test_issue22_with_carriage_return_line_feeds ... ok
test test_issue26_with_carriage_return_line_feeds ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/spec_test.rs (target/debug/deps/specs-6c950b6b2c6409a0)

     Running specs::BlockQuotes

test specs::BlockQuotes::BlockQuotes_TextWrap_Always ... (6ms)
  should format ok
  should wrap a line when it exceeds the line width ok
test specs::BlockQuotes::Callouts ... (8ms)
  should format ok
  should format when just a callout ok
  should format when has blank line ok
test specs::BlockQuotes::BlockQuotes_All ... (9ms)
  should format ok
  should not wrap a line when it exceeds the line width and text wrapping is to maintain ok
  should keep blank lines in the middle ok

     Running specs::Code

thread '<unnamed>' panicked at /Users/chris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dprint-core-0.66.2/src/formatting/printer.rs:623:7:
Debug panic! Found a newline in the string. Before sending the string to the printer it needs to be broken up and the newline sent as a PrintItem::NewLine. `this
out`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Panic in spec 'should wrap inline code across lines' in ./tests/specs/Code/Code_Inline_TextWrap_Always.txt

thread '<unnamed>' panicked at /Users/chris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dprint-development-0.10.1/src/spec_helpers.rs:152:27:
called `Result::unwrap()` on an `Err` value: Any { .. }
test specs::Code::Code_Inline ... (14ms)
  should format inline blocks ok
  should properly space when last on line with soft break ok
  should properly space when first line after soft break ok
  should format code inside text parens ok
  should format double backticks as-is when it includes backticks ok
  should leave spaces around backticks inside double backticks ok
test specs::Code::Code_Inline_TextWrap_Always has been running for more than 60 seconds
```

</details>