### PR TITLE
fix: don't turn a line break between CJK characters into a space

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -7,6 +7,8 @@ pub trait NodeSurroundings {
   fn has_preceding_whitespace(&self, file_text: &str) -> bool;
   fn starts_with_punctuation(&self, file_text: &str) -> bool;
   fn ends_with_punctuation(&self, file_text: &str) -> bool;
+  fn starts_with_unspaced_script(&self, file_text: &str) -> bool;
+  fn ends_with_unspaced_script(&self, file_text: &str) -> bool;
 }
 
 impl<T: Ranged> NodeSurroundings for T {
@@ -28,6 +30,18 @@ impl<T: Ranged> NodeSurroundings for T {
 
   fn ends_with_punctuation(&self, file_text: &str) -> bool {
     matches!(self.span().text(file_text).chars().last(), Some(c) if c.is_ascii_punctuation())
+  }
+
+  /// Whether the node begins with a character of a script written without
+  /// spaces between its words.
+  fn starts_with_unspaced_script(&self, file_text: &str) -> bool {
+    matches!(self.span().text(file_text).chars().next(), Some(c) if crate::generation::utils::is_unspaced_script(c))
+  }
+
+  /// Whether the node ends with a character of a script written without spaces
+  /// between its words.
+  fn ends_with_unspaced_script(&self, file_text: &str) -> bool {
+    matches!(self.span().text(file_text).chars().last(), Some(c) if crate::generation::utils::is_unspaced_script(c))
   }
 }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -152,6 +152,10 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
                 items.push_space();
               } else if matches!(node, Node::Html(_)) {
                 items.push_signal(Signal::NewLine);
+              } else if last_node.ends_with_unspaced_script(context.file_text)
+                && node.starts_with_unspaced_script(context.file_text)
+              {
+                items.extend(get_unspaced_script_newline_wrapping(context));
               } else {
                 items.extend(get_newline_wrapping_based_on_config(context));
               }
@@ -856,7 +860,12 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
 
   struct TextBuilder<'a> {
     items: PrintItems,
+    /// Whether the whitespace waiting to be written held a line break, which
+    /// is what tells it apart from a space where the difference matters.
     was_last_newline: bool,
+    /// The last character written, which decides how the whitespace that
+    /// follows it reads.
+    last_char: Option<char>,
     current_word: Option<String>,
     context: &'a Context<'a>,
   }
@@ -866,6 +875,7 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
       TextBuilder {
         items: PrintItems::new(),
         was_last_newline: false,
+        last_char: None,
         current_word: None,
         context,
       }
@@ -878,11 +888,8 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
 
     pub fn add_char(&mut self, character: char) {
       if character == '\n' || character == ' ' {
-        if self.context.configuration.text_wrap == TextWrap::Maintain && character == '\n' {
-          self.newline();
-        } else {
-          self.space_or_newline();
-        }
+        self.flush_current_word();
+        self.was_last_newline |= character == '\n';
         return;
       }
 
@@ -895,30 +902,55 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
       }
     }
 
