### PR TITLE
fix: handle a block quote within a list within a block quote

### DIFF
--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -28,7 +28,8 @@ pub struct Context<'a> {
   /** The current indentation level within the file being formatted. */
   pub raw_indent_level: u32,
   is_in_list_count: u32,
-  is_in_block_quote_count: u32,
+  /// The indentation level each surrounding block quote started at, from outermost to innermost.
+  block_quote_base_indents: Vec<u32>,
   text_wrap_disabled_count: u32,
   pub format_code_block_text: Box<dyn for<'b> FnMut(&str, &'b str, u32) -> FormatResult + 'a>,
   pub ignore_regex: Regex,
@@ -49,7 +50,7 @@ impl<'a> Context<'a> {
       indent_level: 0,
       raw_indent_level: 0,
       is_in_list_count: 0,
-      is_in_block_quote_count: 0,
+      block_quote_base_indents: Vec::new(),
       text_wrap_disabled_count: 0,
       format_code_block_text: Box::new(format_code_block_text),
       ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
@@ -88,12 +89,15 @@ impl<'a> Context<'a> {
     }
   }
 
-  pub fn mark_in_block_quotes<T>(&mut self, func: impl FnOnce(&mut Context, usize) -> T) -> T {
+  /// Marks being within a block quote, providing the indentation level of every
+  /// surrounding block quote (from outermost to innermost) to the provided function.
+  pub fn mark_in_block_quotes<T>(&mut self, func: impl FnOnce(&mut Context, Vec<u32>) -> T) -> T {
     let original_is_in_list_count = self.is_in_list_count;
     self.is_in_list_count = 0;
-    self.is_in_block_quote_count += 1;
-    let items = func(self, self.is_in_block_quote_count as usize);
-    self.is_in_block_quote_count -= 1;
+    self.block_quote_base_indents.push(self.indent_level);
+    let base_indents = self.block_quote_base_indents.clone();
+    let items = func(self, base_indents);
+    self.block_quote_base_indents.pop();
     self.is_in_list_count = original_is_in_list_count;
     items
   }
@@ -110,7 +114,7 @@ impl<'a> Context<'a> {
   }
 
   pub fn is_in_block_quote(&self) -> bool {
-    self.is_in_block_quote_count > 0
+    !self.block_quote_base_indents.is_empty()
   }
 
   /// Whether the position at `index` is preceded by a blank line, accounting for

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -317,7 +317,7 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
 }
 
 fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItems {
-  context.mark_in_block_quotes(|context, block_quote_count| {
+  context.mark_in_block_quotes(|context, base_indents| {
     let mut items = PrintItems::new();
 
     // add a > for any string that is on the start of a line
@@ -343,22 +343,14 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
           items.push_item(PrintItem::String(text));
         }
         PrintItem::String(text) => {
+          // avoid inserting space in nested block quote markers (`> > foo`).
+          let trailing = MarkersTrailing::Text {
+            space: text.text != ">",
+          };
           items.push_condition(if_true(
             "angleBracketIfStartOfLine",
             condition_resolvers::is_start_of_line(),
-            {
-              let mut items = PrintItems::new();
-              items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::FinishIndent(indent_level)));
-              items.push_string(">".repeat(block_quote_count));
-              // avoid inserting space in nested block quote markers (`> > foo`).
-              if text.text != ">" {
-                items.push_space();
-              }
-              items.push_optional_path(
-                context.get_memoized_rc_path(MemoizedRcPathKind::StartWithSingleIndent(indent_level)),
-              );
-              items
-            },
+            gen_block_quote_markers(&base_indents, indent_level, trailing, context),
           ));
           items.push_item(PrintItem::String(text));
         }
@@ -367,13 +359,7 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
           items.push_condition(if_true(
             "angleBracketIfStartOfLine",
             condition_resolvers::is_start_of_line(),
-            {
-              let mut items = PrintItems::new();
-              items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::FinishIndent(indent_level)));
-              items.push_string(">".repeat(block_quote_count));
-              items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::StartIndent(indent_level)));
-              items
-            },
+            gen_block_quote_markers(&base_indents, indent_level, MarkersTrailing::BlankLine, context),
           ));
           items.push_signal(Signal::NewLine);
         }
