### PR TITLE
chore: lint and format

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -207,7 +207,7 @@ mod tests {
     assert_eq!(result.config.tags.get("markdown").unwrap(), "md");
     // keys should be lowercased
     assert_eq!(result.config.tags.get("jsx").unwrap(), "tsx");
-    assert!(result.config.tags.get("JSX").is_none());
+    assert!(!result.config.tags.contains_key("JSX"));
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -66,7 +66,12 @@ pub fn resolve_config(
     ),
     heading_kind: get_value(&mut config, "headingKind", HeadingKind::Atx, &mut diagnostics),
     unindent_code_blocks: get_value(&mut config, "unindentCodeBlocks", true, &mut diagnostics),
-    list_indent_kind: get_value(&mut config, "listIndentKind", ListIndentKind::CommonMark, &mut diagnostics),
+    list_indent_kind: get_value(
+      &mut config,
+      "listIndentKind",
+      ListIndentKind::CommonMark,
+      &mut diagnostics,
+    ),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -133,4 +133,8 @@ pub enum ListIndentKind {
   PythonMarkdown,
 }
 
-generate_str_to_from![ListIndentKind, [CommonMark, "commonMark"], [PythonMarkdown, "pythonMarkdown"]];
+generate_str_to_from![
+  ListIndentKind,
+  [CommonMark, "commonMark"],
+  [PythonMarkdown, "pythonMarkdown"]
+];

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -78,6 +78,7 @@ pub fn trace_file(
   dprint_core::formatting::trace_printing(
     || {
       let mut context = Context::new(markdown_text, config, format_code_block_text);
+      #[allow(clippy::let_and_return)]
       let print_items = generate(&source_file.into(), &mut context);
       // eprintln!("{}", print_items.get_as_text());
       print_items

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1022,7 +1022,9 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
       };
       let indent_increment = match context.configuration.list_indent_kind {
         crate::configuration::ListIndentKind::CommonMark => (prefix_text.chars().count() + 1) as u32,
-        crate::configuration::ListIndentKind::PythonMarkdown => std::cmp::max(prefix_text.chars().count() as u32 + 1, 4),
+        crate::configuration::ListIndentKind::PythonMarkdown => {
+          std::cmp::max(prefix_text.chars().count() as u32 + 1, 4)
+        }
       };
       context.indent_level += indent_increment;
       items.push_string(prefix_text);


### PR DESCRIPTION
A quick fix so that `cargo fmt` and `cargo clippy --all-features --all-targets` report no errors.