### PR TITLE
Fix: inline code spans may contain newlines and should be wrapped.

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -447,7 +447,7 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
   }
 }
 
-fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
+fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   let text = code.code.trim();
   let mut backtick_text = "`";
   let mut separator = "";
@@ -458,7 +458,11 @@ fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
     }
   }
 
-  format!("{0}{1}{2}{1}{0}", backtick_text, separator, text).into()
+  let mut items = PrintItems::new();
+  items.push_string(format!("{0}{1}", backtick_text, separator));
+  items.extend(gen_str(&code.code, context));
+  items.push_string(format!("{1}{0}", backtick_text, separator));
+  items
 }
 
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {

--- a/tests/specs/Code/Code_Inline.txt
+++ b/tests/specs/Code/Code_Inline.txt
@@ -41,3 +41,11 @@ Testing
 `` `test` ``
 `` `test` test ``
 `` test `test` ``
+
+!! inline code newlines !!
+`Inline code can
+include newlines.`
+
+[expect]
+`Inline code can
+include newlines.`

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -1,4 +1,4 @@
-~~ textWrap: always ~~
+~~ textWrap: always, lineWidth: 40 ~~
 !! should format inline blocks !!
 Testing ` this `  out.
 
@@ -18,3 +18,10 @@ Testing
 
 [expect]
 Testing `this` out.
+
+!! Wrapping within inline code blocks !!
+`long code blocks should have their text wrapped.`
+
+[expect]
+`long code blocks should have their text
+wrapped.`


### PR DESCRIPTION
This is probably similar to #130, which (of course) I failed to notice until after I wrote the PR.