### PR TITLE
fix: format image destinations, and tabs and line endings in link destinations

### DIFF
--- a/src/generation/cmark/parsing/common.rs
+++ b/src/generation/cmark/parsing/common.rs
@@ -4,8 +4,80 @@ pub fn parse_text_in_brackets(start_pos: usize, char_scanner: &mut CharScanner) 
   parse_text_in_container(start_pos, char_scanner, '[', ']')
 }
 
+/// Parses the text up to the parenthesis that closes an inline image.
+///
+/// A link destination may contain parentheses, so within one they only close
+/// the image when unbalanced, and not at all when it's in pointy brackets.
+/// Past the destination a title could contain anything, so stay conservative
+/// and bail out there like this used to everywhere.
 pub fn parse_text_in_parens(start_pos: usize, char_scanner: &mut CharScanner) -> Result<String, ParseError> {
-  parse_text_in_container(start_pos, char_scanner, '(', ')')
+  let mut text = String::new();
+  let mut destination = Destination::NotStarted;
+  let mut parens_depth = 0;
+
+  while let Some((byte_pos, c)) = char_scanner.next() {
+    if c == '\\' {
+      text.push(c);
+      // push next char without close/open check, since it's escaped
+      if let Some((_, next_c)) = char_scanner.next() {
+        text.push(next_c);
+      }
+      if matches!(destination, Destination::NotStarted) {
+        destination = Destination::Bare;
+      }
+      continue;
+    }
+
+    match (&destination, c) {
+      (Destination::NotStarted, ')') => return Ok(text),
+      (Destination::NotStarted, '<') => destination = Destination::PointyBrackets,
+      (Destination::NotStarted, '(') => {
+        destination = Destination::Bare;
+        parens_depth += 1;
+      }
+      (Destination::NotStarted, c) if !c.is_whitespace() => destination = Destination::Bare,
+      (Destination::PointyBrackets, '>') => destination = Destination::Ended,
+      (Destination::Bare, c) if c.is_whitespace() => destination = Destination::Ended,
+      (Destination::Bare, '(') => parens_depth += 1,
+      (Destination::Bare | Destination::Ended, ')') => {
+        if parens_depth == 0 {
+          return Ok(text);
+        }
+        parens_depth -= 1;
+      }
+      (Destination::Ended, '(') => {
+        return Err(ParseError::new(
+          Range {
+            start: byte_pos,
+            end: byte_pos + c.len_utf8(),
+          },
+          "Unexpected open container char `(`.",
+        ))
+      }
+      _ => (),
+    }
+    text.push(c);
+  }
+
+  Err(ParseError::new(
+    Range {
+      start: start_pos,
+      end: char_scanner.pos(),
+    },
+    "Did not find container close char `)`.",
+  ))
+}
+
+/// Where within an inline image's parentheses the destination is.
+enum Destination {
+  /// Only whitespace has been seen so far.
+  NotStarted,
+  /// Within a destination enclosed in pointy brackets.
+  PointyBrackets,
+  /// Within a destination not enclosed in pointy brackets.
+  Bare,
+  /// Past the destination, where a title may follow.
+  Ended,
 }
 
 fn parse_text_in_container(

--- a/src/generation/cmark/parsing/parse_image.rs
+++ b/src/generation/cmark/parsing/parse_image.rs
@@ -79,4 +79,22 @@ mod test {
     assert_eq!(image.range().start, 10);
     assert_eq!(image.range().end, 22);
   }
+
+  #[test]
+  fn it_should_parse_image_with_parens_in_destination() {
+    // balanced parentheses don't close the image
+    assert_url(parse_image(0, "![text](a(b)c)\n", LinkType::Inline), "a(b)c");
+    // ...and within pointy brackets they don't need to be balanced
+    assert_url(parse_image(0, "![text](<a(b>)\n", LinkType::Inline), "<a(b>");
+    assert_url(parse_image(0, "![text](<a)b>)\n", LinkType::Inline), "<a)b>");
+    // an escaped parenthesis is never a container char
+    assert_url(parse_image(0, "![text](a\\(b)\n", LinkType::Inline), "a\\(b");
+  }
+
+  fn assert_url(result: Result<Node, ParseError>, expected: &str) {
+    match result.ok().unwrap() {
+      Node::InlineImage(image) => assert_eq!(image.url, expected),
+      _ => panic!("Expected an inline image."),
+    }
+  }
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -667,7 +667,9 @@ fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
     let (generated_children, generated_children_clone) = clone_items(generated_children);
     let single_line_text = get_items_text(ir_helpers::with_no_new_lines(generated_children_clone));
     if single_line_text.len() < (context.configuration.line_width / 2) as usize {
-      items.push_string(single_line_text);
+      // printing the children back out to text flattens any tab signal
+      // they had, so they need breaking up again
+      items.extend(gen_text_with_tabs(single_line_text));
     } else {
       items.extend(generated_children);
     }
@@ -676,7 +678,7 @@ fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
     items.push_sc(sc!("("));
     // the parser resolves the escapes in an inline link's url, so render it
     // back out with the escapes it needs and no others
-    items.push_string(format_link_destination(link.url.trim()));
+    items.extend(gen_link_destination_text(format_link_destination(link.url.trim())));
     if let Some(title) = &link.title {
       items.push_string(format!(" \"{}\"", title.trim()));
     }
@@ -684,6 +686,39 @@ fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
 
     ir_helpers::new_line_group(items)
   })