-    fn space_or_newline(&mut self) {
-      self.flush_current_word();
-    }
-
-    fn newline(&mut self) {
-      self.flush_current_word();
-      self.was_last_newline = true;
-    }
-
     fn flush_current_word(&mut self) {
       if let Some(current_word) = self.current_word.take() {
         if !self.items.is_empty() {
-          if utils::is_block_start_word(&current_word) {
-            self.items.push_space();
-          } else if self.was_last_newline {
-            self.items.push_signal(Signal::NewLine)
-          } else {
-            self.items.extend(get_space_or_newline_based_on_config(self.context));
-          }
+          self.items.extend(self.whitespace_items(&current_word));
         }
 
+        self.last_char = current_word.chars().last();
         // the word may hold a tab, which the printer measures itself
         self.items.extend(gen_text_with_tabs(current_word));
         self.was_last_newline = false;
+      }
+    }
+
+    /// What to write in place of the whitespace that ran up to the next word.
+    fn whitespace_items(&self, next_word: &str) -> PrintItems {
+      if utils::is_block_start_word(next_word) {
+        // the word would start a block of its own at the start of a line, so
+        // it has to be kept off one
+        return space();
+      }
+      if self.was_last_newline && self.context.configuration.text_wrap == TextWrap::Maintain {
+        return Signal::NewLine.into();
+      }
+      if self.is_between_unspaced_scripts(next_word) {
+        return self.unspaced_script_items();
+      }
+      get_space_or_newline_based_on_config(self.context)
+    }
+
+    /// Whether the whitespace sits between two characters of a script written
+    /// without spaces, where a line break within it isn't rendered as a space
+    /// and a space within it can't be written as a line break.
+    fn is_between_unspaced_scripts(&self, next_word: &str) -> bool {
+      matches!((self.last_char, next_word.chars().next()),
+        (Some(last), Some(next)) if utils::is_unspaced_script(last) && utils::is_unspaced_script(next))
+    }
+
+    fn unspaced_script_items(&self) -> PrintItems {
+      if !self.was_last_newline {
+        // a space between the two characters is rendered, so it's kept as one
+        // rather than being turned into a line break
+        return space();
+      }
+      // a line break between them isn't rendered, so it's dropped rather than
+      // turned into a space, though the line may still be broken where it was
+      if self.context.is_text_wrap_disabled() || self.context.configuration.text_wrap != TextWrap::Always {
+        PrintItems::new()
+      } else {
+        Signal::PossibleNewLine.into()
       }
     }
   }
