### PR TITLE
test: add regression test for #165 (fixed by #188)

### DIFF
--- a/tests/specs/Issues/Issue0165.txt
+++ b/tests/specs/Issues/Issue0165.txt
@@ -1,0 +1,29 @@
+!! should keep a block quote in a nested list item !!
+- list item
+  - > sub-list item quote
+
+[expect]
+- list item
+  - > sub-list item quote
+
+!! should keep a lazy continuation line of a block quote in a nested list item !!
+- list item
+  - > sub-list item quote
+    second line
+
+[expect]
+- list item
+  - > sub-list item quote
+    > second line
+
+!! should keep a block quote followed by a paragraph in a nested list item !!
+- list item
+  - > sub-list item quote
+
+    more text
+
+[expect]
+- list item
+  - > sub-list item quote
+
+    more text


### PR DESCRIPTION
This is a test-only change. #165 no longer reproduces on `main`.

## Investigation

Reported input:

```md
- list item
  - > sub-list item quote
```

- Reproduces at `fdde241` (0.22.1, the latest published release) — output is `- sub-list item quote`, the `>` is dropped.
- Passes on `main`.
- Bisected to f39f43b ("fix: keep block quote marker when it doesn't start a line, and for empty block quotes", #188): fails at its parent e5d5170, passes at f39f43b. That fix is not in a release yet.

## About the coverage

`tests/specs/Issues/Issue0183.txt` was added by #188 itself, and its top-level `- > foo` case already exercises the same branch — every case here fails identically at e5d5170. So this file is documentary rather than new regression protection: it records that the literal input from #165 formats correctly. The lazy-continuation case is the only non-identity expectation, and `Issue0187.txt` only covers lazy continuation inside an outer block quote.

Happy to drop this if you'd rather not carry the redundancy — in that case #165 can just be closed as fixed by #188.

## Out of scope, noted while looking

`- [ ] > quote` formats to `- > [ ] quote`, which loses the task-list checkbox (a `[ ]` inside a block quote is not a task marker). This isn't a regression from #188 — before it, the same input produced `- [ ] quote`, dropping the block quote instead. The root cause is pulldown-cmark emitting the `TaskListMarker` event inside the block quote's paragraph, so it needs generator changes rather than a spec. Left out here so a spec doesn't enshrine the wrong output.