### PR TITLE
fix: ignore escaped chars when checking for closing char in container (#131)

### DIFF
--- a/src/generation/cmark/parsing/common.rs
+++ b/src/generation/cmark/parsing/common.rs
@@ -18,6 +18,12 @@ fn parse_text_in_container(
   while let Some((byte_pos, c)) = char_scanner.next() {
     if c == close_char {
       return Ok(text);
+    } else if c == '\\' {
+      text.push(c);
+      // push next char without close/open check, since it's escaped
+      if let Some((_, next_c)) = char_scanner.next() {
+        text.push(next_c);
+      }
     } else if c == open_char {
       return Err(ParseError::new(
         Range {

--- a/tests/specs/Issues/Issue0131.txt
+++ b/tests/specs/Issues/Issue0131.txt
@@ -1,0 +1,5 @@
+!! should ignore escaped brackets !!
+![brackets inside brackets \[ \] ]()
+
+[expect]
+![brackets inside brackets \[ \]]()


### PR DESCRIPTION
closes: #131