### PR TITLE
fix: keep more link reference definitions

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -125,7 +125,7 @@ pub fn parse_cmark_ast(markdown_text: &str) -> Result<SourceFile, ParseError> {
     markdown_text,
     Parser::new_ext(markdown_text, options).into_offset_iter(),
   );
-  let mut last_event_range: Option<Range> = None;
+  let mut last_node_end: Option<usize> = None;
 
   while let Some(event) = iterator.next() {
     let current_range = iterator.get_last_range();
@@ -133,24 +133,17 @@ pub fn parse_cmark_ast(markdown_text: &str) -> Result<SourceFile, ParseError> {
     // do not parse for link references while inside a table
     if iterator.in_table_count() <= 1 {
       // `or(Some(0))` so the text before the first event is looked at too
-      if let Some(references) = parse_references(
-        last_event_range.as_ref().map(|r| r.end).or(Some(0)),
-        current_range.start,
-        &mut iterator,
-      )? {
+      if let Some(references) = parse_references(last_node_end.or(Some(0)), current_range.start, &mut iterator)? {
         children.push(references);
       }
     }
 
-    children.push(parse_event(event, &mut iterator)?);
-    last_event_range = Some(current_range);
+    let node = parse_event(event, &mut iterator)?;
+    last_node_end = Some(get_references_search_start(&node, current_range.end));
+    children.push(node);
   }
 
-  if let Some(references) = parse_references(
-    last_event_range.as_ref().map(|r| r.end).or(Some(0)),
-    markdown_text.len(),
-    &mut iterator,
-  )? {
+  if let Some(references) = parse_references(last_node_end.or(Some(0)), markdown_text.len(), &mut iterator)? {
     children.push(references);
   }
 
@@ -184,6 +177,17 @@ fn parse_references(
     }
   }
   Ok(None)
+}
+
+/// Gets the position to start searching for link reference definitions at
+/// after the provided node.
+fn get_references_search_start(node: &Node, event_end: usize) -> usize {
+  match node {
+    // cmark includes any link reference definitions that follow a list in the
+    // list's range, so search from where the list's last item ended
+    Node::List(list) => list.range.end,
+    _ => event_end,
+  }
 }
 
 fn parse_event(event: Event, iterator: &mut EventIterator) -> Result<Node, ParseError> {
@@ -316,7 +320,7 @@ fn parse_paragraph(iterator: &mut EventIterator) -> Result<Paragraph, ParseError
 fn parse_block_quote(iterator: &mut EventIterator) -> Result<BlockQuote, ParseError> {
   let start = iterator.start();
   let mut children = Vec::new();
-  let mut last_event_end: Option<usize> = None;
+  let mut last_node_end: Option<usize> = None;
 
   while let Some(event) = iterator.next() {
     if matches!(event, Event::End(TagEnd::BlockQuote(_))) {
@@ -326,18 +330,19 @@ fn parse_block_quote(iterator: &mut EventIterator) -> Result<BlockQuote, ParseEr
     // cmark doesn't raise events for link reference definitions, so look for
     // them in the text leading up to this event
     let current_range = iterator.get_last_range();
-    if let Some(references) = parse_references(last_event_end.or(Some(start)), current_range.start, iterator)? {
+    if let Some(references) = parse_references(last_node_end.or(Some(start)), current_range.start, iterator)? {
       children.push(references);
     }
 
-    children.push(parse_event(event, iterator)?);
-    last_event_end = Some(current_range.end);
+    let node = parse_event(event, iterator)?;
+    last_node_end = Some(get_references_search_start(&node, current_range.end));
+    children.push(node);
   }
 
   let range = iterator.get_range_for_start(start);
   // a block quote may consist of only link reference definitions, in which
   // case it has no children to search after
-  if let Some(references) = parse_references(last_event_end.or(Some(start)), range.end, iterator)? {
+  if let Some(references) = parse_references(last_node_end.or(Some(start)), range.end, iterator)? {
     children.push(references);
   }
 
@@ -633,8 +638,16 @@ fn parse_list(start_index: Option<u64>, iterator: &mut EventIterator) -> Result<
     }
   }
 
+  // cmark includes any link reference definitions that follow a list in the
+  // list's range, so end the list at its last item in order for them to be
+  // found in the text that follows it
+  let end = children
+    .last()
+    .map(|c| c.range().end)
+    .unwrap_or_else(|| iterator.get_last_range().end);
+
   Ok(List {
-    range: iterator.get_range_for_start(start),
+    range: Range { start, end },
     start_index,
     children,
   })
@@ -753,14 +766,14 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
   let mut children = Vec::new();
   let mut sub_lists = Vec::new();
 
-  let mut last_event_end: Option<usize> = None;
+  let mut last_node_end: Option<usize> = None;
   let marker = if let Some((Event::TaskListMarker(is_checked), _)) = iterator.peek() {
     let marker = TaskListMarker {
       range: iterator.get_last_range(),
       is_checked: *is_checked,
     };
     iterator.next();
-    last_event_end = Some(iterator.get_last_range().end);
+    last_node_end = Some(iterator.get_last_range().end);
     Some(marker)
   } else {
     None
@@ -774,8 +787,8 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
     // cmark doesn't raise events for link reference definitions, so look for
     // them in the text leading up to this event
     let current_range = iterator.get_last_range();
-    let references = match last_event_end {
-      Some(last_event_end) => parse_references(Some(last_event_end), current_range.start, iterator)?,
+    let references = match last_node_end {
+      Some(last_node_end) => parse_references(Some(last_node_end), current_range.start, iterator)?,
       // the text before the first event contains the list item's marker and
       // possibly a task list marker, so ignore it when it doesn't parse
       None => parse_item_start_references(start, current_range.start, iterator),
@@ -785,21 +798,23 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
       children.push(references);
     }
 
-    match event {
-      Event::Start(Tag::List(_)) => sub_lists.push(parse_event(event, iterator)?),
-      _ => {
-        children.append(&mut sub_lists); // only add to the sub_lists if it's the last children
-        children.push(parse_event(event, iterator)?)
-      }
-    }
+    let node = parse_event(event, iterator)?;
     // a node may consume multiple events (ex. adjacent text events), so take
     // whatever the iterator ended up on
-    last_event_end = Some(std::cmp::max(current_range.end, iterator.get_last_range().end));
+    let event_end = std::cmp::max(current_range.end, iterator.get_last_range().end);
+    last_node_end = Some(get_references_search_start(&node, event_end));
+    match node {
+      Node::List(_) => sub_lists.push(node),
+      _ => {
+        children.append(&mut sub_lists); // only add to the sub_lists if it's the last children
+        children.push(node)
+      }
+    }
   }
 
   let range = iterator.get_range_for_start(start);
 
-  let references_start = last_event_end
+  let references_start = last_node_end
     // an item may consist of only link reference definitions, in which case
     // it has no children, so start searching after the list item marker
     .or_else(|| get_item_marker_end(iterator.file_text, range.start));
@@ -827,6 +842,8 @@ fn parse_item_start_references(item_start: usize, end: usize, iterator: &mut Eve
 /// Gets the byte position directly after a list item's marker
 /// (ex. after the `-` in `- test` or after the `1.` in `1. test`).
 fn get_item_marker_end(file_text: &str, item_start: usize) -> Option<usize> {
+  // cmark's range for an item includes the indentation before its marker
+  let item_start = item_start + file_text[item_start..].find(|c| !matches!(c, ' ' | '\t'))?;
   let mut chars = file_text[item_start..].char_indices();
   let (_, first_char) = chars.next()?;
 

--- a/src/generation/cmark/parsing/parse_link_reference_definitions.rs
+++ b/src/generation/cmark/parsing/parse_link_reference_definitions.rs
@@ -37,6 +37,11 @@ fn parse_link_reference_definition(
   let name = parse_text_in_brackets(start_pos, char_scanner)?;
   char_scanner.assert_char(':')?;
   char_scanner.skip_spaces();
+  // the destination may be on the line after the label (ex. `[a]:\n/url`)
+  if matches!(char_scanner.peek(), Some((_, '\n'))) {
+    char_scanner.next();
+    skip_line_start(char_scanner);
+  }
   let final_text = parse_reference_link(start_pos, char_scanner)?;
   let (url, title) = parse_link_url_and_title(final_text.trim());
 
@@ -51,14 +56,37 @@ fn parse_link_reference_definition(
   })
 }
 
+/// Skips over the whitespace and any block quote markers a line starts with.
+fn skip_line_start(char_scanner: &mut CharScanner) {
+  char_scanner.skip_spaces();
+  while matches!(char_scanner.peek(), Some((_, '>'))) {
+    char_scanner.next();
+    char_scanner.skip_spaces();
+  }
+}
+
 fn parse_reference_link(start_pos: usize, char_scanner: &mut CharScanner) -> Result<String, ParseError> {
   let mut reference_link = String::new();
   let mut is_in_title = false;
+  let mut had_title = false;
   while let Some((_, c)) = char_scanner.next() {
     match c {
       // a title may span lines, so only the line ending that follows the
       // definition ends it
-      '\n' if !is_in_title => break,
+      '\n' if !is_in_title => {
+        // a title may also start on the line after the destination
+        if had_title || reference_link.trim().is_empty() {
+          break;
+        }
+        skip_line_start(char_scanner);
+        if !matches!(char_scanner.peek(), Some((_, '"'))) {
+          break;
+        }
+        while reference_link.ends_with(|c: char| c.is_whitespace()) {
+          reference_link.pop();
+        }
+        reference_link.push(' ');
+      }
       '\\' if is_in_title => {
         reference_link.push(c);
         // push the next char without checking it, since it's escaped
@@ -71,6 +99,7 @@ fn parse_reference_link(start_pos: usize, char_scanner: &mut CharScanner) -> Res
         // quote anywhere else is part of the destination (ex. `[a]: a"b`)
         if is_in_title {
           is_in_title = false;
+          had_title = true;
         } else if reference_link.chars().next_back().is_none_or(|c| c.is_whitespace()) {
           is_in_title = true;
         }
@@ -149,5 +178,51 @@ mod tests {
     assert_eq!(reference.range.end, 75);
     assert_eq!(reference.name, "other");
     assert_eq!(reference.link, "https://github.com");
+  }
+
+  #[test]
+  fn it_finds_link_reference_with_title_on_next_line() {
+    let result = parse_link_reference_definitions(0, "[reference]: https://dprint.dev\n\"Some title\"");
+    let references = result.ok().unwrap();
+    assert_eq!(references.len(), 1);
+    let reference = &references[0];
+    assert_eq!(reference.name, "reference");
+    // the trailing space is trimmed when generating
+    assert_eq!(reference.link.trim(), "https://dprint.dev");
+    assert_eq!(reference.title, Some("Some title".to_string()));
+  }
+
+  #[test]
+  fn it_finds_link_reference_with_link_on_next_line() {
+    let result = parse_link_reference_definitions(0, "[reference]:\nhttps://dprint.dev");
+    let references = result.ok().unwrap();
+    assert_eq!(references.len(), 1);
+    let reference = &references[0];
+    assert_eq!(reference.name, "reference");
+    assert_eq!(reference.link, "https://dprint.dev");
+    assert_eq!(reference.title, None);
+  }
+
+  #[test]
+  fn it_does_not_treat_the_next_definition_as_a_title() {
+    let result = parse_link_reference_definitions(0, "[a]: https://dprint.dev\n[b]: https://github.com");
+    let references = result.ok().unwrap();
+    assert_eq!(references.len(), 2);
+    assert_eq!(references[0].link, "https://dprint.dev");
+    assert_eq!(references[0].title, None);
+    assert_eq!(references[1].link, "https://github.com");
+    assert_eq!(references[1].title, None);
+  }
+
+  #[test]
+  fn it_finds_link_reference_with_title_on_next_line_in_block_quote() {
+    let result = parse_link_reference_definitions(0, "> [reference]: https://dprint.dev\n> \"Some title\"");
+    let references = result.ok().unwrap();
+    assert_eq!(references.len(), 1);
+    let reference = &references[0];
+    assert_eq!(reference.name, "reference");
+    // the trailing space is trimmed when generating
+    assert_eq!(reference.link.trim(), "https://dprint.dev");
+    assert_eq!(reference.title, Some("Some title".to_string()));
   }
 }

--- a/tests/specs/Links/LinkReferenceDefinitions.txt
+++ b/tests/specs/Links/LinkReferenceDefinitions.txt
@@ -1,0 +1,90 @@
+!! should keep a title that's on the line after the destination !!
+[a]: https://example.com
+"Title"
+
+[expect]
+[a]: https://example.com "Title"
+
+!! should keep a destination that's on the line after the label !!
+[a]:
+https://example.com
+
+[expect]
+[a]: https://example.com
+
+!! should keep a multi-line title that starts on the line after the destination !!
+[a]: https://example.com
+"Title
+that spans lines"
+
+[expect]
+[a]: https://example.com "Title
+that spans lines"
+
+!! should keep a title on the next line in a list item !!
+- Text
+
+  [a]: https://example.com
+  "Title"
+
+  - Sublist
+
+[expect]
+- Text
+
+  [a]: https://example.com "Title"
+
+  - Sublist
+
+!! should keep a title on the next line in a block quote !!
+> [a]: https://example.com
+> "Title"
+
+[expect]
+> [a]: https://example.com "Title"
+
+!! should not treat the next definition as a title !!
+[a]: https://example.com/a
+[b]: https://example.com/b
+
+[expect]
+[a]: https://example.com/a
+[b]: https://example.com/b
+
+!! should keep the definitions on the lines after a list !!
+- Item
+
+[a]: https://example.com/a
+[b]: https://example.com/b
+
+[expect]
+- Item
+
+[a]: https://example.com/a
+[b]: https://example.com/b
+
+!! should keep the definitions on the lines after a sublist !!
+- Item
+
+  - Sublist
+
+  [a]: https://example.com/a
+  [b]: https://example.com/b
+
+[expect]
+- Item
+
+  - Sublist
+
+  [a]: https://example.com/a
+  [b]: https://example.com/b
+
+!! should keep a definition in an indented list item !!
+  - [a]: https://example.com
+
+    Text [a]
+
+[expect]
+- [a]: https://example.com
+
+  Text [a]


### PR DESCRIPTION
Follow up to #210, from reviewing that change.

### A destination or title on the line after the label

CommonMark allows a line ending between the label, destination, and title, but the crude link reference definition parser stopped at the first line ending:

```md
[a]: https://example.com
"Title"
```

That errored out (`Unexpected token `"` while parsing link reference definition`) instead of formatting, and #210 widened where that error is hit, since text between a list item's nodes is now searched. These are now parsed and put on a single line: `[a]: https://example.com "Title"`.

### Definitions that follow a list

cmark stretches a list's range over the link reference definitions that immediately follow it, so any text search that started after the list skipped over the first one and it was deleted:

```md
- Item

[a]: https://example.com/a
[b]: https://example.com/b
```

...became:

```md
- Item

[b]: https://example.com/b
```

A list now ends where its last item does, so the definitions are found in the text that follows it.

### Definitions at the start of an indented list item

cmark's range for a list item includes the indentation before its marker, so `get_item_marker_end` bailed out and a definition at the start of an indented item was dropped.
