### PR TITLE
fix: keep a block quote's marker on a line that holds only a hard break

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1895,6 +1895,10 @@ fn gen_hard_break(context: &mut Context) -> PrintItems {
   /// The two spaces a double space hard break leaves behind, measured as zero
   /// columns because trailing whitespace isn't visible.
   const DOUBLE_SPACE: StringContainer = StringContainer::proc_macro_new_with_char_count("  ", 0);
+  /// Stands in for the text a hard break writes, which is otherwise hidden
+  /// within a condition where nothing rewriting the line can see it (ex. a
+  /// block quote, which writes its markers in front of a line's text).
+  const WRITES_TEXT: StringContainer = StringContainer::proc_macro_new_with_char_count("", 0);
 
   let hard_break = {
     let mut items = PrintItems::new();
@@ -1908,13 +1912,15 @@ fn gen_hard_break(context: &mut Context) -> PrintItems {
     items.push_signal(Signal::NewLine);
     items
   };
-  if_true_or(
+  let mut items = PrintItems::new();
+  items.push_sc(&WRITES_TEXT);
+  items.push_condition(if_true_or(
     "hardBreakOrSpaceIfNewlinesDisabled",
     condition_resolvers::is_forcing_no_newlines(),
     space(),
     hard_break,
-  )
-  .into()
+  ));
+  items
 }
 
 fn gen_table(table: &Table, context: &mut Context) -> PrintItems {

--- a/tests/specs/BlockQuotes/BlockQuotes_HardBreaks.txt
+++ b/tests/specs/BlockQuotes/BlockQuotes_HardBreaks.txt
@@ -1,0 +1,61 @@
+!! should keep the marker of a line whose only content is a hard break !!
+> \
+> bbb
+
+[expect]
+> \
+> bbb
+
+!! should keep the markers of nested block quotes !!
+>> \
+>> bbb
+
+[expect]
+>> \
+>> bbb
+
+!! should keep the marker of a block quote in a list item !!
+- > \
+  > bbb
+
+[expect]
+- > \
+  > bbb
+
+!! should keep the markers of a block quote in a list in a block quote !!
+> - > \
+>   > bar
+
+[expect]
+> - > \
+>   > bar
+
+!! should keep the marker of a hard break beside another one !!
+> aaa\
+> \
+> bbb
+
+[expect]
+> aaa\
+> \
+> bbb
+
+!! should keep the marker of a hard break that opens a later block !!
+> # h
+>
+> \
+> bbb
+
+[expect]
+> # h
+>
+> \
+> bbb
+
+!! should keep writing the marker where text comes before the hard break !!
+> aaa\
+> bbb
+
+[expect]
+> aaa\
+> bbb


### PR DESCRIPTION
```md
> \
> bbb
```

formats to

```md
\
> bbb
```

The first line loses its `>` entirely, so what was one block quote becomes a paragraph followed by a block quote. Formatting is not stable either — the result keeps changing on later passes.

`gen_block_quote` writes its markers in front of the text on each line, finding that text by looking for a `PrintItem::String` in the content's item stream. A hard break's text never appears there: `gen_hard_break` wraps it in a condition, because it becomes a space where newlines are forced off, and a condition's contents are invisible to anything rewriting the stream.

So the hard break now writes an empty, zero-width string of its own in front of that condition, standing in for the text it goes on to write. `gen_block_quote` is unchanged.

Fixed, and stable, in every shape I could construct:

| | before | after |
| --- | --- | --- |
| `> \` / `> bbb` | `\` / `> bbb` | unchanged |
| `>> \` / `>> bbb` | `\` / `>> bbb` | unchanged |
| `- > \` / `  > bbb` | `- \` / `  > bbb` | unchanged |
| `> - > \` / `>   > bar` | `> - \` / `>  > bar` | unchanged |
| `> aaa\` / `> \` / `> bbb` | `> aaa\` / `\` / `> bbb` | unchanged |
| `> # h` / `>` / `> \` / `> bbb` | `> # h` / `>` / `\` / `> bbb` | unchanged |

The last two are worth pointing out: a hard break beside another one, and one that opens a later block within the same quote, were also broken, and the second was not idempotent — a second pass turned one block quote into three separate top-level blocks.

I first fixed only the opening case, by walking the AST to see whether the content began with a hard break and letting `gen_block_quote` hang its opening marker off the condition. That covered less and needed more code, so this replaced it.

**Pre-existing, not addressed:** with `hardBreakKind: doubleSpace`, a hard break with no text before it can't be represented at all — `> \` / `> bbb` becomes `>   ` / `> bbb`, which reads back as no hard break, and reformats to `> bbb`. `main` loses it the same way. That's a modeling limit rather than a marker bug.