### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ harness = false
 [dependencies]
 dprint-core = { version = "0.69.1", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
-pulldown-cmark = { version = "0.11.2", default-features = false }
+pulldown-cmark = { version = "0.13", default-features = false }
 regex = "1"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0"
-unicode-width = "0.1.10"
+unicode-width = "0.2"
 
 [dev-dependencies]
-dprint-development = "0.10.2"
+dprint-development = "0.11.0"
 serde_json = { version = "1.0" }

--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -65,7 +65,7 @@ impl<'a> EventIterator<'a> {
       Some((Event::Start(Tag::Table(_)), _)) => self.in_table_count += 1,
       Some((Event::End(TagEnd::Table), _)) => self.in_table_count = self.in_table_count.saturating_sub(1),
       Some((Event::Start(Tag::BlockQuote(_)), _)) => self.in_block_quote_count += 1,
-      Some((Event::End(TagEnd::BlockQuote), _)) => {
+      Some((Event::End(TagEnd::BlockQuote(_)), _)) => {
         self.in_block_quote_count = self.in_block_quote_count.saturating_sub(1)
       }
       _ => {}
@@ -249,6 +249,15 @@ fn parse_start(start_tag: Tag, iterator: &mut EventIterator) -> Result<Node, Par
     Tag::Item => parse_item(iterator).map(|x| x.into()),
     Tag::HtmlBlock => parse_html_block(iterator).map(|x| x.into()),
     Tag::MetadataBlock(metadata_block_kind) => parse_metadata(metadata_block_kind, iterator).map(|x| x.into()),
+    // these tags are only emitted when their corresponding options are enabled, which they aren't
+    Tag::DefinitionList
+    | Tag::DefinitionListTitle
+    | Tag::DefinitionListDefinition
+    | Tag::Superscript
+    | Tag::Subscript => Err(ParseError::new(
+      iterator.get_last_range(),
+      format!("Tag not implemented {:?}", start_tag),
+    )),
   }
 }
 
@@ -309,7 +318,7 @@ fn parse_block_quote(iterator: &mut EventIterator) -> Result<BlockQuote, ParseEr
 
   while let Some(event) = iterator.next() {
     match event {
-      Event::End(TagEnd::BlockQuote) => break,
+      Event::End(TagEnd::BlockQuote(_)) => break,
       _ => children.push(parse_event(event, iterator)?),
     }
   }
@@ -577,6 +586,11 @@ fn parse_link(
     }
     LinkType::Shortcut | LinkType::ShortcutUnknown => Ok(ShortcutLink { range, children }.into()),
     LinkType::Email | LinkType::Autolink => Ok(AutoLink { range, children }.into()),
+    // only emitted when Options::ENABLE_WIKILINKS is enabled, which it isn't
+    LinkType::WikiLink { .. } => Err(ParseError::new(
+      range,
+      format!("Link type not implemented {:?}", link_type),
+    )),
   }
 }
 

--- a/src/generation/cmark/parsing/parse_image.rs
+++ b/src/generation/cmark/parsing/parse_image.rs
@@ -16,7 +16,8 @@ pub fn parse_image(offset: usize, text: &str, link_type: LinkType) -> Result<Nod
       parse_reference(start_pos, &mut char_scanner)
     }
     LinkType::Shortcut | LinkType::ShortcutUnknown => parse_shortcut(start_pos, &mut char_scanner),
-    LinkType::Email | LinkType::Autolink => Err(ParseError::new(
+    // WikiLink is only emitted when Options::ENABLE_WIKILINKS is enabled, which it isn't
+    LinkType::Email | LinkType::Autolink | LinkType::WikiLink { .. } => Err(ParseError::new(
       Range {
         start: offset,
         end: offset,


### PR DESCRIPTION
Run `cargo update` for compatible bumps and upgrade pulldown-cmark from 0.11 to 0.13.

pulldown-cmark 0.13 required a few source changes:

- `TagEnd::BlockQuote` is now a tuple variant carrying `Option<BlockQuoteKind>`.
- New `Tag` variants: `DefinitionList`, `DefinitionListTitle`, `DefinitionListDefinition`, `Superscript`, `Subscript`.
- New `LinkType::WikiLink` variant.

None of the new variants can be emitted here, since each requires an `Options` flag this plugin doesn't enable. The matches are kept exhaustive rather than using a wildcard so that future upgrades surface new variants at compile time, with the unreachable arms returning a `ParseError` like the other unimplemented link types.