### PR TITLE
fix: formatting for callout markers followed by non-text

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -141,7 +141,7 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               // Callout example:
               // > [!NOTE]
               // > Some note.
-              let is_callout = if context.is_in_block_quote() && matches!(node, Node::Text(_)) {
+              let is_callout = if context.is_in_block_quote() {
                 if let Node::Text(text) = last_node {
                   is_callout_text(&text.text)
                 } else {

--- a/tests/specs/BlockQuotes/Callouts.txt
+++ b/tests/specs/BlockQuotes/Callouts.txt
@@ -22,3 +22,11 @@
 > [!NOTE]
 >
 > Some sort of note
+
+!! should format when followed by italic text !!
+> [!NOTE]
+> _Some_ sort of note
+
+[expect]
+> [!NOTE]
+> _Some_ sort of note


### PR DESCRIPTION
Disclaimer; this is my first exposure to Rust, so I am unaware of the intricacies (or even the basic constructs) of the language. This PR fixes #133 (and would fix https://github.com/denoland/deno/issues/25303 partially) but only in the sense that the tests (including the newly added one) pass. The change itself is relatively simple, and I'm not entirely sure what the extra check represents; presumably it's there for a reason, but if this is the case then it seems that reason is untested.
