### PR TITLE
fix: don't count a double space hard break's spaces toward the line width

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1841,11 +1841,18 @@ fn gen_horizontal_rule(_: &HorizontalRule, position: NodePosition) -> PrintItems
 /// heading). Otherwise the marker it leaves behind would either escape the
 /// character that followed it or be collapsed as extra whitespace.
 fn gen_hard_break(context: &mut Context) -> PrintItems {
+  /// The two spaces a double space hard break leaves behind, measured as zero
+  /// columns because trailing whitespace isn't visible.
+  const DOUBLE_SPACE: StringContainer = StringContainer::proc_macro_new_with_char_count("  ", 0);
+
   let hard_break = {
     let mut items = PrintItems::new();
     match context.configuration.hard_break_kind {
       HardBreakKind::Backslash => items.push_sc(sc!("\\")),
-      HardBreakKind::DoubleSpace => items.push_sc(sc!("  ")),
+      // the two spaces sit at the end of the line, where they take no visible
+      // width, so they're written as zero columns to keep them out of the
+      // decision of where the text before them wraps
+      HardBreakKind::DoubleSpace => items.push_sc(&DOUBLE_SPACE),
     }
     items.push_signal(Signal::NewLine);
     items

--- a/tests/specs/General/HardBreaks_DoubleSpace_TextWrap_Always.txt
+++ b/tests/specs/General/HardBreaks_DoubleSpace_TextWrap_Always.txt
@@ -8,3 +8,11 @@ this is some text
 that will wrap  
 and this is more
 text that will wrap
+
+!! should not count the trailing spaces toward the line width !!
+aaaa bbbb cccc dddd\
+next line here
+
+[expect]
+aaaa bbbb cccc dddd  
+next line here

--- a/tests/specs/General/HardBreaks_TextWrap_Always.txt
+++ b/tests/specs/General/HardBreaks_TextWrap_Always.txt
@@ -1,0 +1,8 @@
+~~ textWrap: always, lineWidth: 20 ~~
+!! should wrap at the same place as a double space hard break !!
+aaaa bbbb cccc dddd\
+next line here
+
+[expect]
+aaaa bbbb cccc dddd\
+next line here


### PR DESCRIPTION
Closes #223.

The two spaces `hardBreakKind: doubleSpace` writes are trailing whitespace — they take no visible width — but they were measured as 2 columns, so the same text wrapped earlier than it does with `hardBreakKind: backslash`.

At `{ "textWrap": "always", "lineWidth": 20 }`:

```md
aaaa bbbb cccc dddd\
next line here
```

| | before | after |
| --- | --- | --- |
| `backslash` | `aaaa bbbb cccc dddd\` | unchanged |
| `doubleSpace` | `aaaa bbbb cccc` / `dddd␠␠` | `aaaa bbbb cccc dddd␠␠` |

The two kinds now wrap in the same place, which is the point of the issue.

`measure_longest_line_width` already applies this reasoning — it trims trailing whitespace before measuring, which is why a setext heading's underline is already sized correctly when the line ends in a hard break. This extends the same rule to the printer's own line-width accounting, by giving the two spaces a `char_count` of 0.

Specs added for both hard break kinds at the same width, so the parity is asserted rather than implied.

**Worth knowing:** an output line can now be 2 raw characters longer than `lineWidth`. Tools that count raw line length rather than visible width (markdownlint MD013, for one) will see 21 where they saw 19.