### PR TITLE
fix: turn a hard break into a space where it can't be one

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1373,11 +1373,24 @@ fn gen_horizontal_rule(_: &HorizontalRule, _: &mut Context) -> PrintItems {
   "---".into()
 }
 
+/// Generates a hard break, which has no representation on a single line, so it
+/// becomes a space where newlines are being forced off (ex. within an ATX
+/// heading). Otherwise the backslash it leaves behind would escape the
+/// character that followed it.
 fn gen_hard_break(_: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-  items.push_sc(sc!("\\"));
-  items.push_signal(Signal::NewLine);
-  items
+  let hard_break = {
+    let mut items = PrintItems::new();
+    items.push_sc(sc!("\\"));
+    items.push_signal(Signal::NewLine);
+    items
+  };
+  if_true_or(
+    "hardBreakOrSpaceIfNewlinesDisabled",
+    condition_resolvers::is_forcing_no_newlines(),
+    space(),
+    hard_break,
+  )
+  .into()
 }
 
 fn gen_table(table: &Table, context: &mut Context) -> PrintItems {

--- a/tests/specs/General/HardBreaks_All.txt
+++ b/tests/specs/General/HardBreaks_All.txt
@@ -5,3 +5,33 @@ asdf
 [expect]
 test\
 asdf
+
+!! should handle a hard break with trailing spaces !!
+test  
+asdf
+
+[expect]
+test\
+asdf
+
+!! should turn a hard break into a space within a heading !!
+Testing a\
+b here
+===
+
+Testing c  
+d here
+---
+
+[expect]
+# Testing a b here
+
+## Testing c d here
+
+!! should turn a hard break into a space within a link in a heading !!
+[this\
+out](/test)
+===
+
+[expect]
+# [this out](/test)

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -66,3 +66,13 @@ out](/test) testing
 Testing [this
 out](/test) testing
 ===================
+
+!! should keep a hard break and size the underline to the longest line !!
+Testing a\
+b here
+===
+
+[expect]
+Testing a\
+b here
+==========


### PR DESCRIPTION
Follow-up to #215, where this turned up while reviewing that change.

A hard break within an ATX heading was dropped, leaving behind the backslash that had rendered it:

```md
Testing a\
b here
===
```

```md
# Testing a\b here
```

`\b` isn't a valid escape, so the backslash stayed literal and the heading rendered as `Testing a\b here` rather than `Testing a`, a line break, `b here`. The same applied to a hard break within a link in a heading (`# [this\out](/test)`) and to the trailing-two-spaces form of a hard break.

`gen_hard_break` pushed a bare `Signal::NewLine`, which the printer drops when newlines are being forced off — unlike `Signal::SpaceOrNewLine`, which still renders a space. So the newline disappeared while the backslash that only made sense in front of it stayed. Now a hard break becomes a space where newlines are forced off, which is what a soft break already did through the `is_forcing_no_newlines` conditional in `get_newline_wrapping_based_on_config`.

A setext heading doesn't force newlines off, so it keeps the hard break, and `measure_longest_line_width` sizes its underline to the longest line — a spec covers that.