@@ -2132,6 +2164,27 @@ fn space() -> PrintItems {
   let mut items = PrintItems::new();
   items.push_space();
   items
+}
+
+/// What takes the place of a line break that falls between two characters of
+/// a script written without spaces between its words, where the break isn't
+/// rendered as a space and so is dropped rather than turned into one.
+fn get_unspaced_script_newline_wrapping(context: &Context) -> PrintItems {
+  match context.configuration.text_wrap {
+    // the line may still be broken where it was, since the break isn't read
+    // as anything either way
+    TextWrap::Always if !context.is_text_wrap_disabled() => Signal::PossibleNewLine.into(),
+    TextWrap::Always | TextWrap::Never => PrintItems::new(),
+    // a line break can't be written where newlines are being forced off (ex.
+    // within a heading), and it stood for nothing, so nothing replaces it
+    TextWrap::Maintain => if_true_or(
+      "newLineIfNewlinesEnabled",
+      condition_resolvers::is_forcing_no_newlines(),
+      PrintItems::new(),
+      Signal::NewLine.into(),
+    )
+    .into(),
+  }
 }
 
 fn get_newline_wrapping_based_on_config(context: &Context) -> PrintItems {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -860,11 +860,8 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
 
   struct TextBuilder<'a> {
     items: PrintItems,
-    /// Whether the whitespace waiting to be written held a line break, which
-    /// is what tells it apart from a space where the difference matters.
-    was_last_newline: bool,
-    /// The last character written, which decides how the whitespace that
-    /// follows it reads.
+    /// The last character written, which decides how the space that follows it
+    /// reads.
     last_char: Option<char>,
     current_word: Option<String>,
     context: &'a Context<'a>,
@@ -874,7 +871,6 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     pub fn new(context: &'a Context) -> TextBuilder<'a> {
       TextBuilder {
         items: PrintItems::new(),
-        was_last_newline: false,
         last_char: None,
         current_word: None,
         context,
@@ -887,9 +883,10 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     }
 
     pub fn add_char(&mut self, character: char) {
-      if character == '\n' || character == ' ' {
+      // a line break within a block reaches the formatter as a soft break of
+      // its own, so a space is the only whitespace that gets here
+      if character == ' ' {
         self.flush_current_word();
-        self.was_last_newline |= character == '\n';
         return;
       }
 
@@ -905,53 +902,36 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     fn flush_current_word(&mut self) {
       if let Some(current_word) = self.current_word.take() {
         if !self.items.is_empty() {
-          self.items.extend(self.whitespace_items(&current_word));
+          self.items.extend(self.space_items(&current_word));
         }
 
         self.last_char = current_word.chars().last();
         // the word may hold a tab, which the printer measures itself
         self.items.extend(gen_text_with_tabs(current_word));
-        self.was_last_newline = false;
       }
     }
 
-    /// What to write in place of the whitespace that ran up to the next word.
-    fn whitespace_items(&self, next_word: &str) -> PrintItems {
+    /// What to write in place of the space that ran up to the next word.
+    fn space_items(&self, next_word: &str) -> PrintItems {
       if utils::is_block_start_word(next_word) {
         // the word would start a block of its own at the start of a line, so
         // it has to be kept off one
         return space();
       }
-      if self.was_last_newline && self.context.configuration.text_wrap == TextWrap::Maintain {
-        return Signal::NewLine.into();
-      }
       if self.is_between_unspaced_scripts(next_word) {
-        return self.unspaced_script_items();
+        // a space between two characters of a script written without spaces is
+        // rendered, so it's kept as one rather than being written as the line
+        // break that would read as nothing
+        return space();
       }
       get_space_or_newline_based_on_config(self.context)
     }
 
-    /// Whether the whitespace sits between two characters of a script written
-    /// without spaces, where a line break within it isn't rendered as a space
-    /// and a space within it can't be written as a line break.
+    /// Whether the space sits between two characters of a script written
+    /// without spaces between its words.
     fn is_between_unspaced_scripts(&self, next_word: &str) -> bool {
       matches!((self.last_char, next_word.chars().next()),
         (Some(last), Some(next)) if utils::is_unspaced_script(last) && utils::is_unspaced_script(next))
-    }
-
-    fn unspaced_script_items(&self) -> PrintItems {
-      if !self.was_last_newline {
-        // a space between the two characters is rendered, so it's kept as one
-        // rather than being turned into a line break
-        return space();
-      }
-      // a line break between them isn't rendered, so it's dropped rather than
-      // turned into a space, though the line may still be broken where it was
-      if self.context.is_text_wrap_disabled() || self.context.configuration.text_wrap != TextWrap::Always {
-        PrintItems::new()
-      } else {
-        Signal::PossibleNewLine.into()
-      }
     }
   }
 }
@@ -2175,15 +2155,10 @@ fn get_unspaced_script_newline_wrapping(context: &Context) -> PrintItems {
     // as anything either way
     TextWrap::Always if !context.is_text_wrap_disabled() => Signal::PossibleNewLine.into(),
     TextWrap::Always | TextWrap::Never => PrintItems::new(),
-    // a line break can't be written where newlines are being forced off (ex.
-    // within a heading), and it stood for nothing, so nothing replaces it
-    TextWrap::Maintain => if_true_or(
-      "newLineIfNewlinesEnabled",
-      condition_resolvers::is_forcing_no_newlines(),
-      PrintItems::new(),
-      Signal::NewLine.into(),
-    )
-    .into(),
+    // where newlines are being forced off (ex. within a heading) the printer
+    // drops this one, which is what should take the place of a break that read
+    // as nothing anyway
+    TextWrap::Maintain => Signal::NewLine.into(),
   }
 }
 

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -28,8 +28,8 @@ pub fn is_unspaced_script(c: char) -> bool {
     // vertical forms, CJK compatibility forms, and small form variants
     | 0xFE10..=0xFE19
     | 0xFE30..=0xFE6F
-    // fullwidth forms, less the halfwidth katakana and hangul between them
-    | 0xFF01..=0xFF60
+    // fullwidth forms and halfwidth katakana, stopping before halfwidth hangul
+    | 0xFF01..=0xFF9F
     | 0xFFE0..=0xFFE6
   )
 }
@@ -217,6 +217,9 @@ mod test {
     assert_eq!(is_unspaced_script('。'), true);
     assert_eq!(is_unspaced_script('，'), true);
     assert_eq!(is_unspaced_script('）'), true);
+    // and the halfwidth forms of the kana and punctuation written with them
+    assert_eq!(is_unspaced_script('ｶ'), true);
+    assert_eq!(is_unspaced_script('｡'), true);
     // korean is written with spaces between its words
     assert_eq!(is_unspaced_script('한'), false);
     assert_eq!(is_unspaced_script('ᄀ'), false);

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -3,6 +3,37 @@ use std::borrow::Cow;
 
 use regex::Regex;
 
+/// Whether the character belongs to a script written without spaces between
+/// its words, where a line break carries no meaning of its own.
+///
+/// Han, kana, and the punctuation and fullwidth forms written alongside them
+/// qualify. Hangul does not: Korean is written with spaces between its words,
+/// so a line break within it reads as one the way it does in English.
+///
+/// See <https://drafts.csswg.org/css-text-4/#line-break-transform>.
+pub fn is_unspaced_script(c: char) -> bool {
+  matches!(
+    c as u32,
+    // CJK radicals and Kangxi radicals
+    0x2E80..=0x2FDF
+    // CJK symbols and punctuation, hiragana, and katakana
+    | 0x3000..=0x30FF
+    // katakana phonetic extensions
+    | 0x31F0..=0x31FF
+    // CJK unified ideographs, and the extension and compatibility blocks
+    | 0x3400..=0x4DBF
+    | 0x4E00..=0x9FFF
+    | 0xF900..=0xFAFF
+    | 0x20000..=0x3FFFD
+    // vertical forms, CJK compatibility forms, and small form variants
+    | 0xFE10..=0xFE19
+    | 0xFE30..=0xFE6F
+    // fullwidth forms, less the halfwidth katakana and hangul between them
+    | 0xFF01..=0xFF60
+    | 0xFFE0..=0xFFE6
+  )
+}
+
 /// Checks if the provided word would start a new block when it appears at the
 /// start of a line (ex. a list item, block quote, heading, thematic break, or
 /// code fence). Such a word can't be moved to the start of a line by wrapping
@@ -175,6 +206,26 @@ pub fn unindent(text: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod test {
   use super::*;
+
+  #[test]
+  fn it_should_find_unspaced_scripts() {
+    // han, hiragana, and katakana
+    assert_eq!(is_unspaced_script('漢'), true);
+    assert_eq!(is_unspaced_script('は'), true);
+    assert_eq!(is_unspaced_script('カ'), true);
+    // the punctuation and fullwidth forms written alongside them
+    assert_eq!(is_unspaced_script('。'), true);
+    assert_eq!(is_unspaced_script('，'), true);
+    assert_eq!(is_unspaced_script('）'), true);
+    // korean is written with spaces between its words
+    assert_eq!(is_unspaced_script('한'), false);
+    assert_eq!(is_unspaced_script('ᄀ'), false);
+    // and neither is anything else
+    assert_eq!(is_unspaced_script('a'), false);
+    assert_eq!(is_unspaced_script(' '), false);
+    assert_eq!(is_unspaced_script(','), false);
+    assert_eq!(is_unspaced_script('é'), false);
+  }
 
   #[test]
   fn it_should_find_list_words() {

--- a/tests/specs/Text/Text_UnspacedScripts.txt
+++ b/tests/specs/Text/Text_UnspacedScripts.txt
@@ -1,0 +1,17 @@
+!! should keep the line breaks of an unspaced script where text is maintained !!
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+[expect]
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+!! should drop a line break between them where newlines are forced off !!
+日本語
+日本語
+===
+
+[expect]
+# 日本語日本語

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
@@ -1,0 +1,45 @@
+~~ textWrap: always, lineWidth: 30 ~~
+!! should drop a line break between two characters of an unspaced script !!
+日本語
+日本語
+
+[expect]
+日本語日本語
+
+!! should break where one was rather than writing a space there !!
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+[expect]
+這個段落是那麼長，
+在一行寫不行。最好用三行寫。
+
+!! should keep a space between them rather than breaking the line there !!
+日本語 日本語 日本語 日本語 日本語
+
+[expect]
+日本語 日本語 日本語 日本語 日本語
+
+!! should still turn a line break beside other text into a space !!
+日本語
+English
+は便利
+
+[expect]
+日本語 English は便利
+
+!! should drop a line break between them within a heading !!
+日本語
+日本語
+===
+
+[expect]
+# 日本語日本語
+
+!! should drop a line break between them within a link !!
+[日本語
+日本語](https://dprint.dev)
+
+[expect]
+[日本語日本語](https://dprint.dev)

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never.txt
@@ -1,0 +1,16 @@
+~~ textWrap: never ~~
+!! should drop a line break between two characters of an unspaced script !!
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+[expect]
+這個段落是那麼長，在一行寫不行。最好用三行寫。
+
+!! should still turn a line break beside other text into a space !!
+日本語
+English
+は便利
+
+[expect]
+日本語 English は便利


### PR DESCRIPTION
Closes #127.

CSS's [line-break-transform](https://drafts.csswg.org/css-text-4/#line-break-transform) rule says that in a script written without word separators, a line break between two of its characters is removed rather than turned into a space. All three of the issue's claims now hold:

| | before | after |
| --- | --- | --- |
| `字 字` at a wrap point | broke onto a new line | space kept, no break |
| `字\n字` (`always` / `never`) | became a space | removed; the line may still break there |
| `字\n字` (`maintain`) | line break kept | unchanged |
| `字\nA`, `A\n字` | became a space | unchanged |

The spec's own example, at `textWrap: always`:

```md
這個段落是那麼長，
在一行寫不行。最好
用三行寫。
```
```md
這個段落是那麼長，在一行寫不行。最好用三行寫。
```

**Two call sites, not one.** A space within a line stays inside a single `Text` node, so the space rule lives in `TextBuilder`. But the parser emits a `SoftBreak` between source lines, so a `Text` node never holds a newline — the line break rule had to go where `gen_nodes` turns a soft break into a separator.

**Korean is deliberately excluded**, since it's written with spaces between its words: a line break within it reads as one the way it does in English. `is_unspaced_script` covers Han, kana, and the punctuation and fullwidth/halfwidth forms written alongside them, and every Hangul block is outside it.

**Where the line can still break.** At `textWrap: always` a dropped break leaves a `Signal::PossibleNewLine` behind, so the text can still wrap where the author had it — just without gaining a space. A run of CJK with no breaks or spaces in it still can't wrap; that's #120.

**Worth a release note:** a long CJK line written with spaces between its words can no longer be wrapped at those spaces, so such a line may now exceed `lineWidth`. That's what the issue asks for, and the specs cover it, but it will surprise someone.

### Follow-on cleanup in the second commit

Reworking `TextBuilder` surfaced that its newline handling is unreachable: since the parser rewrite in #224, `gen_str` is never passed text containing a newline. I confirmed it with a temporary `assert!` over the whole test suite, including the text fuzz and corpus checks — it never fired. The second commit drops that branch (and `was_last_newline` with it), so `TextBuilder` only deals with the spaces it actually sees. Happy to split this out if you'd rather keep it separate.

The same commit widens the halfwidth range from `0xFF01..=0xFF60` to `0xFF01..=0xFF9F`. Halfwidth katakana and the halfwidth ideographic punctuation (`｡｢｣､･`) sit at U+FF61–FF9F and are East Asian Width `H`, which the CSS rule covers; the range still stops before halfwidth Hangul at U+FFA0.