### PR TITLE
feat: add `codeBlock.useTabs` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -144,6 +144,17 @@
         "description": "Removes the blank lines at the start and end of a fenced code block."
       }]
     },
+    "codeBlock.useTabs": {
+      "description": "Whether the plugin that formats the code within a code block should use tabs, overriding that plugin's own `useTabs` configuration. When not specified, that plugin's configuration is left alone.",
+      "type": "boolean",
+      "oneOf": [{
+        "const": true,
+        "description": "Formats the code within a code block using tabs."
+      }, {
+        "const": false,
+        "description": "Formats the code within a code block using spaces."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -199,6 +210,9 @@
     },
     "codeBlock.preserveBlankLines": {
       "$ref": "#/definitions/codeBlock.preserveBlankLines"
+    },
+    "codeBlock.useTabs": {
+      "$ref": "#/definitions/codeBlock.useTabs"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -118,6 +118,13 @@ impl ConfigurationBuilder {
     self.insert("codeBlock.preserveBlankLines", value.into())
   }
 
+  /// Whether the plugin that formats the code within a code block should use
+  /// tabs, overriding that plugin's own `useTabs` configuration.
+  /// Default: not overridden
+  pub fn code_block_use_tabs(&mut self, value: bool) -> &mut Self {
+    self.insert("codeBlock.useTabs", value.into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -185,13 +192,14 @@ mod tests {
       .code_block_skip_format(true)
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
+      .code_block_use_tabs(true)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 16);
+    assert_eq!(inner_config.len(), 17);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }
@@ -216,6 +224,18 @@ mod tests {
     let config = config_builder.global_config(global_config).build();
     assert_eq!(config.line_width, 80); // this is different
     assert_eq!(config.new_line_kind == NewLineKind::LineFeed, true);
+  }
+
+  #[test]
+  fn code_block_use_tabs_only_set_when_specified() {
+    let config = ConfigurationBuilder::new().build();
+    assert_eq!(config.code_block_use_tabs, None);
+
+    let config = ConfigurationBuilder::new().code_block_use_tabs(true).build();
+    assert_eq!(config.code_block_use_tabs, Some(true));
+
+    let config = ConfigurationBuilder::new().code_block_use_tabs(false).build();
+    assert_eq!(config.code_block_use_tabs, Some(false));
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -75,6 +75,7 @@ pub fn resolve_config(
     code_block_skip_format: get_value(&mut config, "codeBlock.skipFormat", false, &mut diagnostics),
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
+    code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -24,6 +24,10 @@ pub struct Configuration {
   pub code_block_preserve_indentation: bool,
   #[serde(rename = "codeBlock.preserveBlankLines")]
   pub code_block_preserve_blank_lines: bool,
+  /// Whether to override the `useTabs` configuration of the plugin that
+  /// formats the code within a code block. `None` leaves it to that plugin.
+  #[serde(rename = "codeBlock.useTabs")]
+  pub code_block_use_tabs: Option<bool>,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -82,6 +82,9 @@ impl SyncPluginHandler<Configuration> for MarkdownPluginHandler {
         let file_path = PathBuf::from(format!("file.{}", ext));
         let mut additional_config = ConfigKeyMap::new();
         additional_config.insert("lineWidth".into(), (line_width as i32).into());
+        if let Some(use_tabs) = config.code_block_use_tabs {
+          additional_config.insert("useTabs".into(), use_tabs.into());
+        }
         let request = SyncHostFormatRequest {
           file_path: &file_path,
           file_bytes: file_text.as_bytes(),


### PR DESCRIPTION
Adds a `codeBlock.useTabs` option that overrides the `useTabs` configuration of the plugin formatting a code block.

It's tri-state: when unspecified (the default), nothing is sent and the code block's plugin uses its own `useTabs` configuration. When set to `true` or `false`, it's provided as an override config alongside `lineWidth` on the host format request.

Closes https://github.com/dprint/dprint-plugin-markdown/issues/68