### PR TITLE
fix: keep a line break in an image's alt text, a title, or a reference label

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -727,6 +727,10 @@ fn gen_reference_label(reference: &str, context: &Context) -> PrintItems {
 }
 
 /// Generates the title that follows an inline image or link's destination.
+///
+/// A title continued onto another line loses that line's indentation, since
+/// there's no telling apart the indentation that's part of the title from the
+/// indentation the enclosing list item or block quote gave it.
 fn gen_title(title: &str, context: &Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_sc(sc!(" \""));
@@ -741,16 +745,32 @@ fn gen_title(title: &str, context: &Context) -> PrintItems {
 /// line breaks the text contains need to be sent as print items instead.
 fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
   let mut items = PrintItems::new();
-  let mut lines = text.lines();
+  // a line ending may be in either of its forms, so split on both characters
+  // and skip the empty text a carriage return and line feed pair leaves behind
+  let mut lines = text.split(['\r', '\n']).filter(|line| !line.is_empty());
   if let Some(line) = lines.next() {
-    items.push_string(line.trim_end().to_string());
+    items.extend(gen_text_with_tabs(line.trim_end().to_string()));
   }
   for line in lines {
-    // the indentation of a continued line is provided by the printer
     items.extend(get_newline_wrapping_based_on_config(context));
-    items.push_string(line.trim().to_string());
+    // the printer provides the indentation and block quote markers of a
+    // continued line, so drop the ones this picked up from the file
+    let line = strip_block_quote_markers(line, context);
+    items.extend(gen_text_with_tabs(line.trim_end().to_string()));
   }
   items
+}
+
+/// Strips the markers a line of raw text picked up by continuing within a
+/// block quote.
+fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
+  let mut line = line.trim_start();
+  if context.is_in_block_quote() {
+    while let Some(rest) = line.strip_prefix('>') {
+      line = rest.trim_start();
+    }
+  }
+  line
 }
 
 /// Writes out text, sending any tab it has as a signal, since the printer
@@ -954,29 +974,35 @@ fn unescape_link_destination(destination: &str) -> String {
 }
 
 fn gen_inline_image(image: &InlineImage, context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-  items.extend(gen_image_alt_text(&image.text, context));
-  items.push_sc(sc!("("));
-  // like a link reference definition, this is the raw text from the file
-  items.extend(gen_link_destination_text(format_raw_link_destination(image.url.trim())));
-  if let Some(title) = &image.title {
-    items.extend(gen_title(title, context));
-  }
-  items.push_sc(sc!(")"));
-  ir_helpers::new_line_group(items)
+  context.with_no_text_wrap(|context| {
+    let mut items = PrintItems::new();
+    items.extend(gen_image_alt_text(&image.text, context));
+    items.push_sc(sc!("("));
+    // like a link reference definition, this is the raw text from the file
+    items.extend(gen_link_destination_text(format_raw_link_destination(image.url.trim())));
+    if let Some(title) = &image.title {
+      items.extend(gen_title(title, context));
+    }
+    items.push_sc(sc!(")"));
+    ir_helpers::new_line_group(items)
+  })
 }
 
 fn gen_reference_image(image: &ReferenceImage, context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-  items.extend(gen_image_alt_text(&image.text, context));
-  items.extend(gen_reference_label(&image.reference, context));
-  ir_helpers::new_line_group(items)
+  context.with_no_text_wrap(|context| {
+    let mut items = PrintItems::new();
+    items.extend(gen_image_alt_text(&image.text, context));
+    items.extend(gen_reference_label(&image.reference, context));
+    ir_helpers::new_line_group(items)
+  })
 }
 
 fn gen_shortcut_image(image: &ShortcutImage, context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-  items.extend(gen_image_alt_text(&image.text, context));
-  ir_helpers::new_line_group(items)
+  context.with_no_text_wrap(|context| {
+    let mut items = PrintItems::new();
+    items.extend(gen_image_alt_text(&image.text, context));
+    ir_helpers::new_line_group(items)
+  })
 }
 
 fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItems {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -687,7 +687,7 @@ fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
     // back out with the escapes it needs and no others
     items.extend(gen_link_destination_text(format_link_destination(link.url.trim())));
     if let Some(title) = &link.title {
-      items.push_string(format!(" \"{}\"", title.trim()));
+      items.extend(gen_title(title, context));
     }
     items.push_sc(sc!(")"));
 
@@ -706,6 +706,51 @@ fn gen_link_destination_text(text: String) -> PrintItems {
     text
   };
   gen_text_with_tabs(text)
+}
+
+/// Generates an image's alt text, which is the raw text from the file.
+fn gen_image_alt_text(text: &str, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  items.push_sc(sc!("!["));
+  items.extend(gen_raw_text(text.trim(), context));
+  items.push_sc(sc!("]"));
+  items
+}
+
+/// Generates the label of a reference image or link.
+fn gen_reference_label(reference: &str, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  items.push_sc(sc!("["));
+  items.extend(gen_raw_text(reference.trim(), context));
+  items.push_sc(sc!("]"));
+  items
+}
+
+/// Generates the title that follows an inline image or link's destination.
+fn gen_title(title: &str, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  items.push_sc(sc!(" \""));
+  items.extend(gen_raw_text(title.trim(), context));
+  items.push_sc(sc!("\""));
+  items
+}
+
+/// Generates raw text from the file that may span multiple lines.
+///
+/// The printer requires the strings it's given to be a single line, so the
+/// line breaks the text contains need to be sent as print items instead.
+fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  let mut lines = text.lines();
+  if let Some(line) = lines.next() {
+    items.push_string(line.trim_end().to_string());
+  }
+  for line in lines {
+    // the indentation of a continued line is provided by the printer
+    items.extend(get_newline_wrapping_based_on_config(context));
+    items.push_string(line.trim().to_string());
+  }
+  items
 }
 
 /// Writes out text, sending any tab it has as a signal, since the printer
