### PR TITLE
fix: keep link reference definitions that were being dropped, and don't separate adjacent nodes

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -132,8 +132,9 @@ pub fn parse_cmark_ast(markdown_text: &str) -> Result<SourceFile, ParseError> {
 
     // do not parse for link references while inside a table
     if iterator.in_table_count() <= 1 {
+      // `or(Some(0))` so the text before the first event is looked at too
       if let Some(references) = parse_references(
-        last_event_range.as_ref().map(|r| r.end),
+        last_event_range.as_ref().map(|r| r.end).or(Some(0)),
         current_range.start,
         &mut iterator,
       )? {
@@ -306,18 +307,32 @@ fn parse_paragraph(iterator: &mut EventIterator) -> Result<Paragraph, ParseError
 fn parse_block_quote(iterator: &mut EventIterator) -> Result<BlockQuote, ParseError> {
   let start = iterator.start();
   let mut children = Vec::new();
+  let mut last_event_end: Option<usize> = None;
 
   while let Some(event) = iterator.next() {
-    match event {
-      Event::End(TagEnd::BlockQuote) => break,
-      _ => children.push(parse_event(event, iterator)?),
+    if matches!(event, Event::End(TagEnd::BlockQuote)) {
+      break;
     }
+
+    // cmark doesn't raise events for link reference definitions, so look for
+    // them in the text leading up to this event
+    let current_range = iterator.get_last_range();
+    if let Some(references) = parse_references(last_event_end.or(Some(start)), current_range.start, iterator)? {
+      children.push(references);
+    }
+
+    children.push(parse_event(event, iterator)?);
+    last_event_end = Some(current_range.end);
   }
 
-  Ok(BlockQuote {
-    range: iterator.get_range_for_start(start),
-    children,
-  })
+  let range = iterator.get_range_for_start(start);
+  // a block quote may consist of only link reference definitions, in which
+  // case it has no children to search after
+  if let Some(references) = parse_references(last_event_end.or(Some(start)), range.end, iterator)? {
+    children.push(references);
+  }
+
+  Ok(BlockQuote { range, children })
 }
 
 fn parse_code_block(code_block_kind: CodeBlockKind, iterator: &mut EventIterator) -> Result<CodeBlock, ParseError> {

--- a/src/generation/cmark/parsing/parse_link_reference_definitions.rs
+++ b/src/generation/cmark/parsing/parse_link_reference_definitions.rs
@@ -53,9 +53,29 @@ fn parse_link_reference_definition(
 
 fn parse_reference_link(start_pos: usize, char_scanner: &mut CharScanner) -> Result<String, ParseError> {
   let mut reference_link = String::new();
+  let mut is_in_title = false;
   while let Some((_, c)) = char_scanner.next() {
     match c {
-      '\n' => break,
+      // a title may span lines, so only the line ending that follows the
+      // definition ends it
+      '\n' if !is_in_title => break,
+      '\\' if is_in_title => {
+        reference_link.push(c);
+        // push the next char without checking it, since it's escaped
+        if let Some((_, next_c)) = char_scanner.next() {
+          reference_link.push(next_c);
+        }
+      }
+      '"' => {
+        // a title opens after the whitespace that ends the destination, so a
+        // quote anywhere else is part of the destination (ex. `[a]: a"b`)
+        if is_in_title {
+          is_in_title = false;
+        } else if reference_link.chars().next_back().is_none_or(|c| c.is_whitespace()) {
+          is_in_title = true;
+        }
+        reference_link.push(c);
+      }
       _ => reference_link.push(c),
     }
   }

--- a/src/generation/common/ast_nodes.rs
+++ b/src/generation/common/ast_nodes.rs
@@ -293,6 +293,12 @@ impl Node {
     }
   }
 
+  /// Whether any whitespace, not only a space, comes before this node.
+  pub fn has_preceding_whitespace(&self, file_text: &str) -> bool {
+    let range = self.range();
+    matches!(file_text[..range.start].chars().next_back(), Some(c) if c.is_whitespace())
+  }
+
   pub fn starts_with_punctuation(&self, file_text: &str) -> bool {
     let range = self.range();
     let text = &file_text[range.start..range.end];

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -174,7 +174,8 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               } else if let Node::Html(_) = node {
                 node.has_preceding_space(context.file_text)
               } else {
-                true
+                // ex. two images beside each other shouldn't be separated
+                node.has_preceding_whitespace(context.file_text)
               };
 
               if needs_space {
@@ -995,9 +996,10 @@ fn gen_auto_link(link: &AutoLink, context: &mut Context) -> PrintItems {
   })
 }
 
-fn gen_link_reference(link_ref: &LinkReference, _: &mut Context) -> PrintItems {
+fn gen_link_reference(link_ref: &LinkReference, context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_string(format!("[{}]: ", link_ref.name.trim()));
+  items.extend(gen_reference_label(&link_ref.name, context));
+  items.push_sc(sc!(": "));
 
   let url = format_raw_link_destination(link_ref.link.trim());
   if url.is_empty() {
@@ -1009,7 +1011,7 @@ fn gen_link_reference(link_ref: &LinkReference, _: &mut Context) -> PrintItems {
   }
 
   if let Some(title) = &link_ref.title {
-    items.push_string(format!(" \"{}\"", title.trim()));
+    items.extend(gen_title(title, context));
   }
   ir_helpers::new_line_group(items)
 }

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -235,3 +235,9 @@ reference]
 ![a](x.png)![b](y.png)
 
 ![a](x.png) ![b](y.png)
+
+!! should not separate an image from adjacent code !!
+`a`![b](y.png)`c`
+
+[expect]
+`a`![b](y.png)`c`

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -225,3 +225,13 @@ reference]
 ![a	b][e	f]
 
 [e f]: https://dprint.dev/image.png
+
+!! should not separate adjacent images !!
+![a](x.png)![b](y.png)
+
+![a](x.png) ![b](y.png)
+
+[expect]
+![a](x.png)![b](y.png)
+
+![a](x.png) ![b](y.png)

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -115,3 +115,79 @@ reference]
 # [testing][some reference]
 
 [some reference]: https://dprint.dev
+
+!! should keep a link reference definition that comes before other content !!
+[some name]: https://dprint.dev
+
+[some name]
+
+[expect]
+[some name]: https://dprint.dev
+
+[some name]
+
+!! should keep a link reference definition in a block quote !!
+> [some name]: https://dprint.dev
+>
+> [some name]
+
+[expect]
+> [some name]: https://dprint.dev
+>
+> [some name]
+
+!! should keep a link reference definition that's a block quote's only content !!
+> [some name]: https://dprint.dev
+
+[expect]
+> [some name]: https://dprint.dev
+
+!! should keep a line break in a link reference definition's label !!
+[some
+name]: https://dprint.dev
+
+[some name]
+
+[expect]
+[some
+name]: https://dprint.dev
+
+[some name]
+
+!! should keep the block quote markers of a line break in a definition's label !!
+> [some
+> name]: https://dprint.dev
+>
+> [some name]
+
+[expect]
+> [some
+> name]: https://dprint.dev
+>
+> [some name]
+
+!! should not separate adjacent links !!
+[a](x)[b](y)
+
+[expect]
+[a](x)[b](y)
+
+!! should keep a line break in a link reference definition's title !!
+[n]: https://dprint.dev "some
+title"
+
+[n]
+
+[expect]
+[n]: https://dprint.dev "some
+title"
+
+[n]
+
+!! should keep a quote in a link reference definition's destination !!
+[a]: https://dprint.dev/q"z
+[b]: https://dprint.dev
+
+[expect]
+[a]: https://dprint.dev/q"z
+[b]: https://dprint.dev

--- a/tests/specs/TextDecoration/TextDecoration_All.txt
+++ b/tests/specs/TextDecoration/TextDecoration_All.txt
@@ -26,3 +26,15 @@ Test ~~strikethrough~~ test
 *wor*d
 *word*1
 _word_?
+
+!! should not separate adjacent text decoration !!
+**a**_b_
+
+[expect]
+**a**_b_
+
+!! should turn a tab between adjacent nodes into a space !!
+**a**	_b_
+
+[expect]
+**a** _b_


### PR DESCRIPTION
Follows on from #199. What started as "definitions with a multi-line label get dropped" turned out to be much broader — the multi-line part was incidental.

## Link reference definitions were silently deleted

cmark raises no events for link reference definitions, so they're found by scanning the text *between* events. Two regions were never scanned, and anything in them was dropped without a warning — turning working links into dangling ones.

**1. Before the first event.** The scan loop started from the previous event's end, which is `None` on the first iteration, so the whole region before the first event was skipped. Nothing to do with multi-line labels — this ate ordinary definitions at the top of a file, a very common layout:

```md
[some name]: https://dprint.dev

hello
```

formatted to just `hello`.

**2. Inside a block quote.** `parse_block_quote` never scanned for definitions at all (`parse_item` already had its own scan, which is why list items were unaffected). Every definition in a block quote was deleted, wherever it sat:

```md
> [some name]: https://dprint.dev
```

formatted to bare `>`.

`parse_block_quote` now does the same gap scanning the top-level loop does, so definitions before, between and after its children are all kept.

## A definition's label or title couldn't span lines

Two separate causes, both now fixed:

- `gen_link_reference` pushed the label and title as raw strings, which panics on a line break or tab. It now uses the `gen_reference_label` / `gen_title` helpers from #199, so it follows `textWrap` and keeps block quote markers correct.
- `parse_reference_link` stopped at the first line ending, so a title spanning lines left a dangling second line and failed with `Unexpected token`. It now tracks whether it's inside a title. A title only opens after the whitespace that ends the destination, so a quote *in* a destination stays part of it — `[a]: https://dprint.dev/q"z` no longer swallows the definition on the next line.

## Adjacent inline nodes gained a space

`gen_nodes` fell back to "needs a space" for any two adjacent inline nodes that weren't text, so nodes written flush against each other were pushed apart:

| input | was | now |
|---|---|---|
| `![a](x)![b](y)` | `![a](x) ![b](y)` | unchanged |
| `[a](x)[b](y)` | `[a](x) [b](y)` | unchanged |
| `**a**_b_` | `**a** _b_` | unchanged |

The last one changes how the source renders. The fallback now asks whether whitespace actually preceded the node. It checks any whitespace rather than only a space, so a tab still separates (`**a**<tab>_b_` → `**a** _b_`) instead of gluing the nodes together.

## Not included

- **A block quote loses its `>` on a wrapped line inside a link or setext heading.** `clone_items` wraps content in an `RcPath`, and the block quote transform passes those through opaquely, so newlines inside them never get markers. Fixing it by descending into paths is unsafe as it stands: the memoized indent paths the transform emits for nested block quotes contain `StartIndent`/`FinishIndent` signals, and flattening those would drift its `indent_level` and risk regressing #200. It needs a way to tell content paths from marker paths.
- **Titles in single quotes or parens, and escaped quotes in a title**, are folded into the destination by `parse_link_url_and_title`. Verified byte-identical to `main`, so pre-existing — but previously invisible in the positions above, because the definition was being deleted outright.