### PR TITLE
feat: add `codeBlock.indentWidth` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -155,6 +155,10 @@
         "description": "Formats the code within a code block using spaces."
       }]
     },
+    "codeBlock.indentWidth": {
+      "description": "The indentation width the plugin that formats the code within a code block should use, overriding that plugin's own `indentWidth` configuration. When not specified, that plugin's configuration is left alone.",
+      "type": "number"
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -213,6 +217,9 @@
     },
     "codeBlock.useTabs": {
       "$ref": "#/definitions/codeBlock.useTabs"
+    },
+    "codeBlock.indentWidth": {
+      "$ref": "#/definitions/codeBlock.indentWidth"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -125,6 +125,14 @@ impl ConfigurationBuilder {
     self.insert("codeBlock.useTabs", value.into())
   }
 
+  /// The indentation width the plugin that formats the code within a code
+  /// block should use, overriding that plugin's own `indentWidth`
+  /// configuration.
+  /// Default: not overridden
+  pub fn code_block_indent_width(&mut self, value: u8) -> &mut Self {
+    self.insert("codeBlock.indentWidth", (value as i32).into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -193,13 +201,14 @@ mod tests {
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
       .code_block_use_tabs(true)
+      .code_block_indent_width(2)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 17);
+    assert_eq!(inner_config.len(), 18);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }
@@ -236,6 +245,15 @@ mod tests {
 
     let config = ConfigurationBuilder::new().code_block_use_tabs(false).build();
     assert_eq!(config.code_block_use_tabs, Some(false));
+  }
+
+  #[test]
+  fn code_block_indent_width_only_set_when_specified() {
+    let config = ConfigurationBuilder::new().build();
+    assert_eq!(config.code_block_indent_width, None);
+
+    let config = ConfigurationBuilder::new().code_block_indent_width(2).build();
+    assert_eq!(config.code_block_indent_width, Some(2));
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -76,6 +76,7 @@ pub fn resolve_config(
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
     code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),
+    code_block_indent_width: get_nullable_value(&mut config, "codeBlock.indentWidth", &mut diagnostics),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -28,6 +28,10 @@ pub struct Configuration {
   /// formats the code within a code block. `None` leaves it to that plugin.
   #[serde(rename = "codeBlock.useTabs")]
   pub code_block_use_tabs: Option<bool>,
+  /// Whether to override the `indentWidth` configuration of the plugin that
+  /// formats the code within a code block. `None` leaves it to that plugin.
+  #[serde(rename = "codeBlock.indentWidth")]
+  pub code_block_indent_width: Option<u8>,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -85,6 +85,9 @@ impl SyncPluginHandler<Configuration> for MarkdownPluginHandler {
         if let Some(use_tabs) = config.code_block_use_tabs {
           additional_config.insert("useTabs".into(), use_tabs.into());
         }
+        if let Some(indent_width) = config.code_block_indent_width {
+          additional_config.insert("indentWidth".into(), (indent_width as i32).into());
+        }
         let request = SyncHostFormatRequest {
           file_path: &file_path,
           file_bytes: file_text.as_bytes(),


### PR DESCRIPTION
Follow-up to #232. Adds a `codeBlock.indentWidth` option that overrides the `indentWidth` configuration of the plugin formatting a code block.

Same tri-state shape as `codeBlock.useTabs`: when unspecified (the default), nothing is sent and the code block's plugin uses its own `indentWidth` configuration. When set, it's provided as an override config alongside `lineWidth` on the host format request.

This covers the last of the global config keys worth forwarding — `newLineKind` doesn't need one, since the formatted code is re-emitted line by line with the markdown file's own newline kind.