### PR TITLE
fix: keep link reference definition that is a list item's only content

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -698,11 +698,16 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
 
   let range = iterator.get_range_for_start(start);
 
-  let last_range = sub_lists
+  let references_start = sub_lists
     .last()
     .map(|c| c.range())
-    .or_else(|| children.last().map(|c| c.range()));
-  if let Some(references) = parse_references(last_range.map(|r| r.end), range.end, iterator)? {
+    .or_else(|| children.last().map(|c| c.range()))
+    .map(|r| r.end)
+    .or_else(|| marker.as_ref().map(|m| m.range.end))
+    // an item may consist of only link reference definitions, in which case
+    // it has no children, so start searching after the list item marker
+    .or_else(|| get_item_marker_end(iterator.file_text, range.start));
+  if let Some(references) = parse_references(references_start, range.end, iterator)? {
     children.push(references);
   }
 
@@ -712,6 +717,34 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
     children,
     sub_lists,
   })
+}
+
+/// Gets the byte position directly after a list item's marker
+/// (ex. after the `-` in `- test` or after the `1.` in `1. test`).
+fn get_item_marker_end(file_text: &str, item_start: usize) -> Option<usize> {
+  let mut chars = file_text[item_start..].char_indices();
+  let (_, first_char) = chars.next()?;
+
+  if matches!(first_char, '-' | '*' | '+') {
+    return Some(item_start + first_char.len_utf8());
+  }
+  if !first_char.is_ascii_digit() {
+    return None;
+  }
+
+  // ordered list marker (ex. `1.` or `1)`)
+  for (index, c) in chars {
+    if c.is_ascii_digit() {
+      continue;
+    }
+    return if matches!(c, '.' | ')') {
+      Some(item_start + index + c.len_utf8())
+    } else {
+      None
+    };
+  }
+
+  None
 }
 
 fn parse_metadata(kind: MetadataBlockKind, iterator: &mut EventIterator) -> Result<MetadataBlock, ParseError> {

--- a/tests/specs/Issues/Issue0192.txt
+++ b/tests/specs/Issues/Issue0192.txt
@@ -1,0 +1,42 @@
+!! should keep a link reference definition that's the only content of a list item !!
+- [0,35 mm;]: url
+
+[expect]
+- [0,35 mm;]: url
+
+!! should keep multiple link reference definitions in a list item !!
+- [a]:   b
+  [c]: d "title"
+
+[expect]
+- [a]: b
+  [c]: d "title"
+
+!! should keep a link reference definition in an ordered list item !!
+1. [a]: b
+2. [c]: d
+
+[expect]
+1. [a]: b
+2. [c]: d
+
+!! should keep a link reference definition in a nested list item !!
+- - [a]: b
+
+[expect]
+-
+  - [a]: b
+
+!! should keep a link reference definition in a block quote's list item !!
+> - [a]: b
+
+[expect]
+> - [a]: b
+
+!! should keep empty list items as-is !!
+-
+-
+
+[expect]
+-
+-


### PR DESCRIPTION
Closes #192

A list item whose only content is a link reference definition had its content silently dropped:

```md
- [0,35 mm;]: url
```

...formatted to just `-`.

pulldown-cmark emits no events for link reference definitions, so such an item has zero children. `parse_item` only scanned for link reference definitions *after* the last child's range, and with no children it passed `None` and skipped the scan entirely.

Now it falls back to scanning from just after the list item marker (or after the task list marker, when there is one), via a new `get_item_marker_end` helper that handles `-`/`*`/`+` and ordered markers like `1.` / `1)`.
