### PR TITLE
fix: maintain a line break within a link's text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,15 +52,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.10",
- "windows-sys 0.45.0",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -120,7 +119,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -135,11 +134,10 @@ dependencies = [
 
 [[package]]
 name = "dprint-development"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cc5c05c28cb1bfc6c4a22174e634c0096a99288b2844518b7e3da77337b9ff"
+checksum = "90b3b095f94733262261bfeb860a6550e1d656dd108240c43004bd0f1b419837"
 dependencies = [
- "anyhow",
  "console",
  "file_test_runner",
  "serde_json",
@@ -158,7 +156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "unicode-width 0.1.10",
+ "unicode-width",
 ]
 
 [[package]]
@@ -169,9 +167,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -236,12 +234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,7 +281,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -303,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -515,12 +507,6 @@ checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -541,13 +527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -555,22 +538,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.42.2"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -579,21 +556,15 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -603,21 +574,9 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -633,21 +592,9 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -657,21 +604,9 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -829,20 +829,8 @@ fn gen_footnote_definition(footnote_definition: &FootnoteDefinition, context: &m
 fn gen_inline_link(link: &InlineLink, context: &mut Context) -> PrintItems {
   context.with_no_text_wrap(|context| {
     let mut items = PrintItems::new();
-    let generated_children = gen_nodes(&link.children, context);
     items.push_sc(sc!("["));
-
-    // force the text to be on a single line in some scenarios
-    let (generated_children, generated_children_clone) = clone_items(generated_children);
-    let single_line_text = get_items_text(ir_helpers::with_no_new_lines(generated_children_clone));
-    if single_line_text.len() < (context.configuration.line_width / 2) as usize {
-      // printing the children back out to text flattens any tab signal
-      // they had, so they need breaking up again
-      items.extend(gen_text_with_tabs(single_line_text));
-    } else {
-      items.extend(generated_children);
-    }
-
+    items.extend(gen_nodes(&link.children, context));
     items.push_sc(sc!("]"));
     items.push_sc(sc!("("));
     // the parser resolves the escapes in an inline link's url, so render it
@@ -1570,22 +1558,24 @@ fn space() -> PrintItems {
 }
 
 fn get_newline_wrapping_based_on_config(context: &Context) -> PrintItems {
+  if context.is_text_wrap_disabled() {
+    // ex. within a link, whose text is moved onto a single line when text is
+    // being wrapped, but keeps the line breaks it has when text is maintained
+    return match context.configuration.text_wrap {
+      TextWrap::Always | TextWrap::Never => space(),
+      TextWrap::Maintain => if_true_or(
+        "newLineOrSpaceIfNewlinesDisabled",
+        condition_resolvers::is_forcing_no_newlines(),
+        space(),
+        Signal::NewLine.into(),
+      )
+      .into(),
+    };
+  }
   match context.configuration.text_wrap {
     TextWrap::Always => Signal::SpaceOrNewLine.into(),
     TextWrap::Never => space(),
-    TextWrap::Maintain => {
-      if context.is_text_wrap_disabled() {
-        if_true_or(
-          "newLineOrSpaceIfNewlinesDisabled",
-          condition_resolvers::is_forcing_no_newlines(),
-          space(),
-          Signal::NewLine.into(),
-        )
-        .into()
-      } else {
-        Signal::NewLine.into()
-      }
-    }
+    TextWrap::Maintain => Signal::NewLine.into(),
   }
 }
 

--- a/tests/specs/Images/Images_All.txt
+++ b/tests/specs/Images/Images_All.txt
@@ -163,14 +163,15 @@ reference]
 
 [some text]: https://dprint.dev/image.png
 
-!! should move alt text onto a single line within a link !!
+!! should keep a line break in alt text within a link !!
 [![some
 text]](https://dprint.dev)
 
 [some text]: https://dprint.dev/image.png
 
 [expect]
-[![some text]](https://dprint.dev)
+[![some
+text]](https://dprint.dev)
 
 [some text]: https://dprint.dev/image.png
 

--- a/tests/specs/Issues/Issue0149.txt
+++ b/tests/specs/Issues/Issue0149.txt
@@ -33,3 +33,27 @@ out](/test) testing
 
 [expect]
 # Testing [this out](/test) testing
+
+!! should maintain a line break within a link's text in a footnote definition !!
+Text[^1]
+
+[^1]: Testing [this
+    out](/test) testing
+
+[expect]
+Text[^1]
+
+[^1]: Testing [this
+    out](/test) testing
+
+!! should maintain a line break within a link's text in a definition list !!
+Term
+
+: Testing [this
+  out](/test) testing
+
+[expect]
+Term
+
+: Testing [this
+  out](/test) testing

--- a/tests/specs/Issues/Issue0149.txt
+++ b/tests/specs/Issues/Issue0149.txt
@@ -1,0 +1,35 @@
+!! should maintain a line break within a link's text !!
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, [quis
+nostrud](https://example.com) exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat.
+
+[expect]
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, [quis
+nostrud](https://example.com) exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat.
+
+!! should maintain a line break within a link's text in a list item !!
+- Testing [this
+  out](/test) testing
+
+[expect]
+- Testing [this
+  out](/test) testing
+
+!! should maintain a line break within a link's text in a block quote !!
+> Testing [this
+> out](/test) testing
+
+[expect]
+> Testing [this
+> out](/test) testing
+
+!! should move a link's text onto a single line within a heading !!
+Testing [this
+out](/test) testing
+===
+
+[expect]
+# Testing [this out](/test) testing

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -71,6 +71,28 @@ out](/test) test
 Test [this
 out](/test) test
 
+!! should keep a hard break in a link's text !!
+[this  
+out](/test)
+
+[this\
+out](/test)
+
+[expect]
+[this\
+out](/test)
+
+[this\
+out](/test)
+
+!! should keep a line break in a code span within a link's text !!
+[`this
+out`](/test)
+
+[expect]
+[`this
+out`](/test)
+
 !! handle when file only has link reference directive !!
 [Some reference]: https://github.com
 

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -63,12 +63,13 @@ Testing <https://google.com> this.
 [expect]
 [![CI](image.svg)](https://github.com)
 
-!! should handle going multi-line to single line within a link !!
+!! should keep a line break in a link's text !!
 Test [this
 out](/test) test
 
 [expect]
-Test [this out](/test) test
+Test [this
+out](/test) test
 
 !! handle when file only has link reference directive !!
 [Some reference]: https://github.com

--- a/tests/specs/Links/Links_TextWrap_Always.txt
+++ b/tests/specs/Links/Links_TextWrap_Always.txt
@@ -31,3 +31,28 @@ Testing this out with some text to
 ensure wrapping still works after.
 
 [Some reference with text that exceeds line width]: https://github.com
+
+!! should move a link's text onto a single line !!
+Test [this
+out](/test) test
+
+[expect]
+Test [this out](/test) test
+
+!! should move alt text onto a single line within a link !!
+[![some
+text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png
+
+[expect]
+[![some text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png
+
+!! should move a title onto a single line within a link !!
+[testing](https://dprint.dev "some
+title")
+
+[expect]
+[testing](https://dprint.dev "some title")

--- a/tests/specs/Links/Links_TextWrap_Never.txt
+++ b/tests/specs/Links/Links_TextWrap_Never.txt
@@ -1,0 +1,25 @@
+~~ lineWidth: 40, textWrap: never ~~
+!! should move a link's text onto a single line !!
+Test [this
+out](/test) test
+
+[expect]
+Test [this out](/test) test
+
+!! should move alt text onto a single line within a link !!
+[![some
+text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png
+
+[expect]
+[![some text]](https://dprint.dev)
+
+[some text]: https://dprint.dev/image.png
+
+!! should move a title onto a single line within a link !!
+[testing](https://dprint.dev "some
+title")
+
+[expect]
+[testing](https://dprint.dev "some title")

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -56,3 +56,13 @@ This Header
 spans
 multiple lines
 ==============
+
+!! should keep a line break within a link's text and size the underline to the longest line !!
+Testing [this
+out](/test) testing
+===
+
+[expect]
+Testing [this
+out](/test) testing
+===================


### PR DESCRIPTION
Closes #149.

With the default `"textWrap": "maintain"`, a line break within an inline link's text was deleted, which made the line it was on much longer:

```md
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, [quis nostrud](https://example.com) exercitation ullamco laboris nisi ut aliquip ex ea
commodo consequat.
```

`gen_inline_link` flattened the link's text onto a single line whenever the flattened text was under half the line width, no matter what `textWrap` was set to. That heuristic is gone, and instead `get_newline_wrapping_based_on_config` returns a plain space for `always` and `never` when wrapping is disabled — which is how a link keeps its text on a single line for #53 — while `maintain` keeps the line break, apart from where newlines are forced off (ex. within an ATX heading).

Removing the flattening also stops a few things from being corrupted within a link's text, since it re-printed the children with no line ending at all:

| input | before | after |
| --- | --- | --- |
| `[this  ⏎out](/test)` | `[this\out](/test)` | `[this\` ⏎ `out](/test)` |
| `[this\⏎out](/test)` | `[this\out](/test)` | `[this\` ⏎ `out](/test)` |
| ``[`this⏎out`](/test)`` | ``[`thisout`](/test)`` | ``[`this`` ⏎ ``out`](/test)`` |

`[this\out]` isn't a hard break, so those changed what the link rendered as.

Specs cover the line break in a paragraph, list item, block quote, footnote definition, definition list and setext heading (whose underline is sized to the longest line), that it's still moved onto a single line within an ATX heading and for `always` and `never`, and the corruptions above.

`Cargo.lock` was out of sync with `Cargo.toml` since #207, so this updates it too.
