### PR TITLE
fix: enclose link URI with pointy brackets if necessary

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -647,14 +647,39 @@ fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
 
     items.push_sc(sc!("]"));
     items.push_sc(sc!("("));
-    items.push_string(link.url.trim().to_string());
+    let url = link.url.trim().to_string();
+    let pointy_brackets_are_needed = inline_link_destination_needs_pointy_brackets(&url);
+    if pointy_brackets_are_needed {
+      items.push_sc(sc!("<"));
+    }
+    items.push_string(url);
     if let Some(title) = &link.title {
       items.push_string(format!(" \"{}\"", title.trim()));
+    }
+    if pointy_brackets_are_needed {
+      items.push_sc(sc!(">"));
     }
     items.push_sc(sc!(")"));
 
     ir_helpers::new_line_group(items)
   })
+}
+
+/// Returns `true` if destination contains a space or unbalanced parentheses.
+fn inline_link_destination_needs_pointy_brackets(destination: &str) -> bool {
+  let mut parentheses_depth = 0;
+  for c in destination.chars() {
+    match c {
+      ' ' => return true,
+      '(' => parentheses_depth += 1,
+      ')' => parentheses_depth -= 1,
+      _ => (),
+    }
+    if parentheses_depth < 0 {
+      return true;
+    }
+  }
+  parentheses_depth != 0
 }
 
 fn gen_reference_link(link: &ReferenceLink, context: &mut Context) -> PrintItems {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -717,11 +717,32 @@ fn gen_auto_link(link: &AutoLink, context: &mut Context) -> PrintItems {
 fn gen_link_reference(link_ref: &LinkReference, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_string(format!("[{}]: ", link_ref.name.trim()));
-  items.push_string(link_ref.link.trim().to_string());
+
+  let mut url = link_ref.link.trim();
+  if url.starts_with("<") && url.ends_with(">") {
+    url = &url[1..(url.len() - 1)]
+  }
+  let url = url.replace(r#"\("#, "(").replace(r#"\)"#, ")");
+  let pointy_brackets_are_needed = link_reference_destination_needs_pointy_brackets(&url);
+  if pointy_brackets_are_needed {
+    items.push_sc(sc!("<"));
+  }
+  items.push_string(url);
+  if pointy_brackets_are_needed {
+    items.push_sc(sc!(">"));
+  }
+
   if let Some(title) = &link_ref.title {
     items.push_string(format!(" \"{}\"", title.trim()));
   }
   ir_helpers::new_line_group(items)
+}
+
+fn link_reference_destination_needs_pointy_brackets(destination: &str) -> bool {
+  if destination.is_empty() {
+    return true;
+  }
+  inline_link_destination_needs_pointy_brackets(destination)
 }
 
 fn gen_inline_image(image: &InlineImage, _: &mut Context) -> PrintItems {

--- a/tests/specs/Issues/Issue0179.txt
+++ b/tests/specs/Issues/Issue0179.txt
@@ -21,3 +21,19 @@
 [link](<foo(bar>)
 [link](<foo)(bar>)
 [link](<foo)(bar>)
+
+!! the same style should apply to link reference definitions !!
+[1]: <foo%20bar((()))baz>
+[2]: <>
+[3]: <foo bar>
+[4]: foo\(bar
+[5]: foo\)\(bar
+[6]: <foo)(bar>
+
+[expect]
+[1]: foo%20bar((()))baz
+[2]: <>
+[3]: <foo bar>
+[4]: <foo(bar>
+[5]: <foo)(bar>
+[6]: <foo)(bar>

--- a/tests/specs/Issues/Issue0179.txt
+++ b/tests/specs/Issues/Issue0179.txt
@@ -1,0 +1,23 @@
+!! should remove unnecessary pointy brackets !!
+[link](<>)
+[link](<foo%20bar((()))baz>)
+
+[expect]
+[link]()
+[link](foo%20bar((()))baz)
+
+!! should preserve pointy brackets if destination contains spaces !!
+[link](<foo bar>)
+
+[expect]
+[link](<foo bar>)
+
+!! destination containing escaped unbalanced parentheses should be formatted in the same style with spaces !!
+[link](foo\(bar)
+[link](foo\)\(bar)
+[link](<foo)(bar>)
+
+[expect]
+[link](<foo(bar>)
+[link](<foo)(bar>)
+[link](<foo)(bar>)


### PR DESCRIPTION
The first commit 3c4d951 fixes #179.

The second commit 6d4bcf6 is not necessary for fixing #179. The changes force link reference destinations to be formatted in the same style as inline link destinations. It is opinionated and may surprise existing users. If you don’t link that, I will revert.
