### PR TITLE
fix: upgrade to dprint-core 0.69.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.68.2"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb1dc2cac6929b352e64ee15d45cecb990f081eebbec99be0444edb01e642a8"
+checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
 dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
+checksum = "67359cea061dd052fca921d3589a9ce59bc16fa23bfb9d06d5c669a1dbd23915"
 dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "tests/spec_test.rs"
 harness = false
 
 [dependencies]
-dprint-core = { version = "0.69.0", features = ["formatting"] }
+dprint-core = { version = "0.69.1", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
 pulldown-cmark = { version = "0.11.2", default-features = false }
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "tests/spec_test.rs"
 harness = false
 
 [dependencies]
-dprint-core = { version = "0.68.2", features = ["formatting"] }
+dprint-core = { version = "0.69.0", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
 pulldown-cmark = { version = "0.11.2", default-features = false }
 regex = "1"


### PR DESCRIPTION
Upgrades `dprint-core` from 0.68.2 to 0.69.0.

No source changes were required — this repo does not construct `ir_helpers::GeneratedValue` struct literals, so the new `is_known_multi_line` field is not a breaking change here. Only `Cargo.toml` and `Cargo.lock` changed.

`cargo test` passes: 70 spec tests, 17 + 5 unit tests, 2 doc tests.