### PR TITLE
fix: keep block quote markers on lines within a link or setext heading

### DIFF
--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use dprint_core::formatting::PrintItemPath;
 use dprint_core::formatting::PrintItems;
@@ -36,6 +37,9 @@ pub struct Context<'a> {
   pub ignore_start_regex: Regex,
   pub ignore_end_regex: Regex,
   memoized_rc_paths: HashMap<MemoizedRcPathKind, Option<PrintItemPath>>,
+  /// The paths above, by address, so they can be told apart from the paths
+  /// that hold generated content.
+  memoized_rc_path_addresses: HashSet<usize>,
 }
 
 impl<'a> Context<'a> {
@@ -57,6 +61,7 @@ impl<'a> Context<'a> {
       ignore_start_regex: get_ignore_comment_regex(&configuration.ignore_start_directive),
       ignore_end_regex: get_ignore_comment_regex(&configuration.ignore_end_directive),
       memoized_rc_paths: HashMap::new(),
+      memoized_rc_path_addresses: HashSet::new(),
     }
   }
 
@@ -85,8 +90,17 @@ impl<'a> Context<'a> {
       }
       let path = items.into_rc_path();
       self.memoized_rc_paths.insert(kind, path);
+      if let Some(path) = path {
+        self.memoized_rc_path_addresses.insert(path as *const _ as usize);
+      }
       path
     }
+  }
+
+  /// Whether the path is one of the memoized paths handed out above, rather
+  /// than a path holding generated content.
+  pub fn is_memoized_rc_path(&self, path: PrintItemPath) -> bool {
+    self.memoized_rc_path_addresses.contains(&(path as *const _ as usize))
   }
 
   /// Marks being within a block quote, providing the indentation level of every

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -327,7 +327,8 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
     // the opening `>` cannot rely on being at the start of a line, because a block
     // quote may begin mid-line -- for example directly after a list item marker.
     let mut needs_opening_marker = true;
-    for print_item in gen_nodes(&block_quote.children, context).iter() {
+    let children = gen_nodes(&block_quote.children, context);
+    for print_item in get_content_print_items(children, context) {
       match print_item {
         PrintItem::String(text) if needs_opening_marker => {
           // at the beginning of a block quote, '>' is necessary
@@ -384,6 +385,31 @@ fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItem
 
     items
   })
+}
+
+/// Gets the print items of a block quote's content, stepping into the paths
+/// that hold generated content so the markers can be added to the lines within
+/// them (ex. the text of a link, which is shared in a path in order to measure
+/// it). The paths holding the markers of a nested block quote are left alone,
+/// since the indentation they contain isn't the content's.
+fn get_content_print_items(items: PrintItems, context: &Context) -> Vec<PrintItem> {
+  let mut result = Vec::new();
+  let mut iterators = vec![items.iter()];
+
+  while let Some(mut iterator) = iterators.pop() {
+    while let Some(print_item) = iterator.next() {
+      match print_item {
+        PrintItem::RcPath(path) if !context.is_memoized_rc_path(path) => {
+          iterators.push(iterator);
+          iterators.push(PrintItemsIterator::new(path));
+          break;
+        }
+        _ => result.push(print_item),
+      }
+    }
+  }
+
+  result
 }
 
 enum MarkersTrailing {

--- a/tests/specs/BlockQuotes/BlockQuotes_All.txt
+++ b/tests/specs/BlockQuotes/BlockQuotes_All.txt
@@ -30,3 +30,27 @@
 > Second
 >
 > Third
+
+!! should keep the markers of a line break within a link's text !!
+> [some words here that are quite long
+> and more text](a.png)
+
+[expect]
+> [some words here that are quite long
+> and more text](a.png)
+
+!! should keep the markers of a line break within a link's text when nested !!
+> > [some words here that are quite long
+> > and more text](a.png)
+
+[expect]
+>> [some words here that are quite long
+>> and more text](a.png)
+
+!! should keep the markers of a line break within a link's text in a list !!
+> - [some words here that are quite long
+>   and more text](a.png)
+
+[expect]
+> - [some words here that are quite long
+>   and more text](a.png)

--- a/tests/specs/BlockQuotes/BlockQuotes_HeadingKind_Setext.txt
+++ b/tests/specs/BlockQuotes/BlockQuotes_HeadingKind_Setext.txt
@@ -1,0 +1,18 @@
+~~ headingKind: setext ~~
+!! should keep the markers of a setext heading !!
+> some words here that are quite long and more text again that keeps going on and on
+> ===
+
+[expect]
+> some words here that are quite long and more text again that keeps going on and on
+> ==================================================================================
+
+!! should keep the markers of a line break within a setext heading's link !!
+> [some words here that are quite long
+> and more](a.png) text
+> ===
+
+[expect]
+> [some words here that are quite long
+> and more](a.png) text
+> ====================================


### PR DESCRIPTION
The last of the follow-ups from #199 / #205.

A block quote adds its `>` by walking the print items of its content and prefixing each line. `clone_items` shares items through an `RcPath` so they can be measured and printed, and the walk stepped over those paths without looking inside — so any line break within one never got a marker:

```md
> [some words here that are quite long
> and more text](a.png)
```

formatted to

```md
> [some words here that are quite long
and more text](a.png)
```

and the second line falls out of the block quote entirely.

Setext headings were worse. They share their children the same way, so the heading text lost its marker on *every* line, including the first:

```md
> some words here that are quite long and more
> ===
```

formatted with the heading text outside the quote and only the underline still in it.

## Telling the two kinds of path apart

Simply stepping into every path isn't safe. The markers of a nested block quote are themselves emitted through memoized paths, and those hold `StartIndent`/`FinishIndent` signals. Walking into them would let the enclosing block quote's `indent_level` drift as it counted indentation that belongs to the inner block quote's markers rather than to the content — regressing the nesting that #200 fixed.

Since the memoized paths all come from `get_memoized_rc_path`, `Context` now records their addresses as it hands them out, and `is_memoized_rc_path` answers whether a given path is one of them. `get_content_print_items` steps into every other path — the ones holding generated content — and leaves the marker paths alone.

## Verified

- Fixes the wrapped link text case, nested (`>> `), and within a list item (`>   `, keeping the list indentation).
- Fixes setext headings in a block quote, including one whose text contains a wrapped link.
- Table cells share items the same way; tables in block quotes (incl. nested, and a long cell) are byte-identical to `main`.
- A block quote holding a heading, wrapping paragraph, list with a link and image, nested quote, table, code block, footnote definition and inline decoration is byte-identical to `main` under `textWrap: always`, so the change only reaches the cases that were broken.