@@ -397,6 +383,60 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
 
     items
   })
+}
+
+enum MarkersTrailing {
+  /// Text follows the markers on the same line.
+  Text { space: bool },
+  /// Nothing follows the markers on the line.
+  BlankLine,
+}
+
+/// Generates the `>` markers that prefix a line within a block quote, keeping the
+/// indentation that occurs between the block quote levels (ex. `> - > text`, where
+/// a list within the outer block quote indents the inner block quote).
+fn gen_block_quote_markers(
+  base_indents: &[u32],
+  inner_indent_level: u32,
+  trailing: MarkersTrailing,
+  context: &mut Context,
+) -> PrintItems {
+  let mut items = PrintItems::new();
+  let outermost_indent = *base_indents.first().unwrap();
+  let current_indent = *base_indents.last().unwrap() + inner_indent_level;
+
+  // go back to where the outermost marker belongs, then write each
+  // marker at the indentation its block quote started at
+  items.push_optional_path(
+    context.get_memoized_rc_path(MemoizedRcPathKind::FinishIndent(current_indent - outermost_indent)),
+  );
+  let mut written_indent = outermost_indent;
+  for base_indent in base_indents {
+    if *base_indent > written_indent {
+      items.push_space();
+      items.push_optional_path(
+        context.get_memoized_rc_path(MemoizedRcPathKind::StartWithSingleIndent(base_indent - written_indent)),
+      );
+      written_indent = *base_indent;
+    }
+    items.push_sc(sc!(">"));
+  }
+
+  let remaining_indent = current_indent - written_indent;
+  match trailing {
+    MarkersTrailing::Text { space } => {
+      if space {
+        items.push_space();
+      }
+      items
+        .push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::StartWithSingleIndent(remaining_indent)));
+    }
+    MarkersTrailing::BlankLine => {
+      items.push_optional_path(context.get_memoized_rc_path(MemoizedRcPathKind::StartIndent(remaining_indent)));
+    }
+  }
+
+  items
 }
 
 fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {

--- a/tests/specs/Issues/Issue0187.txt
+++ b/tests/specs/Issues/Issue0187.txt
@@ -1,0 +1,75 @@
+!! should handle a block quote in a list in a block quote !!
+> - > foo
+>   > bar
+
+[expect]
+> - > foo
+>   > bar
+
+!! should handle a lazy continuation line !!
+> - > foo
+bar
+
+[expect]
+> - > foo
+>   > bar
+
+!! should handle a blank line in a block quote in a list in a block quote !!
+> - > foo
+>   >
+>   > bar
+
+[expect]
+> - > foo
+>   >
+>   > bar
+
+!! should handle an ordered list between block quotes !!
+> 1. > foo
+>    > bar
+
+[expect]
+> 1. > foo
+>    > bar
+
+!! should handle nested block quotes within a list in a block quote !!
+> - > > foo
+>   > > bar
+
+[expect]
+> - >> foo
+>   >> bar
+
+!! should handle a list within nested block quotes !!
+> > - > foo
+> >   > bar
+
+[expect]
+>> - > foo
+>>   > bar
+
+!! should handle a list outside the outer block quote !!
+- > - > foo
+  >   > bar
+
+[expect]
+- > - > foo
+  >   > bar
+
+!! should handle a sub list !!
+> - foo
+>   - > bar
+>     > baz
+
+[expect]
+> - foo
+>   - > bar
+>     > baz
+
+!! should handle alternating lists and block quotes !!
+> - > 1. > foo
+>   >    > bar
+
+[expect]
+> - > 1. > foo
+>   >    > bar


### PR DESCRIPTION
Fixes formatting of a block quote nested inside a list inside a block quote.

```md
> - > foo
>   > bar
```

Previously the second line was output as `  >> bar` (dropping the outer block quote and the list item), and reformatting that produced yet another result.

The block quote generation wrote all of the `>` markers for a line next to each other (`">".repeat(block_quote_count)`), which works when the levels are adjacent (`>>`) or when the surrounding lists are outside the outermost block quote, but loses the indentation of any list occurring *between* two block quote levels.

Now each block quote records the indentation level it started at, and a line's markers are written at those levels with the indentation in between, so `> - > 1. > text` round trips as well.

Closes #187
