### PR TITLE
fix: keep text that would start a block off the start of a line

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -64,6 +64,24 @@ impl<'a> Node<'a> {
     }
   }
 
+  /// Whether the node would start a block of its own, or turn the line above
+  /// it into one, if it were moved to the start of a line by wrapping.
+  ///
+  /// Unlike [`Self::starts_block_in_paragraph`] this counts what the node's
+  /// first word would start on its own, since the text after it can wrap onto
+  /// the line below and leave it there alone.
+  pub fn starts_block_at_line_start(&self, word_can_be_left_alone: bool) -> bool {
+    match self {
+      Node::Text(text) => crate::generation::utils::starts_block_at_line_start(text.text, word_can_be_left_alone),
+      // a block of html already stands on its own, so nothing about where it
+      // is written can turn it into one
+      Node::Html(html) => {
+        !html.is_block && crate::generation::utils::starts_block_at_line_start(&html.text, word_can_be_left_alone)
+      }
+      _ => false,
+    }
+  }
+
   fn first_word(&self) -> Option<&'a str> {
     let Node::Text(text) = self else {
       return None;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -146,7 +146,7 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               // > Some note.
               if is_callout_node(last_node, context) && !context.is_text_wrap_disabled() {
                 items.push_signal(Signal::NewLine); // force a newline
-              } else if node.starts_block_in_paragraph() {
+              } else if node.starts_block_at_line_start(text_can_be_wrapped_away(context)) {
                 // text that would start a block can't be moved to the start of
                 // a line without changing what it means
                 items.push_space();
@@ -179,7 +179,9 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               };
 
               if needs_space {
-                if node.starts_with_list_word() {
+                if node.starts_block_at_line_start(text_can_be_wrapped_away(context)) || node.starts_with_list_word() {
+                  // the node would start a block of its own at the start of a
+                  // line, so it has to be kept off one
                   items.push_space();
                 } else {
                   items.extend(get_space_or_newline_based_on_config(context));
@@ -798,10 +800,9 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
       return;
     }
     if !items.is_empty() {
-      // a chunk may have significant whitespace merged into it, so only the
-      // leading token decides whether it could start a block
-      let leading_token = word.split(' ').next().unwrap_or(word);
-      if utils::is_block_start_word(leading_token) {
+      // only the chunk is looked at, since a code span's text is written out
+      // in chunks rather than a line at a time
+      if utils::wrapping_word_starts_block(word, text_can_be_wrapped_away(context)) {
         items.push_space();
       } else if was_last_newline {
         items.push_signal(Signal::NewLine);
@@ -850,27 +851,31 @@ fn is_callout_text(text: &str) -> bool {
 }
 
 fn gen_str(text: &str, context: &mut Context) -> PrintItems {
-  let mut text_builder = TextBuilder::new(context);
+  let mut text_builder = TextBuilder::new(text, context);
 
-  for c in text.chars() {
-    text_builder.add_char(c);
+  for (index, c) in text.char_indices() {
+    text_builder.add_char(index, c);
   }
 
   return text_builder.build();
 
   struct TextBuilder<'a> {
     items: PrintItems,
+    /// The text being written, which the words are read back out of in order
+    /// to work out what a line would begin with.
+    text: &'a str,
     /// The last character written, which decides how the space that follows it
     /// reads.
     last_char: Option<char>,
-    current_word: Option<String>,
+    current_word: Option<(usize, String)>,
     context: &'a Context<'a>,
   }
 
   impl<'a> TextBuilder<'a> {
-    pub fn new(context: &'a Context) -> TextBuilder<'a> {
+    pub fn new(text: &'a str, context: &'a Context) -> TextBuilder<'a> {
       TextBuilder {
         items: PrintItems::new(),
+        text,
         last_char: None,
         current_word: None,
         context,
@@ -882,7 +887,7 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
       self.items
     }
 
-    pub fn add_char(&mut self, character: char) {
+    pub fn add_char(&mut self, index: usize, character: char) {
       // a line break within a block reaches the formatter as a soft break of
       // its own, so a space is the only whitespace that gets here
       if character == ' ' {
@@ -890,19 +895,19 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
         return;
       }
 
-      if let Some(current_word) = self.current_word.as_mut() {
+      if let Some((_, current_word)) = self.current_word.as_mut() {
         current_word.push(character);
       } else {
-        let mut text = String::new();
-        text.push(character);
-        self.current_word = Some(text);
+        let mut word = String::new();
+        word.push(character);
+        self.current_word = Some((index, word));
       }
     }
 
     fn flush_current_word(&mut self) {
-      if let Some(current_word) = self.current_word.take() {
+      if let Some((start, current_word)) = self.current_word.take() {
         if !self.items.is_empty() {
-          self.items.extend(self.space_items(&current_word));
+          self.items.extend(self.space_items(start, &current_word));
         }
 
         self.last_char = current_word.chars().last();
@@ -913,9 +918,9 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     }
 
     /// What to write in place of the space that ran up to the next word.
-    fn space_items(&self, next_word: &str) -> PrintItems {
-      if utils::is_block_start_word(next_word) {
-        // the word would start a block of its own at the start of a line, so
+    fn space_items(&self, next_word_start: usize, next_word: &str) -> PrintItems {
+      if utils::wrapping_word_starts_block(&self.text[next_word_start..], text_can_be_wrapped_away(self.context)) {
+        // the text would start a block of its own at the start of a line, so
         // it has to be kept off one
         return space();
       }
@@ -2167,6 +2172,12 @@ fn measure_longest_line_width(items: PrintItems, max_width: u32) -> usize {
     .map(|line| UnicodeWidthStr::width(line.trim_end_matches(WHITESPACE)))
     .max()
     .unwrap_or(0)
+}
+
+/// Whether the text after a word can be wrapped onto the line below it, which
+/// is what would leave the word by itself on a line of its own.
+fn text_can_be_wrapped_away(context: &Context) -> bool {
+  context.configuration.text_wrap == TextWrap::Always && !context.is_text_wrap_disabled()
 }
 
 fn get_space_or_newline_based_on_config(context: &Context) -> PrintItems {

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -80,46 +80,35 @@ pub fn forbids_line_break_after(c: char) -> bool {
   )
 }
 
-/// Checks if the provided word would start a new block when it appears at the
-/// start of a line (ex. a list item, block quote, heading, thematic break, or
-/// code fence). Such a word can't be moved to the start of a line by wrapping
-/// without changing the meaning of the document.
-/// Assumes the provided string is one word and doesn't have whitespace.
-pub fn is_block_start_word(word: &str) -> bool {
-  if is_list_word(word) {
-    return true;
-  }
+/// Whether the text would start a block of its own, or turn the line above it
+/// into one, if it were moved to the start of a line. Such text can't be moved
+/// there by wrapping without changing what the document means.
+///
+/// Takes the text from the word that would begin the line through to the end
+/// of it, since what starts a block is decided by the whole line: `1.` opens a
+/// list only when something follows it, and `|-|` turns the line above it into
+/// a table header only in its entirety.
+///
+/// `word_can_be_left_alone` says whether the text after the first word can be
+/// wrapped onto the line below and leave that word by itself, which is what
+/// makes what the word would start on its own count as well. Where text isn't
+/// being wrapped it can't, and holding the word back would only join lines the
+/// document was written with.
+pub fn starts_block_at_line_start(line_text: &str, word_can_be_left_alone: bool) -> bool {
+  let leading_word = line_text.split(' ').next().unwrap_or(line_text);
+  word_can_be_left_alone && crate::parser::starts_block_in_paragraph(leading_word)
+    || crate::parser::starts_block_in_paragraph(line_text)
+}
 
-  // block quote (ex. >, >>, >text)
-  if word.starts_with('>') {
-    return true;
-  }
-
-  // definition list marker, which is a `:` followed by whitespace
-  if word == ":" {
-    return true;
-  }
-
-  // atx heading (ex. #, ###) -- only when nothing follows the hashes,
-  // since #text isn't a heading
-  let hash_count = word.chars().take_while(|c| *c == '#').count();
-  if hash_count > 0 && hash_count <= 6 && word.len() == hash_count {
-    return true;
-  }
-
-  // setext heading underline (ex. =, ===), which would turn the previous
-  // line into a heading
-  if !word.is_empty() && word.chars().all(|c| c == '=') {
-    return true;
-  }
-
-  // thematic break or code fence (ex. ---, ***, ___, ~~~ and three backticks)
-  match word.chars().next() {
-    Some(c) if matches!(c, '-' | '*' | '_' | '`' | '~') => {
-      word.chars().count() >= 3 && word.chars().all(|other| other == c)
-    }
-    _ => false,
-  }
+/// Whether the text would start a block of its own if the word that begins it
+/// were moved to the start of a line by wrapping.
+///
+/// A word that would become a list marker counts as well as what
+/// [`starts_block_at_line_start`] finds, since the text that wraps onto the
+/// line after the marker is what would turn it into a real one.
+pub fn wrapping_word_starts_block(line_text: &str, word_can_be_left_alone: bool) -> bool {
+  let leading_word = line_text.split(' ').next().unwrap_or(line_text);
+  is_list_word(leading_word) || starts_block_at_line_start(line_text, word_can_be_left_alone)
 }
 
 /// Checks if the provided word is a word that could be a list.
@@ -324,27 +313,50 @@ mod test {
   }
 
   #[test]
-  fn it_should_find_block_start_words() {
-    assert_eq!(is_block_start_word("test"), false);
-    assert_eq!(is_block_start_word("-"), true);
-    assert_eq!(is_block_start_word("1."), true);
-    assert_eq!(is_block_start_word(">"), true);
-    assert_eq!(is_block_start_word(">text"), true);
-    assert_eq!(is_block_start_word("#"), true);
-    assert_eq!(is_block_start_word("######"), true);
-    assert_eq!(is_block_start_word("#######"), false);
-    assert_eq!(is_block_start_word("#text"), false);
-    assert_eq!(is_block_start_word("="), true);
-    assert_eq!(is_block_start_word("==="), true);
-    assert_eq!(is_block_start_word("=text"), false);
-    assert_eq!(is_block_start_word("---"), true);
-    assert_eq!(is_block_start_word("***"), true);
-    assert_eq!(is_block_start_word("___"), true);
-    assert_eq!(is_block_start_word("~~~"), true);
-    assert_eq!(is_block_start_word("```"), true);
-    assert_eq!(is_block_start_word("--"), false);
-    assert_eq!(is_block_start_word("~~"), false);
-    assert_eq!(is_block_start_word("---a"), false);
+  fn it_should_find_text_that_starts_a_block_at_a_line_start() {
+    assert_eq!(starts_block_at_line_start("test", true), false);
+    assert_eq!(wrapping_word_starts_block("-", true), true);
+    assert_eq!(wrapping_word_starts_block("1.", true), true);
+    assert_eq!(starts_block_at_line_start(">", true), true);
+    assert_eq!(starts_block_at_line_start(">text", true), true);
+    assert_eq!(starts_block_at_line_start("#", true), true);
+    assert_eq!(starts_block_at_line_start("######", true), true);
+    assert_eq!(starts_block_at_line_start("#######", true), false);
+    assert_eq!(starts_block_at_line_start("#text", true), false);
+    assert_eq!(starts_block_at_line_start("=", true), true);
+    assert_eq!(starts_block_at_line_start("===", true), true);
+    assert_eq!(starts_block_at_line_start("=text", true), false);
+    assert_eq!(starts_block_at_line_start("---", true), true);
+    assert_eq!(starts_block_at_line_start("***", true), true);
+    assert_eq!(starts_block_at_line_start("___", true), true);
+    assert_eq!(starts_block_at_line_start("~~~", true), true);
+    assert_eq!(starts_block_at_line_start("```", true), true);
+    assert_eq!(starts_block_at_line_start("~~", true), false);
+    assert_eq!(starts_block_at_line_start("---a", true), false);
+    // two dashes underline the line above into a heading
+    assert_eq!(starts_block_at_line_start("--", true), true);
+    // html, a footnote definition, and a table's delimiter row
+    assert_eq!(starts_block_at_line_start("<div>", true), true);
+    assert_eq!(starts_block_at_line_start("<!-- x -->", true), true);
+    assert_eq!(starts_block_at_line_start("[^note]:", true), true);
+    assert_eq!(starts_block_at_line_start("|---|", true), true);
+    // the word decides it even where the rest of the line reads as text, since
+    // that text can wrap onto the line below and leave the word alone
+    assert_eq!(starts_block_at_line_start("-- text", true), true);
+    assert_eq!(starts_block_at_line_start("--- text", true), true);
+    assert_eq!(starts_block_at_line_start("text --", true), false);
+    // a list marker is only a marker once text follows it on the line, so it
+    // counts for a word that wrapping would move but not for a node that
+    // already begins a line
+    assert_eq!(starts_block_at_line_start("40.", true), false);
+    assert_eq!(wrapping_word_starts_block("40.", true), true);
+    assert_eq!(starts_block_at_line_start("6. Test", true), false);
+    assert_eq!(wrapping_word_starts_block("6. Test", true), true);
+    // where the text after the word can't be wrapped away the word is never
+    // left alone, so only what the whole line starts counts
+    assert_eq!(starts_block_at_line_start("-- text", false), false);
+    assert_eq!(starts_block_at_line_start("--", false), true);
+    assert_eq!(starts_block_at_line_start("=== not a heading", false), false);
   }
 
   #[test]

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -918,7 +918,12 @@ fn escape_position(text: &str, is_markup: bool) -> Option<usize> {
 /// Whether the text is made of the characters a table's delimiter row is, which
 /// is what it takes for the line above it to become a header.
 fn is_table_delimiter_shape(text: &str) -> bool {
-  text.contains('-') && has_unescaped_pipe(text) && text.bytes().all(|b| matches!(b, b'-' | b':' | b'|' | b' ' | b'\t'))
+  // the first byte rules most text out before the scans that look through all
+  // of it, which the formatter asks about a line at a time as it wraps one
+  matches!(text.as_bytes().first(), Some(b'-' | b':' | b'|' | b' ' | b'\t'))
+    && text.contains('-')
+    && has_unescaped_pipe(text)
+    && text.bytes().all(|b| matches!(b, b'-' | b':' | b'|' | b' ' | b'\t'))
 }
 
 // ==== block recognition ====

--- a/tests/specs/Code/Code_Inline_BlockStarts.txt
+++ b/tests/specs/Code/Code_Inline_BlockStarts.txt
@@ -1,0 +1,8 @@
+~~ textWrap: always, lineWidth: 14 ~~
+!! should not wrap two dashes within a code span to the start of a line !!
+aaaaaaaaaa `bbbbbbbbbb --` cc
+
+[expect]
+aaaaaaaaaa
+`bbbbbbbbbb --`
+cc

--- a/tests/specs/Text/Text_BlockStarts.txt
+++ b/tests/specs/Text/Text_BlockStarts.txt
@@ -1,0 +1,13 @@
+!! should keep the line breaks written around text that would start a block !!
+Some text
+-- a dash starts this line
+
+line one
+=== not a heading because of this text
+
+[expect]
+Some text
+-- a dash starts this line
+
+line one
+=== not a heading because of this text

--- a/tests/specs/Text/Text_BlockStarts_TextWrap_Always.txt
+++ b/tests/specs/Text/Text_BlockStarts_TextWrap_Always.txt
@@ -1,0 +1,43 @@
+~~ textWrap: always, lineWidth: 12 ~~
+!! should not wrap two dashes to the start of a line, which underline the line above into a heading !!
+aaaaaaaaaa bbbbbbbbbb --
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbbb --
+
+!! should not wrap html to the start of a line, where it becomes a block of its own !!
+aaaaaaaaaa bbbbbbbbbb <div>
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbbb <div>
+
+!! should not wrap a comment to the start of a line !!
+aaaaaaaaaa bbbbbbbbbb <!-- x -->
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbbb <!-- x -->
+
+!! should not wrap a footnote definition to the start of a line !!
+aaaaaaaaaa bbbbbbbbbb [^note]:
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbbb [^note]:
+
+!! should not wrap a row of dashes and pipes to the start of a line, which turns the line above into a table header !!
+aaaaaaaaaa bbbbbbbbbb |---|
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbbb |---|
+
+!! should not wrap two dashes from the line below to the start of a line !!
+aaaaaaaaaa
+-- bbbbbbbbbb
+
+[expect]
+aaaaaaaaaa --
+bbbbbbbbbb


### PR DESCRIPTION
When wrapping, text can't be moved to the start of a line if that would start a block of its own, or turn the line above it into one. The check for that was written by hand and missed most of what the parser already knows about.

At `{"textWrap": "always", "lineWidth": 12}`:

```md
aaaaaaaaaa bbbbbbbbbb --
```

formats to `aaaaaaaaaa` / `bbbbbbbbbb` / `--`, and formatting **that** gives:

```md
## aaaaaaaaaa bbbbbbbbbb
```

A paragraph silently becomes a heading. `--` is the specific gap — one dash is caught as a list marker and three as a thematic break, but two is neither, and one is enough for a setext underline. The same shape holds for `<div>` (the paragraph splits into an html block), `[^a]:` (a footnote definition) and `|---|` (a table's delimiter row).

It now asks `starts_block_in_paragraph`, which is what decides this everywhere else, about the whole line **and** about the word that would begin it — the word alone matters because the text after it can be wrapped onto the next line and leave it there by itself.

### Only where text is being wrapped

The word-alone half is asked only under `textWrap: always`. Anywhere else the text after the word can't be wrapped away, so the word is never left alone, and holding it back would just join lines the document was written with:

```md
Some text
-- a dash starts this line
```

Under the default `textWrap: maintain` that has to stay as it is. Across 700 generated documents at `maintain` and 700 at `never`, output is byte-identical to `main`; at `always` it differs on 245 of 700, and format-twice instability drops from 183 to 11.

### Two levels, deliberately

`starts_block_at_line_start` is for a node that already begins a line; `wrapping_word_starts_block` adds `is_list_word` for a word that wrapping would move, since `40.` becomes a real marker once text wraps onto the line after it. Widening the node-level one the same way collapses nested ordered lists (`2. Testing` / `   6. Test` onto one line), which is why they're separate.

### Also here

`is_table_delimiter_shape` checks its first byte before the two full scans it opens with. The formatter now asks it about the rest of the line once per word, which made an 80k-word paragraph take 1.15s instead of 0.19s; it's 0.21s now.

### Known residuals, all pre-existing and unchanged by this

- A block-starting token that is the **first** word of its block can still be isolated by the break *after* it: `> --- delta alpha bb` wraps to `> ---` / `> delta ...`, and `---` alone is a thematic break. Preventing that needs line-start knowledge the IR builder doesn't have — the blunt rule regressed three existing specs.
- A construct spanning **several** words, isolated by breaks on both sides: `aaaaaaaa _ _ _ zz` at width 6 gains a thematic break. Neither half of the predicate sees it, since the leading word is harmless and the rest of the line is ordinary text. `* * *` and `- - -` escape only by accident, through `is_list_word`.
- `[^a]:` parses as a FootnoteReference node plus text when a matching definition exists, so the node-level check doesn't see it.
- `gen_code_str` is handed one chunk rather than a line, so its check is still effectively word-level. Commented at the call site.