### PR TITLE
fix: add cpp tag to .cpp extension mapping

### DIFF
--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -118,6 +118,7 @@ impl SyncPluginHandler<Configuration> for MarkdownPluginHandler {
         "json" => Some("json"),
         "jsonc" => Some("jsonc"),
         "rust" | "rs" => Some("rs"),
+        "cpp" => Some("cpp"),
         "csharp" | "cs" => Some("cs"),
         "visualbasic" | "vb" => Some("vb"),
         "html" => Some("html"),


### PR DESCRIPTION
From https://github.com/dprint/dprint-plugin-markdown/issues/145