### PR TITLE
chore: use npm plugin specifiers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,5 +4,4 @@ about: Create a feature request
 title: ''
 labels: ''
 assignees: ''
-
 ---

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -4,5 +4,4 @@ about: Anything else
 title: ''
 labels: ''
 assignees: ''
-
 ---

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Then in your project's directory with a dprint.json file, run:
 
 ```shellsession
 dprint add markdown
-# or install from npm
-dprint add npm:@dprint/markdown
 ```
 
 See https://dprint.dev/plugins/markdown/ for more information.

--- a/dprint.json
+++ b/dprint.json
@@ -13,10 +13,10 @@
     "**/target"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.9.wasm",
-    "https://plugins.dprint.dev/json-0.19.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.3.wasm",
-    "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7"
+    "npm:@dprint/typescript@0.96.1",
+    "npm:@dprint/json@0.23.0",
+    "npm:@dprint/markdown@0.22.1",
+    "npm:@dprint/toml@0.8.0",
+    "npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67"
   ]
 }

--- a/scripts/generate_release_notes.ts
+++ b/scripts/generate_release_notes.ts
@@ -23,7 +23,7 @@ Then in your project's dprint configuration file:
        // markdown config goes here
      },
      "plugins": [
-       "https://plugins.dprint.dev/markdown-${version}.wasm"
+       "npm:@dprint/markdown@${version}"
      ]
    }
    \`\`\`


### PR DESCRIPTION
`dprint add <plugin>` now outputs npm specifiers, so update the config file and install instructions to match.