+}
+
+/// Writes out a rendered link destination, handling the characters the printer
+/// can't be handed as part of a string.
+fn gen_link_destination_text(text: String) -> PrintItems {
+  // a destination can't contain a line ending in either of its forms, so keep
+  // one as the character reference it could only have come from
+  let text = if text.contains(['\n', '\r']) {
+    text.replace('\r', "&#13;").replace('\n', "&#10;")
+  } else {
+    text
+  };
+  gen_text_with_tabs(text)
+}
+
+/// Writes out text, sending any tab it has as a signal, since the printer
+/// can't be handed one as part of a string.
+fn gen_text_with_tabs(text: String) -> PrintItems {
+  let mut items = PrintItems::new();
+  if !text.contains('\t') {
+    items.push_string(text);
+    return items;
+  }
+
+  for (i, part) in text.split('\t').enumerate() {
+    if i > 0 {
+      items.push_signal(Signal::Tab);
+    }
+    if !part.is_empty() {
+      items.push_str(part);
+    }
+  }
+  items
 }
 
 /// Renders an unescaped link destination, enclosing it in pointy brackets and
@@ -789,7 +824,7 @@ fn gen_link_reference(link_ref: &LinkReference, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_string(format!("[{}]: ", link_ref.name.trim()));
 
-  items.push_string(format_raw_link_destination(link_ref.link.trim()));
+  items.extend(gen_link_destination_text(format_raw_link_destination(link_ref.link.trim())));
 
   if let Some(title) = &link_ref.title {
     items.push_string(format!(" \"{}\"", title.trim()));

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -406,9 +406,9 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
 
   // header
   if code_block.is_fenced {
-    items.push_string(backtick_text.clone());
+    items.push_str(&backtick_text);
     if let Some(tag) = &code_block.tag {
-      items.push_string(tag.to_string());
+      items.push_str(tag);
     }
     items.push_signal(Signal::NewLine);
   }
@@ -1030,9 +1030,9 @@ fn gen_task_list_marker_children(
 fn gen_task_list_marker(marker: &TaskListMarker, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   if marker.is_checked {
-    items.push_string("[x]".into());
+    items.push_sc(sc!("[x]"));
   } else {
-    items.push_string("[ ]".into());
+    items.push_sc(sc!("[ ]"));
   }
 
   items

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -824,7 +824,14 @@ fn gen_link_reference(link_ref: &LinkReference, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_string(format!("[{}]: ", link_ref.name.trim()));
 
-  items.extend(gen_link_destination_text(format_raw_link_destination(link_ref.link.trim())));
+  let url = format_raw_link_destination(link_ref.link.trim());
+  if url.is_empty() {
+    // unlike an inline link, a link reference definition can't have an
+    // empty destination without these
+    items.push_sc(sc!("<>"));
+  } else {
+    items.extend(gen_link_destination_text(url));
+  }
 
   if let Some(title) = &link_ref.title {
     items.push_string(format!(" \"{}\"", title.trim()));
@@ -842,11 +849,6 @@ fn format_raw_link_destination(destination: &str) -> String {
     .strip_prefix('<')
     .and_then(|destination| destination.strip_suffix('>'))
     .unwrap_or(destination);
-  if destination.is_empty() {
-    // a link reference definition can't have an empty destination without these
-    return "<>".to_string();
-  }
-
   let needs_pointy_brackets = link_destination_needs_pointy_brackets(&unescape_link_destination(destination));
   let mut text = String::with_capacity(destination.len() + 2);
   if needs_pointy_brackets {
@@ -903,7 +905,8 @@ fn gen_inline_image(image: &InlineImage, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_string(format!("![{}]", image.text.trim()));
   items.push_sc(sc!("("));
-  items.push_string(image.url.trim().to_string());
+  // like a link reference definition, this is the raw text from the file
+  items.extend(gen_link_destination_text(format_raw_link_destination(image.url.trim())));
   if let Some(title) = &image.title {
     items.push_string(format!(" \"{}\"", title.trim()));
   }
@@ -1409,7 +1412,9 @@ mod tests {
 
   #[test]
   fn formats_raw_link_destination_keeping_its_escapes() {
-    assert_eq!(format_raw_link_destination("<>"), "<>");
+    // the caller decides what an empty destination gets written as
+    assert_eq!(format_raw_link_destination("<>"), "");
+    assert_eq!(format_raw_link_destination(""), "");
     assert_eq!(format_raw_link_destination("<foo bar>"), "<foo bar>");
     assert_eq!(format_raw_link_destination(r"foo\_bar"), r"foo\_bar");
     assert_eq!(format_raw_link_destination("x?a=1&amp;b=2"), "x?a=1&amp;b=2");

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -28,3 +28,57 @@ testing
 [Other reference]: https://dprint.dev/image.png "Testing"
 
 testing
+
+!! should remove unnecessary pointy brackets from a destination !!
+![img](<foo>)
+![img](<>)
+
+[expect]
+![img](foo)
+![img]()
+
+!! should keep pointy brackets a destination needs !!
+![img](<foo bar>)
+![img](<foo bar> "title")
+
+[expect]
+![img](<foo bar>)
+![img](<foo bar> "title")
+
+!! should enclose a destination in pointy brackets when it needs them !!
+![img](foo\(bar)
+![img](a>b\(c)
+
+[expect]
+![img](<foo(bar>)
+![img](<a\>b(c>)
+
+!! should handle parentheses in a destination !!
+![img](a(b)c)
+![img](<a(b>)
+![img](<a)b>)
+![img](a(b)c "title")
+
+[expect]
+![img](a(b)c)
+![img](<a(b>)
+![img](<a)b>)
+![img](a(b)c "title")
+
+!! should not treat a pointy bracket after the destination start as enclosing it !!
+![t](\a<b)c>)
+![t](a<b)
+
+[expect]
+![t](\a<b)c>)
+![t](a<b)
+
+!! should handle a destination that starts with a parenthesis !!
+![t]((a)b)
+![t](())
+![t]((a) "title")
+
+[expect]
+![t]((a)b)
+![t](())
+![t]((a) "title")

--- a/tests/specs/Issues/Issue0179.txt
+++ b/tests/specs/Issues/Issue0179.txt
@@ -122,11 +122,15 @@
 
 !! should keep a tab in a destination !!
 [link](<a	b>)
+![img](<a	b>)
+[![img](<a	b>)](c)
 
 [1]: <a	b>
 
 [expect]
 [link](<a	b>)
+![img](<a	b>)
+[![img](<a	b>)](c)
 
 [1]: <a	b>
 

--- a/tests/specs/Issues/Issue0179.txt
+++ b/tests/specs/Issues/Issue0179.txt
@@ -119,3 +119,21 @@
 
 [expect]
 [1]: <a\>b(c>
+
+!! should keep a tab in a destination !!
+[link](<a	b>)
+
+[1]: <a	b>
+
+[expect]
+[link](<a	b>)
+
+[1]: <a	b>
+
+!! should keep a line ending in a destination as a character reference !!
+[link](foo&#10;bar)
+[link](foo&#13;bar)
+
+[expect]
+[link](<foo&#10;bar>)
+[link](<foo&#13;bar>)


### PR DESCRIPTION
The two things I left alone in #196, plus a small allocation cleanup. Three commits, each reviewable on its own.

### `a032400` — a tab or line ending in a destination panicked the formatter

The printer needs both handed over as signals rather than as part of a string, so these blew up:

```md
[link](<a	b>)         # Debug panic! Found a tab in the string.
[link](foo&#10;bar)   # Debug panic! Found a newline in the string.
```

A tab is now sent as `Signal::Tab`, which round trips it exactly. A line ending can't appear in either form of a destination, so it's kept as the character reference it could only have come from.

The link text path needed the same treatment: it prints its children back out to a `String` to decide whether they fit on one line, which flattens the tab signal straight back into a string. Without that, the common badge shape `[![alt](<a	b>)](url)` still panicked.

Still unfixed, and out of scope here: **titles** never go through this path, so `[t](/url "a	b")` still panics, as does a tab in ordinary inline text. Both are pre-existing and neither is a destination. Happy to take them in a follow-up.

### `dfa5cbb` — an image's destination is now formatted like a link's

It was written out as the raw text from the file, so it never picked up any of the handling links have:

```md
![img](<foo>)   ->  ![img](<foo>)   # now ![img](foo)
![img](a>b\(c)  ->  ![img](a>b\(c)  # now ![img](<a\>b(c>)
```

This needed a fix to the image parser first. `parse_text_in_parens` bailed out on any unescaped `(`, which meant **the formatter refused to format the whole file** for a valid image like `![img](a(b)c)`. It also made the change above non-idempotent, since the formatter started emitting destinations its own parser then rejected.

Parentheses are now tracked as a depth within the destination, and ignored entirely within pointy brackets. Past the destination a title could contain anything, so it stays conservative and bails out there exactly as before — the two remaining known limitations (`![t](/url "a(b")` and the `'…'` / `(…)` title forms `parse_link_url_and_title` doesn't recognise) error identically to today rather than being silently rewritten.

### `c053d71` — don't heap allocate strings that get pushed as items

`push_string` takes ownership and then copies the text into the bump allocator anyway, so building a `String` first just to hand it over is a heap allocation that gets thrown away. `push_str` copies straight into the bump, and `push_sc` doesn't allocate at all for a static string.

---

Worth flagging for review: every regression I hit building this came from relaxing one of these conservative bail-outs, and each one produced output that was *idempotent* — so `format_twice` in the spec runner didn't catch any of them. The spec cases added here cover the ones I found, but that's the area to be suspicious of.
