### PR TITLE
feat: add listIndentKind config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4e75767fbc9d92b90e4d0c011f61358cde9513b31ef07ea3631b15ffc3b4fd"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
 dependencies = [
  "bitflags",
  "memchr",

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -84,6 +84,18 @@
         "description": "Uses an underline of = or - beneath the heading text (setext headings). Only applies to level 1 and 2 headings."
       }]
     },
+    "listIndentKind": {
+      "description": "The style of indentation to use for list items. CommonMark aligns to the content column after the marker. PythonMarkdown uses a fixed 4-space indent, required by tools like mkdocs-material.",
+      "type": "string",
+      "default": "commonMark",
+      "oneOf": [{
+        "const": "commonMark",
+        "description": "Indents continuation lines to align with the content after the list marker (e.g. 3 spaces for '1. ', 4 for '10. ')."
+      }, {
+        "const": "pythonMarkdown",
+        "description": "Always indents by 4 spaces, regardless of marker width."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -124,6 +136,9 @@
     },
     "headingKind": {
       "$ref": "#/definitions/headingKind"
+    },
+    "listIndentKind": {
+      "$ref": "#/definitions/listIndentKind"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -85,6 +85,12 @@ impl ConfigurationBuilder {
     self.insert("headingKind", value.to_string().into())
   }
 
+  /// The style of list indentation to use.
+  /// Default: `ListIndentKind::CommonMark`
+  pub fn list_indent_kind(&mut self, value: ListIndentKind) -> &mut Self {
+    self.insert("listIndentKind", value.to_string().into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -147,13 +153,14 @@ mod tests {
       .strong_kind(StrongKind::Underscores)
       .unordered_list_kind(UnorderedListKind::Asterisks)
       .heading_kind(HeadingKind::Atx)
+      .list_indent_kind(ListIndentKind::PythonMarkdown)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 11);
+    assert_eq!(inner_config.len(), 12);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -65,6 +65,7 @@ pub fn resolve_config(
       &mut diagnostics,
     ),
     heading_kind: get_value(&mut config, "headingKind", HeadingKind::Atx, &mut diagnostics),
+    list_indent_kind: get_value(&mut config, "listIndentKind", ListIndentKind::CommonMark, &mut diagnostics),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -16,6 +16,7 @@ pub struct Configuration {
   pub strong_kind: StrongKind,
   pub unordered_list_kind: UnorderedListKind,
   pub heading_kind: HeadingKind,
+  pub list_indent_kind: ListIndentKind,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,
@@ -115,3 +116,20 @@ pub enum HeadingKind {
 }
 
 generate_str_to_from![HeadingKind, [Setext, "setext"], [Atx, "atx"]];
+
+/// The style of indentation to use for list items.
+///
+/// CommonMark aligns continuation lines to the content column after the marker
+/// (e.g. 3 spaces for `1. `, 4 spaces for `10. `). PythonMarkdown uses a fixed
+/// 4-space indent regardless of marker width, which is required by tools like
+/// mkdocs-material.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ListIndentKind {
+  /// Indents continuation lines to align with the content after the list marker (default).
+  CommonMark,
+  /// Always indents by 4 spaces, regardless of marker width.
+  PythonMarkdown,
+}
+
+generate_str_to_from![ListIndentKind, [CommonMark, "commonMark"], [PythonMarkdown, "pythonMarkdown"]];

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -741,7 +741,10 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
       } else {
         String::from(context.configuration.unordered_list_kind.list_char(is_alternate))
       };
-      let indent_increment = (prefix_text.chars().count() + 1) as u32;
+      let indent_increment = match context.configuration.list_indent_kind {
+        crate::configuration::ListIndentKind::CommonMark => (prefix_text.chars().count() + 1) as u32,
+        crate::configuration::ListIndentKind::PythonMarkdown => std::cmp::max(prefix_text.chars().count() as u32 + 1, 4),
+      };
       context.indent_level += indent_increment;
       items.push_string(prefix_text);
       let after_child = LineAndColumn::new("afterChild");

--- a/tests/specs/Lists/Lists_ListIndentKind_PythonMarkdown.txt
+++ b/tests/specs/Lists/Lists_ListIndentKind_PythonMarkdown.txt
@@ -1,0 +1,36 @@
+~~ listIndentKind: pythonMarkdown ~~
+!! should indent nested ordered list by 4 spaces !!
+1. first
+   1. nested first
+   2. nested second
+2. second
+
+[expect]
+1. first
+    1. nested first
+    2. nested second
+2. second
+
+!! should indent nested unordered list by 4 spaces !!
+- first
+  - nested first
+  - nested second
+- second
+
+[expect]
+- first
+    - nested first
+    - nested second
+- second
+
+!! should indent double-digit ordered list consistently !!
+9. Testing
+   6. Test
+10. Other
+    7. Testing
+
+[expect]
+9. Testing
+    6. Test
+10. Other
+    7. Testing


### PR DESCRIPTION
## Summary

- Adds a new `listIndentKind` configuration option controlling how nested list items are indented
- `commonMark` (default) keeps the existing behaviour — indent width matches the content column after the marker (`3` for `1. `, `4` for `10. `, etc.)
- `pythonMarkdown` enforces a minimum 4-space indent regardless of marker width, which is what tools like mkdocs-material need

## Details

The indent for nested list items was previously hardcoded to `marker_width + 1` (see `gen_list` in `generate.rs`). That's correct per CommonMark but breaks mkdocs-material's card grids and other features that depend on Python-Markdown's fixed 4-space rule.

The new option branches on the config at that single calculation point — no other logic changes. Default is `commonMark` so this is fully backwards-compatible.

## Test plan

- [ ] Existing list specs all pass unchanged (they run with the default `commonMark`)
- [ ] New spec file `Lists_ListIndentKind_PythonMarkdown.txt` covers ordered, unordered, and double-digit marker cases with `pythonMarkdown` mode
- [ ] `cargo test` green

Closes #147