### PR TITLE
feat: break a line within a script written without spaces between its words

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -906,8 +906,9 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
         }
 
         self.last_char = current_word.chars().last();
-        // the word may hold a tab, which the printer measures itself
-        self.items.extend(gen_text_with_tabs(current_word));
+        self
+          .items
+          .extend(gen_word_with_unspaced_script_breaks(current_word, self.context));
       }
     }
 
@@ -1444,6 +1445,44 @@ fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
     }
   }
   line
+}
+
+/// Writes the word, breaking it up where a line can be broken within a script
+/// written without spaces between its words.
+///
+/// A run of such a script holds no spaces for the line to be broken at, so
+/// without this it would be written on one line however long it ran. Only a
+/// break with one of its characters on either side can be written: anywhere
+/// else the break would be read back as a space that wasn't written.
+fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> PrintItems {
+  if context.configuration.text_wrap != TextWrap::Always || context.is_text_wrap_disabled() {
+    return gen_text_with_tabs(word);
+  }
+
+  let mut items = PrintItems::new();
+  let mut segment_start = 0;
+  let mut last_char: Option<char> = None;
+  for (index, character) in word.char_indices() {
+    if matches!(last_char, Some(last) if breaks_between(last, character)) {
+      items.extend(gen_text_with_tabs(word[segment_start..index].to_string()));
+      items.push_signal(Signal::PossibleNewLine);
+      segment_start = index;
+    }
+    last_char = Some(character);
+  }
+  items.extend(gen_text_with_tabs(word[segment_start..].to_string()));
+
+  return items;
+
+  /// Whether a line can be broken between the two characters, which needs both
+  /// to belong to a script written without spaces, and neither to be a mark
+  /// that has to stay with the character beside it.
+  fn breaks_between(last: char, next: char) -> bool {
+    utils::is_unspaced_script(last)
+      && utils::is_unspaced_script(next)
+      && !utils::forbids_line_break_after(last)
+      && !utils::forbids_line_break_before(next)
+  }
 }
 
 /// Writes out text, sending any tab it has as a signal, since the printer

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -34,6 +34,52 @@ pub fn is_unspaced_script(c: char) -> bool {
   )
 }
 
+/// Whether a line can't be broken before the character, which is what keeps
+/// the marks that close or trail a phrase off the start of a line.
+///
+/// This is the part of Japanese line breaking (kinsoku shori) that every
+/// renderer applies. See <https://www.w3.org/TR/jlreq/#characters_not_starting_a_line>.
+pub fn forbids_line_break_before(c: char) -> bool {
+  matches!(
+    c,
+    // marks that close or trail a phrase
+    '、' | '。' | '，' | '．' | '：' | '；' | '？' | '！' | '‼' | '⁇' | '⁈' | '⁉'
+    | '〕' | '〉' | '》' | '」' | '』' | '】' | '〙' | '〛' | '〞' | '〟' | '）'
+    | '｝' | '］' | '｠' | '＞' | '»' | '›'
+    // the middle dot, which separates the words within a phrase
+    | '・'
+    // the halfwidth forms of the same
+    | '｡' | '｣' | '､' | '･'
+    // iteration marks, which stand for the character before them
+    | '々' | '〻' | 'ゝ' | 'ゞ' | 'ヽ' | 'ヾ'
+    // the marks that voice the character before them, combining or not
+    | '゛' | '゜' | 'ﾞ' | 'ﾟ' | '\u{3099}' | '\u{309A}'
+    // the prolonged sound marks and the small kana, which belong to the
+    // syllable written before them
+    | 'ー' | 'ｰ' | '〜' | '～'
+    | 'ぁ' | 'ぃ' | 'ぅ' | 'ぇ' | 'ぉ' | 'っ' | 'ゃ' | 'ゅ' | 'ょ' | 'ゎ' | 'ゕ' | 'ゖ'
+    | 'ァ' | 'ィ' | 'ゥ' | 'ェ' | 'ォ' | 'ッ' | 'ャ' | 'ュ' | 'ョ' | 'ヮ' | 'ヵ' | 'ヶ'
+    // the small katakana written for the sounds of other languages
+    | '\u{31F0}'..='\u{31FF}'
+    // the halfwidth small kana
+    | '\u{FF67}'..='\u{FF6F}'
+  )
+}
+
+/// Whether a line can't be broken after the character, which is what keeps the
+/// marks that open a phrase off the end of a line.
+///
+/// See <https://www.w3.org/TR/jlreq/#characters_not_ending_a_line>.
+pub fn forbids_line_break_after(c: char) -> bool {
+  matches!(
+    c,
+    '〔' | '〈' | '《' | '「' | '『' | '【' | '〘' | '〚' | '〝' | '（'
+    | '｛' | '［' | '｟' | '＜' | '«' | '‹'
+    // the halfwidth form of the same
+    | '｢'
+  )
+}
+
 /// Checks if the provided word would start a new block when it appears at the
 /// start of a line (ex. a list item, block quote, heading, thematic break, or
 /// code fence). Such a word can't be moved to the start of a line by wrapping
