### PR TITLE
fix: do not use a backslash hard break after a callout header

### DIFF
--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -31,6 +31,8 @@ pub struct Context<'a> {
   is_in_list_count: u32,
   /// The indentation level each surrounding block quote started at, from outermost to innermost.
   block_quote_base_indents: Vec<u32>,
+  /// The start position of the first child of each surrounding block quote.
+  block_quote_content_starts: Vec<Option<usize>>,
   text_wrap_disabled_count: u32,
   pub format_code_block_text: Box<dyn for<'b> FnMut(&str, &'b str, u32) -> FormatResult + 'a>,
   pub ignore_regex: Regex,
@@ -55,6 +57,7 @@ impl<'a> Context<'a> {
       raw_indent_level: 0,
       is_in_list_count: 0,
       block_quote_base_indents: Vec::new(),
+      block_quote_content_starts: Vec::new(),
       text_wrap_disabled_count: 0,
       format_code_block_text: Box::new(format_code_block_text),
       ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
@@ -103,14 +106,21 @@ impl<'a> Context<'a> {
     self.memoized_rc_path_addresses.contains(&(path as *const _ as usize))
   }
 
-  /// Marks being within a block quote, providing the indentation level of every
-  /// surrounding block quote (from outermost to innermost) to the provided function.
-  pub fn mark_in_block_quotes<T>(&mut self, func: impl FnOnce(&mut Context, Vec<u32>) -> T) -> T {
+  /// Marks being within a block quote whose content starts at `content_start`,
+  /// providing the indentation level of every surrounding block quote (from
+  /// outermost to innermost) to the provided function.
+  pub fn mark_in_block_quotes<T>(
+    &mut self,
+    content_start: Option<usize>,
+    func: impl FnOnce(&mut Context, Vec<u32>) -> T,
+  ) -> T {
     let original_is_in_list_count = self.is_in_list_count;
     self.is_in_list_count = 0;
     self.block_quote_base_indents.push(self.indent_level);
+    self.block_quote_content_starts.push(content_start);
     let base_indents = self.block_quote_base_indents.clone();
     let items = func(self, base_indents);
+    self.block_quote_content_starts.pop();
     self.block_quote_base_indents.pop();
     self.is_in_list_count = original_is_in_list_count;
     items
@@ -129,6 +139,11 @@ impl<'a> Context<'a> {
 
   pub fn is_in_block_quote(&self) -> bool {
     !self.block_quote_base_indents.is_empty()
+  }
+
+  /// Whether the position is where the innermost block quote's content starts.
+  pub fn is_block_quote_content_start(&self, pos: usize) -> bool {
+    self.block_quote_content_starts.last().copied().flatten() == Some(pos)
   }
 
   /// Whether the position at `index` is preceded by a blank line, accounting for

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -148,16 +148,7 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               // Callout example:
               // > [!NOTE]
               // > Some note.
-              let is_callout = if context.is_in_block_quote() {
-                if let Node::Text(text) = last_node {
-                  is_callout_text(&text.text)
-                } else {
-                  false
-                }
-              } else {
-                false
-              };
-              if is_callout && !context.is_text_wrap_disabled() {
+              if is_callout_node(last_node, context) && !context.is_text_wrap_disabled() {
                 items.push_signal(Signal::NewLine); // force a newline
               } else if matches!(node, Node::Html(_)) {
                 items.push_signal(Signal::NewLine);
@@ -210,6 +201,17 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
           | Node::TableCell(_) => {}
         }
       }
+    }
+
+    // a hard break after a callout header (ex. `> [!NOTE]` with trailing
+    // spaces) would stop it from being recognized as a callout, so only newline
+    if matches!(node, Node::HardBreak(_))
+      && !context.is_text_wrap_disabled()
+      && last_node.map(|n| is_callout_node(n, context)).unwrap_or(false)
+    {
+      items.push_signal(Signal::NewLine);
+      last_node = Some(node);
+      continue;
     }
 
     items.extend(generate(node, context));
@@ -325,7 +327,8 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
 }
 
 fn gen_block_quote(block_quote: &BlockQuote, context: &mut Context) -> PrintItems {
-  context.mark_in_block_quotes(|context, base_indents| {
+  let content_start = block_quote.children.first().map(|child| child.range().start);
+  context.mark_in_block_quotes(content_start, |context, base_indents| {
     let mut items = PrintItems::new();
 
     // add a > for any string that is on the start of a line
@@ -668,9 +671,21 @@ fn gen_text(text: &Text, context: &mut Context) -> PrintItems {
   gen_str(&text.text, context)
 }
 
+/// Whether the node is a callout header (ex. `[!NOTE]`), which is only
+/// recognized as one when it's the very first thing in a block quote.
+fn is_callout_node(node: &Node, context: &Context) -> bool {
+  match node {
+    Node::Text(text) => context.is_block_quote_content_start(text.range.start) && is_callout_text(&text.text),
+    _ => false,
+  }
+}
+
 fn is_callout_text(text: &str) -> bool {
   // ex. [!NOTE]
-  text.starts_with("[!") && text.ends_with("]") && text[2..text.len() - 1].chars().all(|c| c.is_ascii_uppercase())
+  let Some(kind) = text.strip_prefix("[!").and_then(|text| text.strip_suffix("]")) else {
+    return false;
+  };
+  !kind.is_empty() && kind.chars().all(|c| c.is_ascii_uppercase())
 }
 
 fn gen_str(text: &str, context: &mut Context) -> PrintItems {

--- a/tests/specs/BlockQuotes/Callouts.txt
+++ b/tests/specs/BlockQuotes/Callouts.txt
@@ -30,3 +30,25 @@
 [expect]
 > [!NOTE]
 > _Some_ sort of note
+
+!! should format when has trailing hard break after callout !!
+> [!IMPORTANT]  
+> Crucial information necessary for users to succeed.
+
+[expect]
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+!! should format when hard break after callout with nothing else !!
+> [!IMPORTANT]  
+
+[expect]
+> [!IMPORTANT]
+
+!! should keep hard break when not a callout !!
+> Some text  
+> and more text
+
+[expect]
+> Some text\
+> and more text

--- a/tests/specs/BlockQuotes/Callouts_TextWrap_Never.txt
+++ b/tests/specs/BlockQuotes/Callouts_TextWrap_Never.txt
@@ -1,0 +1,16 @@
+~~ textWrap: never ~~
+!! should format !!
+> [!NOTE]
+> Some sort of note
+
+[expect]
+> [!NOTE]
+> Some sort of note
+
+!! should format when has trailing hard break after callout !!
+> [!IMPORTANT]  
+> Crucial information necessary for users to succeed.
+
+[expect]
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.

--- a/tests/specs/Issues/Issue0148.txt
+++ b/tests/specs/Issues/Issue0148.txt
@@ -1,0 +1,53 @@
+!! should not use a backslash hard break after a callout header !!
+> [!IMPORTANT]  
+> Crucial information necessary for users to succeed.
+
+[expect]
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+!! should not use a backslash hard break after a nested callout header !!
+> > [!NOTE]  
+> > Some sort of note
+
+[expect]
+>> [!NOTE]
+>> Some sort of note
+
+!! should keep hard break when callout syntax is not at the start of the block quote !!
+> Some text
+> [!NOTE]  
+> more text
+
+[expect]
+> Some text
+> [!NOTE]\
+> more text
+
+!! should keep hard break when callout syntax starts a later paragraph !!
+> First para
+>
+> [!NOTE]  
+> more text
+
+[expect]
+> First para
+>
+> [!NOTE]\
+> more text
+
+!! should keep hard break when callout syntax is emphasized !!
+> _[!NOTE]  
+> more text_
+
+[expect]
+> _[!NOTE]\
+> more text_
+
+!! should keep hard break when the callout kind is empty !!
+> [!]  
+> more text
+
+[expect]
+> [!]\
+> more text


### PR DESCRIPTION
Closes #148

A callout header line ending in two or more spaces is a markdown hard break, which was formatted to the backslash form:

```md
> [!IMPORTANT]  
> Crucial information necessary for users to succeed.
```

...became `> [!IMPORTANT]\`, and GitHub then no longer recognizes the block quote as an alert. Now only a newline is emitted, so the output is:

```md
> [!IMPORTANT]
> Crucial information necessary for users to succeed.
```

While in there, callout detection was tightened to require the callout text to start the block quote's content (which is what GitHub requires), so a genuine hard break isn't dropped when `[!NOTE]` shows up mid-paragraph, in a later paragraph, or wrapped in emphasis/a link. `[!]` is also no longer treated as a callout.
