### PR TITLE
fix: make setext width variable based on the text

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -72,6 +72,18 @@
         "description": "Uses asterisks (*) as primary character for lists."
       }]
     },
+    "headingKind": {
+      "description": "The style of heading to use for level 1 and level 2 headings. Level 3 and higher always use ATX headings.",
+      "type": "string",
+      "default": "atx",
+      "oneOf": [{
+        "const": "atx",
+        "description": "Uses # or ## before the heading text (ATX headings)."
+      }, {
+        "const": "setext",
+        "description": "Uses an underline of = or - beneath the heading text (setext headings). Only applies to level 1 and 2 headings."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -106,6 +118,12 @@
     },
     "strongKind": {
       "$ref": "#/definitions/strongKind"
+    },
+    "unorderedListKind": {
+      "$ref": "#/definitions/unorderedListKind"
+    },
+    "headingKind": {
+      "$ref": "#/definitions/headingKind"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -93,7 +93,7 @@ impl UnorderedListKind {
 
 generate_str_to_from![UnorderedListKind, [Dashes, "dashes"], [Asterisks, "asterisks"]];
 
-/// The style of heading to use for level 1 and level headings:
+/// The style of heading to use for level 1 and level 2 headings:
 /// [setext](https://spec.commonmark.org/0.31.2/#setext-headings) or
 /// [ATX](https://spec.commonmark.org/0.31.2/#atx-headings). Level 3 and
 /// higher headings always use ATX headings, since Markdown only supports

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -16,22 +16,35 @@ Second Header
 
 [expect]
 H1
-========================================
+==
 
 H2
-----------------------------------------
+--
 
 ### H3
 
 #### H4
 
 First Header
-========================================
+============
 
 Second Header
+-------------
+
+!! should handle level 2 multi-line heading !!
+This Header
+spans
+multiple lines
 ----------------------------------------
 
-!! Headers are allowed to flow over multiple lines.
+
+[expect]
+This Header
+spans
+multiple lines
+--------------
+
+!! should handle level 1 multi-line heading !!
 This Header
 spans
 multiple lines
@@ -42,4 +55,4 @@ multiple lines
 This Header
 spans
 multiple lines
-========================================
+==============

--- a/tests/specs/headers/Headers_Setext_TextWrap_Always.txt
+++ b/tests/specs/headers/Headers_Setext_TextWrap_Always.txt
@@ -1,0 +1,22 @@
+~~ lineWidth: 40, headingKind: setext, textWrap: always ~~
+!! should wrap long level 1 heading and size underline to longest line !!
+# This heading is long enough that it should wrap onto multiple lines
+
+[expect]
+This heading is long enough that it
+should wrap onto multiple lines
+===================================
+
+!! should wrap long level 2 heading and size underline to longest line !!
+## This heading is long enough that it should wrap onto multiple lines
+
+[expect]
+This heading is long enough that it
+should wrap onto multiple lines
+-----------------------------------
+
+!! should not wrap level 3 and higher headings !!
+### This heading is long enough that it should wrap onto multiple lines
+
+[expect]
+### This heading is long enough that it should wrap onto multiple lines


### PR DESCRIPTION
Follow-up to https://github.com/dprint/dprint-plugin-markdown/pull/155