@@ -228,6 +274,40 @@ mod test {
     assert_eq!(is_unspaced_script(' '), false);
     assert_eq!(is_unspaced_script(','), false);
     assert_eq!(is_unspaced_script('é'), false);
+  }
+
+  #[test]
+  fn it_should_find_characters_that_cant_start_a_line() {
+    // marks that close or trail a phrase
+    assert_eq!(forbids_line_break_before('。'), true);
+    assert_eq!(forbids_line_break_before('、'), true);
+    assert_eq!(forbids_line_break_before('」'), true);
+    assert_eq!(forbids_line_break_before('）'), true);
+    assert_eq!(forbids_line_break_before('・'), true);
+    // the small kana and the marks that belong to the syllable before them
+    assert_eq!(forbids_line_break_before('っ'), true);
+    assert_eq!(forbids_line_break_before('ョ'), true);
+    assert_eq!(forbids_line_break_before('ー'), true);
+    assert_eq!(forbids_line_break_before('\u{3099}'), true);
+    assert_eq!(forbids_line_break_before('\u{FF6F}'), true);
+    // a line can start with anything else
+    assert_eq!(forbids_line_break_before('あ'), false);
+    assert_eq!(forbids_line_break_before('漢'), false);
+    assert_eq!(forbids_line_break_before('「'), false);
+    assert_eq!(forbids_line_break_before('a'), false);
+  }
+
+  #[test]
+  fn it_should_find_characters_that_cant_end_a_line() {
+    assert_eq!(forbids_line_break_after('「'), true);
+    assert_eq!(forbids_line_break_after('（'), true);
+    assert_eq!(forbids_line_break_after('【'), true);
+    assert_eq!(forbids_line_break_after('｢'), true);
+    // a line can end with anything else
+    assert_eq!(forbids_line_break_after('」'), false);
+    assert_eq!(forbids_line_break_after('。'), false);
+    assert_eq!(forbids_line_break_after('漢'), false);
+    assert_eq!(forbids_line_break_after('a'), false);
   }
 
   #[test]

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
@@ -6,20 +6,21 @@
 [expect]
 日本語日本語
 
-!! should break where one was rather than writing a space there !!
+!! should break to fit the line rather than writing a space where one was !!
 這個段落是那麼長，
 在一行寫不行。最好
 用三行寫。
 
 [expect]
-這個段落是那麼長，
-在一行寫不行。最好用三行寫。
+這個段落是那麼長，在一行寫不
+行。最好用三行寫。
 
-!! should keep a space between them rather than breaking the line there !!
+!! should break within a run rather than at a space between them !!
 日本語 日本語 日本語 日本語 日本語
 
 [expect]
-日本語 日本語 日本語 日本語 日本語
+日本語 日本語 日本語 日本語 日
+本語
 
 !! should still turn a line break beside other text into a space !!
 日本語

--- a/tests/specs/Text/Text_UnspacedScripts_Wrapping.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_Wrapping.txt
@@ -1,0 +1,23 @@
+~~ textWrap: always, lineWidth: 20 ~~
+!! should break a run that holds no spaces to break at !!
+これは日本語のテキストです。長い文章を書いています。
+
+[expect]
+これは日本語のテキス
+トです。長い文章を書
+いています。
+
+!! should not break where the run meets other text !!
+日本語のtranspilationとbundlingです。
+
+[expect]
+日本語
+のtranspilationとbundlingで
+す。
+
+!! should leave a line long rather than break where a space would be read back !!
+これはテストです日本語日本語- テスト
+
+[expect]
+これはテストです日本
+語日本語- テスト

--- a/tests/specs/Text/Text_UnspacedScripts_Wrapping_LineWidth12.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_Wrapping_LineWidth12.txt
@@ -1,0 +1,8 @@
+~~ textWrap: always, lineWidth: 12 ~~
+!! should not break before a mark that closes or trails a phrase !!
+これはテストです。「かっこ」の中身。
+
+[expect]
+これはテスト
+です。「かっ
+こ」の中身。


### PR DESCRIPTION
Closes #120.

Japanese and Chinese are written without spaces between words, so a run of them gives the formatter nothing to wrap at and the line runs on however long it is. This inserts a break opportunity between the characters of such a run, so `textWrap: always` can fit it to `lineWidth`.

```md
Denoは、最新のWeb用のオープンソースJavaScriptランタイムです。Denoは、構成不要
のTypeScript、比類のないセキュリティ、完全な組み込みツールチェーンを備えたWeb標
準に基づいて構築されており、JavaScriptを使用するための最も簡単で生産的な方法で
す。Deno Deployは簡単にDenoのプロジェクトがデプロイ出来て便利です。
```

### Only between two of its characters

A break is written only where such a character sits on **both** sides of it. That's the same rule #127 used for reading a break, and it has to be, or the formatter would write a break that it reads back as a space:

```md
日本語のtranspilationとbundlingです。
```

Breaking that at `の` / `transpilation` looks tighter, and it's what Prettier does, but per [line-break-transform](https://drafts.csswg.org/css-text-4/#line-break-transform) a break is only removed when both sides are East Asian — beside anything else it renders as a space. Formatting such a break and then unwrapping it gives `日本語の transpilation とbundlingです。`, two spaces that were never written. So a run of other text is left whole and the line breaks before it instead, which can leave the line long. That's the cost of not changing the document.

There's a fuzz check for this in the same shape: format at some width, reformat the result at a very wide one, and compare against formatting the original wide. 2800 documents across widths 10/20/40/80 — no round trip changed the text, no output's content differed from `main`, and nothing failed to format twice to the same thing.

### Kinsoku shori

Breaking anywhere would produce wrong Japanese, so `utils` gained the two rules every renderer applies: `。`, `、`, `・`, closing brackets, the small kana, the prolonged sound mark and the voicing marks can't start a line, and `「`, `（`, `【` can't end one. See [JLReq](https://www.w3.org/TR/jlreq/#characters_not_starting_a_line).

```md
これはテスト
です。「かっ
こ」の中身。
```

### Notes

- Only under `textWrap: always`, and not where wrapping is off — `maintain` and `never` are untouched, and a heading or link is left on its line.
- Two specs from #230 changed, since a line that used to run long now breaks inside a run. A space between two runs is still never turned into a break, which is #127's rule; the break just lands elsewhere. I retitled both to say what they now assert rather than only updating the expected text.
- A 312KB CJK document formats in 0.126s.