### PR TITLE
fix: do not trim a code span that's only whitespace

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -549,12 +549,13 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
 }
 
 fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
+  let trimmed_text = code.code.trim();
   // a code span that's only whitespace keeps its text because trimming
   // it would cause the code span to disappear entirely
-  let text = if code.code.trim().is_empty() {
+  let text = if trimmed_text.is_empty() {
     code.code.as_str()
   } else {
-    code.code.trim()
+    trimmed_text
   };
   let backtick_text = "`".repeat(get_backtick_count(text));
   let separator = if text.starts_with('`') || text.ends_with('`') {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -549,7 +549,13 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
 }
 
 fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
-  let text = code.code.trim();
+  // a code span that's only whitespace keeps its text because trimming
+  // it would cause the code span to disappear entirely
+  let text = if code.code.trim().is_empty() {
+    code.code.as_str()
+  } else {
+    code.code.trim()
+  };
   let backtick_text = "`".repeat(get_backtick_count(text));
   let separator = if text.starts_with('`') || text.ends_with('`') {
     " "

--- a/tests/specs/Issues/Issue0163.txt
+++ b/tests/specs/Issues/Issue0163.txt
@@ -1,0 +1,26 @@
+!! should not trim a code span that's only whitespace !!
+Optionally, a delimiter char may be provided. By default, the parser uses a delimiter char of `SPACE` (`U+0020`), literally ` `.
+
+Multiple spaces: `   `.
+
+[expect]
+Optionally, a delimiter char may be provided. By default, the parser uses a delimiter char of `SPACE` (`U+0020`), literally ` `.
+
+Multiple spaces: `   `.
+
+!! should not trim a code span that's only a newline !!
+Testing `
+` out.
+
+[expect]
+Testing ` ` out.
+
+!! should not trim a code span that's only whitespace in a table !!
+| a | b |
+| - | - |
+| ` ` | `  ` |
+
+[expect]
+| a   | b    |
+| --- | ---- |
+| ` ` | `  ` |


### PR DESCRIPTION
Closes #163

`gen_code` trimmed the code span text, so a span whose content is only whitespace (ex. `` ` ` ``) trimmed to nothing and printed as `` `` ``, silently changing the document's AST.

Now the text is kept as-is when it's entirely whitespace and trimmed as before otherwise. `gen_code_str` already handled the rest: a whitespace only span keeps its exact width and a newline only span renders as a single space, which is the same content per CommonMark.