### PR TITLE
fix: maintain the indentation of an html block's first line

### DIFF
--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -40,7 +40,12 @@ impl<'a> EventIterator<'a> {
       self.last_range = range;
       self.next = self.move_iterator_next();
 
-      if !self.allow_empty_text_events {
+      // pulldown-cmark provides the indentation of an html block's first line
+      // as a synthesized text event with an empty range, so don't discard it
+      // here because parse_html_block uses it to maintain the indentation
+      let is_html_block_start = matches!(event, Event::Start(Tag::HtmlBlock));
+
+      if !self.allow_empty_text_events && !is_html_block_start {
         // skip over any empty text or html events
         while let Some((Event::Text(_), range)) | Some((Event::Html(_), range)) = &self.next {
           if trim_document_whitespace(&self.file_text[range.start..range.end]).is_empty() {
@@ -552,14 +557,23 @@ fn parse_inline_math(_text: CowStr, iterator: &mut EventIterator) -> Result<Inli
 }
 
 fn parse_html_block(iterator: &mut EventIterator) -> Result<Html, ParseError> {
-  let start = iterator.start();
+  let mut start = iterator.start();
   let original_allow_empty_text_events = iterator.allow_empty_text_events;
   iterator.allow_empty_text_events = true;
 
+  let mut is_first_event = true;
   while let Some(event) = iterator.next() {
-    if let Event::End(TagEnd::HtmlBlock) = event {
-      break;
+    match event {
+      Event::End(TagEnd::HtmlBlock) => break,
+      // pulldown-cmark excludes the indentation of an html block's first line
+      // from the ranges, providing it as a synthesized text event instead, so
+      // include it in the range in order to maintain the indentation
+      Event::Text(text) if is_first_event => {
+        start -= trailing_spaces_len(iterator.file_text, start, text.len());
+      }
+      _ => {}
     }
+    is_first_event = false;
   }
 
   iterator.allow_empty_text_events = original_allow_empty_text_events;
@@ -571,6 +585,19 @@ fn parse_html_block(iterator: &mut EventIterator) -> Result<Html, ParseError> {
       end: start + iterator.file_text[range].trim_end().len(),
     },
   })
+}
+
+/// Gets the length of the spaces found before the provided index,
+/// searching backwards up to a maximum length. Only spaces are
+/// handled because the maximum length is a column count, which won't
+/// line up with the byte count when tabs are involved.
+fn trailing_spaces_len(file_text: &str, end: usize, max_len: usize) -> usize {
+  let bytes = file_text.as_bytes();
+  let mut len = 0;
+  while len < max_len && len < end && bytes[end - len - 1] == b' ' {
+    len += 1;
+  }
+  len
 }
 
 fn parse_footnote_reference(name: CowStr, iterator: &mut EventIterator) -> Result<FootnoteReference, ParseError> {

--- a/src/generation/cmark/parse_cmark_ast.rs
+++ b/src/generation/cmark/parse_cmark_ast.rs
@@ -40,12 +40,10 @@ impl<'a> EventIterator<'a> {
       self.last_range = range;
       self.next = self.move_iterator_next();
 
-      // pulldown-cmark provides the indentation of an html block's first line
-      // as a synthesized text event with an empty range, so don't discard it
-      // here because parse_html_block uses it to maintain the indentation
-      let is_html_block_start = matches!(event, Event::Start(Tag::HtmlBlock));
-
-      if !self.allow_empty_text_events && !is_html_block_start {
+      // note: pulldown-cmark provides the indentation of an html block's first
+      // line as a synthesized text event with an empty range, so don't discard
+      // it here because parse_html_block uses it to maintain the indentation
+      if !self.allow_empty_text_events && !matches!(event, Event::Start(Tag::HtmlBlock)) {
         // skip over any empty text or html events
         while let Some((Event::Text(_), range)) | Some((Event::Html(_), range)) = &self.next {
           if trim_document_whitespace(&self.file_text[range.start..range.end]).is_empty() {
@@ -618,6 +616,8 @@ fn parse_footnote_definition(name: CowStr, iterator: &mut EventIterator) -> Resu
     }
   }
 
+  remove_indent_beside_marker(&mut children, iterator.file_text);
+
   Ok(FootnoteDefinition {
     range: iterator.get_range_for_start(start),
     name: String::from(name.as_ref()),
@@ -887,6 +887,8 @@ fn parse_item(iterator: &mut EventIterator) -> Result<Item, ParseError> {
     children.push(references);
   }
 
+  remove_indent_beside_marker(&mut children, iterator.file_text);
+
   Ok(Item {
     range,
     marker,
@@ -1041,7 +1043,19 @@ fn parse_definition_list_definition(iterator: &mut EventIterator) -> Result<Defi
     children.push(references);
   }
 
+  remove_indent_beside_marker(&mut children, iterator.file_text);
+
   Ok(DefinitionListDefinition { range, children })
+}
+
+/// A container's first child is generated beside its marker (ex. `- ` or `: `),
+/// where the indentation an html block keeps for its first line stops being
+/// indentation, so discard it in that case.
+fn remove_indent_beside_marker(children: &mut [Node], file_text: &str) {
+  if let Some(Node::Html(html)) = children.first_mut() {
+    let text = &file_text[html.range.start..html.range.end];
+    html.range.start += text.len() - text.trim_start_matches(' ').len();
+  }
 }
 
 /// Gets the byte position directly after a definition's `:` marker, which may

--- a/tests/specs/Issues/Issue0124.txt
+++ b/tests/specs/Issues/Issue0124.txt
@@ -1,0 +1,49 @@
+!! should maintain the indentation of an html block's first line !!
+<table>
+  <tr>
+  <td></td>
+
+  </tr>
+</table>
+
+[expect]
+<table>
+  <tr>
+  <td></td>
+
+  </tr>
+</table>
+
+!! should maintain the indentation in a list !!
+- Test
+
+    <div>
+    </div>
+
+[expect]
+- Test
+
+    <div>
+    </div>
+
+!! should maintain the indentation in a block quote !!
+> <div>
+>
+>   </div>
+
+[expect]
+> <div>
+>
+>   </div>
+
+!! should not include a list marker in the html !!
+- <div>
+
+[expect]
+- <div>
+
+!! should maintain up to three spaces of indentation !!
+   <div>
+
+[expect]
+   <div>

--- a/tests/specs/Issues/Issue0124.txt
+++ b/tests/specs/Issues/Issue0124.txt
@@ -47,3 +47,48 @@
 
 [expect]
    <div>
+
+!! should discard the indentation when beside a marker !!
+-
+    <div>
+      Test
+    </div>
+
+[expect]
+- <div>
+      Test
+    </div>
+
+!! should maintain the indentation in a footnote definition !!
+[^1]: Test
+
+      <div>
+      </div>
+
+Test[^1]
+
+[expect]
+[^1]: Test
+
+      <div>
+      </div>
+
+Test[^1]
+
+!! should not restore a tab of indentation !!
+- Test
+
+	<div>
+
+[expect]
+- Test
+
+  <div>
+
+!! should maintain the indentation of an indented ignore comment !!
+  <!-- dprint-ignore -->
+  <div>   </div>
+
+[expect]
+  <!-- dprint-ignore -->
+  <div>   </div>


### PR DESCRIPTION
Closes #124

A blank line in the middle of html splits it into two html blocks:

```md
<table>
  <tr>
  <td></td>

  </tr>
</table>
```

The indentation of the second block's first line was being discarded.

pulldown-cmark excludes the indentation of an html block's first line
from the event ranges, providing it as a synthesized text event with an
empty range instead. That event was being discarded along with the other
empty events, so the indentation never made it into the block's range.

Only spaces are restored, because the synthesized text is a column count
that doesn't line up with the byte count when tabs are involved (a tab
indented block formats the same as before).

Additionally, the first child of a list item, definition, or footnote
definition is generated beside the marker, where the indentation stops
being indentation, so it's discarded in that case in order to keep the
output stable.