@@ -801,7 +846,7 @@ fn gen_reference_link(link: &ReferenceLink, context: &mut Context) -> PrintItems
     items.push_sc(sc!("["));
     items.extend(gen_nodes(&link.children, context));
     items.push_sc(sc!("]"));
-    items.push_string(format!("[{}]", link.reference.trim()));
+    items.extend(gen_reference_label(&link.reference, context));
     ir_helpers::new_line_group(items)
   })
 }
@@ -908,29 +953,29 @@ fn unescape_link_destination(destination: &str) -> String {
   text
 }
 
-fn gen_inline_image(image: &InlineImage, _: &mut Context) -> PrintItems {
+fn gen_inline_image(image: &InlineImage, context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_string(format!("![{}]", image.text.trim()));
+  items.extend(gen_image_alt_text(&image.text, context));
   items.push_sc(sc!("("));
   // like a link reference definition, this is the raw text from the file
   items.extend(gen_link_destination_text(format_raw_link_destination(image.url.trim())));
   if let Some(title) = &image.title {
-    items.push_string(format!(" \"{}\"", title.trim()));
+    items.extend(gen_title(title, context));
   }
   items.push_sc(sc!(")"));
   ir_helpers::new_line_group(items)
 }
 
-fn gen_reference_image(image: &ReferenceImage, _: &mut Context) -> PrintItems {
+fn gen_reference_image(image: &ReferenceImage, context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_string(format!("![{}]", image.text.trim()));
-  items.push_string(format!("[{}]", image.reference.trim()));
+  items.extend(gen_image_alt_text(&image.text, context));
+  items.extend(gen_reference_label(&image.reference, context));
   ir_helpers::new_line_group(items)
 }
 
-fn gen_shortcut_image(image: &ShortcutImage, _: &mut Context) -> PrintItems {
+fn gen_shortcut_image(image: &ShortcutImage, context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_string(format!("![{}]", image.text.trim()));
+  items.extend(gen_image_alt_text(&image.text, context));
   ir_helpers::new_line_group(items)
 }
 

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -173,3 +173,55 @@ text]](https://dprint.dev)
 [![some text]](https://dprint.dev)
 
 [some text]: https://dprint.dev/image.png
+
+!! should keep the block quote markers of a line break in alt text !!
+> ![some
+> text](https://dprint.dev/image.png)
+
+> > ![some
+> > text][testing]
+
+[testing]: https://dprint.dev/image.png
+
+[expect]
+> ![some
+> text](https://dprint.dev/image.png)
+
+>> ![some
+>> text][testing]
+
+[testing]: https://dprint.dev/image.png
+
+!! should move alt text onto a single line within a heading !!
+![some
+text](https://dprint.dev/image.png)
+===
+
+[expect]
+# ![some text](https://dprint.dev/image.png)
+
+!! should keep a reference label resolvable within a heading !!
+![img][some
+reference]
+===
+
+[some reference]: https://dprint.dev/image.png
+
+[expect]
+# ![img][some reference]
+
+[some reference]: https://dprint.dev/image.png
+
+!! should keep a tab in alt text, a title and a reference label !!
+![a	b](https://dprint.dev/image.png "c	d")
+
+![a	b][e	f]
+
+[e f]: https://dprint.dev/image.png
+
+[expect]
+![a	b](https://dprint.dev/image.png "c	d")
+
+![a	b][e	f]
+
+[e f]: https://dprint.dev/image.png

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -106,3 +106,70 @@ testing
 ![t]((a)b)
 ![t](())
 ![t]((a) "title")
+
+!! should keep a line break in alt text !!
+![some
+text](https://dprint.dev/image.png)
+
+![some
+text][testing]
+
+![some
+text]
+
+[testing]: https://dprint.dev/image.png
+
+[expect]
+![some
+text](https://dprint.dev/image.png)
+
+![some
+text][testing]
+
+![some
+text]
+
+[testing]: https://dprint.dev/image.png
+
+!! should keep a line break in a title !!
+![img](https://dprint.dev/image.png "some
+title")
+
+[expect]
+![img](https://dprint.dev/image.png "some
+title")
+
+!! should keep a line break in a reference label !!
+![img][some
+reference]
+
+[some reference]: https://dprint.dev/image.png
+
+[expect]
+![img][some
+reference]
+
+[some reference]: https://dprint.dev/image.png
+
+!! should keep the indentation of a line break in alt text out of the text !!
+- ![some
+  text]
+
+[some text]: https://dprint.dev/image.png
+
+[expect]
+- ![some
+  text]
+
+[some text]: https://dprint.dev/image.png
+
+!! should move alt text onto a single line within a link !!
+[![some
+text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png
+
+[expect]
+[![some text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -75,3 +75,23 @@ Test [this out](/test) test
 
 [expect]
 [Some reference]: https://github.com
+
+!! should keep a line break in a title !!
+[testing](https://dprint.dev "some
+title")
+
+[expect]
+[testing](https://dprint.dev "some
+title")
+
+!! should keep a line break in a reference label !!
+[testing][some
+reference]
+
+[some reference]: https://dprint.dev
+
+[expect]
+[testing][some
+reference]
+
+[some reference]: https://dprint.dev

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -95,3 +95,23 @@ reference]
 reference]
 
 [some reference]: https://dprint.dev
+
+!! should keep the block quote markers of a line break in a title !!
+> [testing](https://dprint.dev "some
+> title")
+
+[expect]
+> [testing](https://dprint.dev "some
+> title")
+
+!! should keep a reference label resolvable within a heading !!
+[testing][some
+reference]
+===
+
+[some reference]: https://dprint.dev
+
+[expect]
+# [testing][some reference]
+
+[some reference]: https://dprint.dev


### PR DESCRIPTION
Formatting panicked on any image whose alt text spanned a line break:

```md
![some
text](image.png)
```

> Debug panic! Found a newline in the string. Before sending the string to the printer it needs to be broken up and the newline sent as a `PrintItem::NewLine`.

The image generators pushed the raw text from the file straight through as a single string, so a line break inside it reached the printer. The same defect applied to a few other raw strings that can span lines:

- an image's alt text (inline, reference and shortcut)
- an inline image or link's title
- a reference image or link's label

Now those go through `gen_raw_text`, which sends each line break as a print item via `get_newline_wrapping_based_on_config`, so they follow `textWrap` like the surrounding text does:

- `maintain` (default) keeps the line break
- `always` joins the lines and re-wraps at the line width
- `never` joins the lines

Each continued line is trimmed and its indentation comes from the printer instead, which keeps a line break inside a list item idempotent:

```md
- ![some
  text]
```

An image nested in a link still collapses onto one line, since the link forces no newlines.

Specs added to `Images_All.txt` and `Links_All.txt`. The suite formats twice, so these cover idempotency too.