### PR TITLE
fix: use an atx heading where a setext heading would be empty

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -285,26 +285,39 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
 }
 
 fn gen_heading(heading: &Heading, context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-
+  // setext headings only apply to level 1 and level 2.
   if heading.level < 3 && context.configuration.heading_kind == HeadingKind::Setext {
-    // setext headings only apply to level 1 and level 2.
-    let heading_children = gen_nodes(&heading.children, context);
-    let (heading_children, cloned_children) = clone_items(heading_children);
-    items.extend(heading_children);
-    items.push_item(PrintItem::Signal(Signal::NewLine));
+    let children = gen_nodes(&heading.children, context);
+    let (children, cloned_children) = clone_items(children);
 
     // render the heading text with the actual line width so wrapping is
     // applied, then measure the longest line for the underline width.
     let underline_width = measure_longest_line_width(cloned_children, context.configuration.line_width);
-    let underline_char = if heading.level == 1 { "=" } else { "-" };
-    items.push_string(underline_char.repeat(underline_width));
-  } else {
-    // atx headings apply to all levels.
-    items.push_string(format!("{} ", "#".repeat(heading.level as usize)));
-    items.extend(with_no_new_lines(gen_nodes(&heading.children, context)));
+
+    // an underline with no text above it isn't a heading at all, so an
+    // empty heading can only be written as atx
+    if underline_width > 0 {
+      let mut items = PrintItems::new();
+      items.extend(children);
+      items.push_signal(Signal::NewLine);
+      let underline_char = if heading.level == 1 { "=" } else { "-" };
+      items.push_string(underline_char.repeat(underline_width));
+      return items;
+    }
+
+    return gen_atx_heading(heading.level, children);
   }
 
+  // atx headings apply to all levels.
+  gen_atx_heading(heading.level, gen_nodes(&heading.children, context))
+}
+
+fn gen_atx_heading(level: u32, children: PrintItems) -> PrintItems {
+  let mut items = PrintItems::new();
+  items.push_string("#".repeat(level as usize));
+  // an empty heading is just the number signs, so don't leave a trailing space
+  items.push_signal(Signal::SpaceIfNotTrailing);
+  items.extend(with_no_new_lines(children));
   items
 }
 

--- a/tests/specs/headers/Headers_All.txt
+++ b/tests/specs/headers/Headers_All.txt
@@ -50,3 +50,25 @@ places.
 
 [expect]
 # Here is a test
+
+!! should not leave a trailing space for an empty heading !!
+#
+
+##
+
+######
+
+> #
+
+- #
+
+[expect]
+#
+
+##
+
+######
+
+> #
+
+- #

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -76,3 +76,73 @@ b here
 Testing a\
 b here
 ==========
+
+!! should use an atx heading when the heading is empty !!
+#
+
+##
+
+# a
+
+#
+
+# b
+
+[expect]
+#
+
+##
+
+a
+=
+
+#
+
+b
+=
+
+!! should use an atx heading for an empty heading in a container !!
+> #
+
+- #
+
+> > #
+
+[^1]: #
+
+term
+
+: #
+
+[expect]
+> #
+
+- #
+
+>> #
+
+[^1]: #
+
+term
+
+: #
+
+!! should use an atx heading when the heading has no visible width !!
+#  
+
+# ​
+
+[expect]
+#  
+
+# ​
+
+!! should not leave a trailing space for an empty level 3 or higher heading !!
+###
+
+######
+
+[expect]
+###
+
+######


### PR DESCRIPTION
With `headingKind: setext`, an empty level 1 or 2 heading was written as a bare underline with no text above it — which isn't a heading at all. The heading was lost on the next format:

| input | formatted | formatted again |
| --- | --- | --- |
| `#` | *(blank lines)* | *(empty file)* |
| `- #` | `-`<br>`␠␠` | `-` |
| `> #` | `>`<br>`>␠` | `>` |

`gen_heading` now measures the underline width before committing to setext, and falls back to an atx heading when there's nothing to underline. That also covers headings whose content has no visible width (ex. a non-breaking space or a zero-width space), which were losing their heading semantics the same way.

While adding specs for this it became apparent that an empty atx heading emits a trailing space (`"# "`), so `gen_atx_heading` now pushes `Signal::SpaceIfNotTrailing` rather than folding the space into the `#` prefix string. An empty heading formats to plain `#`.

### Verification

Beyond the new specs, I diffed output against the previous commit over 861 documents (every spec case in the repo split into its own document, plus 142 heading-focused cases covering block quotes up to 3 deep, lists, nested lists, list-in-quote, footnote definitions, definition lists, tables, and `dprint-ignore`) × 36 configs — `lineWidth` × `headingKind` × `textWrap` × `listIndentKind`:

- 0 stable → unstable regressions
- 1242 unstable → stable
- Every changed line is a *removed* trailing space on a line of container markers plus hashes; no line with real heading content changed. Previously 34 distinct trailing-whitespace line shapes were emitted across the corpus, now 0.

Unrelated pre-existing instabilities I confirmed are unchanged by this (each identical on the base commit, worth separate issues): a setext heading whose only content is an HTML comment (`# <!-- c -->`); and a panic on `unreachable!()` in `generate` for a setext heading as the first child of a task list item.
