### PR TITLE
feat: add `maxBlankLines` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -202,6 +202,12 @@
     "listIndentKind": {
       "$ref": "#/definitions/listIndentKind"
     },
+    "maxBlankLines": {
+      "description": "The maximum number of consecutive blank lines to keep between blocks.",
+      "default": 1,
+      "minimum": 1,
+      "type": "number"
+    },
     "codeBlock.skipFormat": {
       "$ref": "#/definitions/codeBlock.skipFormat"
     },

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -97,6 +97,12 @@ impl ConfigurationBuilder {
     self.insert("listIndentKind", value.to_string().into())
   }
 
+  /// The maximum number of consecutive blank lines to keep between blocks.
+  /// Default: 1
+  pub fn max_blank_lines(&mut self, value: u32) -> &mut Self {
+    self.insert("maxBlankLines", (value as i32).into())
+  }
+
   /// Whether to leave the code within a code block as it was written rather
   /// than formatting it with the plugin that handles the code's language.
   /// Default: `false`
@@ -189,6 +195,7 @@ mod tests {
       .heading_kind(HeadingKind::Atx)
       .hard_break_kind(HardBreakKind::DoubleSpace)
       .list_indent_kind(ListIndentKind::PythonMarkdown)
+      .max_blank_lines(2)
       .code_block_skip_format(true)
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
@@ -199,7 +206,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 17);
+    assert_eq!(inner_config.len(), 18);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }
@@ -236,6 +243,18 @@ mod tests {
 
     let config = ConfigurationBuilder::new().code_block_use_tabs(false).build();
     assert_eq!(config.code_block_use_tabs, Some(false));
+  }
+
+  #[test]
+  fn max_blank_lines_below_one() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("maxBlankLines".into(), 0.into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].property_name, "maxBlankLines");
+    assert!(result.diagnostics[0].message.contains("at least 1"));
+    assert_eq!(result.config.max_blank_lines, 1);
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -72,6 +72,7 @@ pub fn resolve_config(
       ListIndentKind::CommonMark,
       &mut diagnostics,
     ),
+    max_blank_lines: get_max_blank_lines(&mut config, &mut diagnostics),
     code_block_skip_format: get_value(&mut config, "codeBlock.skipFormat", false, &mut diagnostics),
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
@@ -114,6 +115,20 @@ pub fn resolve_config(
     config: resolved_config,
     diagnostics,
   }
+}
+
+/// A block is always separated from the one above it by a blank line, so a
+/// maximum below one isn't something the formatter could ever stay under.
+fn get_max_blank_lines(config: &mut ConfigKeyMap, diagnostics: &mut Vec<ConfigurationDiagnostic>) -> u32 {
+  let value = get_value(config, "maxBlankLines", 1, diagnostics);
+  if value < 1 {
+    diagnostics.push(ConfigurationDiagnostic {
+      property_name: "maxBlankLines".to_string(),
+      message: "Expected a value of at least 1.".to_string(),
+    });
+    return 1;
+  }
+  value
 }
 
 fn get_tags(config: &mut ConfigKeyMap, diagnostics: &mut Vec<ConfigurationDiagnostic>) -> HashMap<String, String> {

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -18,6 +18,8 @@ pub struct Configuration {
   pub heading_kind: HeadingKind,
   pub hard_break_kind: HardBreakKind,
   pub list_indent_kind: ListIndentKind,
+  /// The maximum number of consecutive blank lines to keep between blocks.
+  pub max_blank_lines: u32,
   #[serde(rename = "codeBlock.skipFormat")]
   pub code_block_skip_format: bool,
   #[serde(rename = "codeBlock.preserveIndentation")]

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -218,7 +218,18 @@ impl<'a> Context<'a> {
   /// Whether the position at `index` is preceded by a blank line, accounting for
   /// the block quote markers that prefix a blank line inside a block quote.
   pub fn has_leading_blankline(&self, index: usize) -> bool {
-    has_leading_blankline(index, self.file_text, self.is_in_block_quote())
+    self.get_leading_blank_lines(index) > 0
+  }
+
+  /// The number of blank lines that precede the position at `index`, limited to
+  /// the configured maximum.
+  pub fn get_leading_blank_lines(&self, index: usize) -> u32 {
+    get_leading_blank_lines(
+      index,
+      self.file_text,
+      self.is_in_block_quote(),
+      self.configuration.max_blank_lines,
+    )
   }
 
   pub fn with_no_text_wrap<T>(&mut self, func: impl FnOnce(&mut Context) -> T) -> T {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -160,8 +160,8 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
                 items.extend(get_newline_wrapping_based_on_config(context));
               }
             } else if new_line_count > 1 {
-              items.push_signal(Signal::NewLine);
-              items.push_signal(Signal::NewLine);
+              let blank_lines = std::cmp::min(new_line_count - 1, context.configuration.max_blank_lines);
+              items.extend(get_blank_lines(blank_lines));
             } else {
               let needs_space = if let Node::Html(_) = last_node {
                 node.has_preceding_space(context.file_text)
@@ -190,11 +190,10 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
           Node::LinkReference(_) => {
             if matches!(node, Node::LinkReference(_)) {
               // definitions are kept on their own lines, with whatever blank
-              // line separated them in the file
-              if context.get_new_lines_in_range(last_node.span().end, node.span().start) > 1 {
-                items.push_signal(Signal::NewLine);
-              }
-              items.push_signal(Signal::NewLine);
+              // lines separated them in the file
+              let new_line_count = context.get_new_lines_in_range(last_node.span().end, node.span().start);
+              let blank_lines = std::cmp::min(new_line_count.saturating_sub(1), context.configuration.max_blank_lines);
+              items.extend(get_blank_lines(blank_lines));
             } else {
               items.extend(get_conditional_blank_line(node.span(), context));
             }
@@ -293,12 +292,11 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
   return items;
 
   fn get_conditional_blank_line(span: Span, context: &mut Context) -> PrintItems {
-    let mut items = PrintItems::new();
-    if !context.is_in_list() || context.has_leading_blankline(span.start) {
-      items.push_signal(Signal::NewLine);
-    }
-    items.push_signal(Signal::NewLine);
-    items
+    // within a list two blocks may sit on consecutive lines, which is what
+    // keeps the list tight. Everywhere else a blank line is what separates them
+    let minimum = if context.is_in_list() { 0 } else { 1 };
+    let blank_lines = std::cmp::max(context.get_leading_blank_lines(span.start), minimum);
+    get_blank_lines(blank_lines)
   }
 }
 
@@ -1690,10 +1688,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
     // generate items
     for (index, child) in list.children.iter().enumerate() {
       if index > 0 {
-        items.push_signal(Signal::NewLine);
-        if context.has_leading_blankline(child.span().start) {
-          items.push_signal(Signal::NewLine);
-        }
+        items.extend(get_blank_lines(context.get_leading_blank_lines(child.span().start)));
       }
       let prefix_text = if let Some(start_index) = list.start_index {
         let end_char = if is_alternate { ")" } else { "." };
@@ -1754,10 +1749,9 @@ fn gen_item(item: &Item, context: &mut Context) -> PrintItems {
   ));
 
   if !item.sub_lists.is_empty() {
-    items.push_signal(Signal::NewLine);
-    if context.has_leading_blankline(item.sub_lists.first().unwrap().span().start) {
-      items.push_signal(Signal::NewLine);
-    }
+    items.extend(get_blank_lines(
+      context.get_leading_blank_lines(item.sub_lists.first().unwrap().span().start),
+    ));
     items.extend(gen_nodes(&item.sub_lists, context));
   }
 
@@ -1770,10 +1764,7 @@ fn gen_definition_list(definition_list: &DefinitionList, context: &mut Context) 
 
     for (index, child) in definition_list.children.iter().enumerate() {
       if index > 0 {
-        items.push_signal(Signal::NewLine);
-        if context.has_leading_blankline(child.span().start) {
-          items.push_signal(Signal::NewLine);
-        }
+        items.extend(get_blank_lines(context.get_leading_blank_lines(child.span().start)));
       }
 
       items.extend(match child {
@@ -1856,10 +1847,9 @@ fn gen_task_list_marker_children(
 
   // insert the remaining children without indent
   if indent_child_index_end > 0 && indent_child_index_end != children.len() {
-    items.push_signal(Signal::NewLine);
-    if context.has_leading_blankline(children[indent_child_index_end].span().start) {
-      items.push_signal(Signal::NewLine);
-    }
+    items.extend(get_blank_lines(
+      context.get_leading_blank_lines(children[indent_child_index_end].span().start),
+    ));
   }
   items.extend(gen_nodes(&children[indent_child_index_end..], context));
   items
@@ -2167,6 +2157,15 @@ fn measure_longest_line_width(items: PrintItems, max_width: u32) -> usize {
     .map(|line| UnicodeWidthStr::width(line.trim_end_matches(WHITESPACE)))
     .max()
     .unwrap_or(0)
+}
+
+/// Ends the current line and writes `count` blank lines below it.
+fn get_blank_lines(count: u32) -> PrintItems {
+  let mut items = PrintItems::new();
+  for _ in 0..count + 1 {
+    items.push_signal(Signal::NewLine);
+  }
+  items
 }
 
 fn get_space_or_newline_based_on_config(context: &Context) -> PrintItems {

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -158,13 +158,14 @@ pub fn is_list_word(word: &str) -> bool {
   }
 }
 
-/// Whether the position at `index` is preceded by a blank line.
+/// The number of blank lines that precede the position at `index`, counting no
+/// further than `max` of them.
 ///
 /// When `in_block_quote` is `true`, the block quote markers (`>`) that prefix an
 /// otherwise blank line are skipped while scanning backwards. Without this a blank
 /// line inside a block quote (which is written as `>`) would not be recognized as
 /// blank because of the leading `>` character.
-pub fn has_leading_blankline(index: usize, text: &str, in_block_quote: bool) -> bool {
+pub fn get_leading_blank_lines(index: usize, text: &str, in_block_quote: bool, max: u32) -> u32 {
   let mut newline_count = 0;
   // whether the character to the right of this one was a newline, which makes
   // a carriage return here the start of the line ending it already counted
@@ -174,8 +175,11 @@ pub fn has_leading_blankline(index: usize, text: &str, in_block_quote: bool) -> 
     after_newline = c == '\n';
     if ends_line {
       newline_count += 1;
-      if newline_count >= 2 {
-        return true;
+      // the first line ending found is the one the line above ends with
+      // rather than a blank line, so it takes one more than `max` of them
+      // before the maximum is passed
+      if newline_count > max {
+        break;
       }
     } else if c == '\r' {
       continue;
@@ -187,7 +191,7 @@ pub fn has_leading_blankline(index: usize, text: &str, in_block_quote: bool) -> 
       break;
     }
   }
-  false
+  newline_count.saturating_sub(1)
 }
 
 pub fn file_has_ignore_file_directive(file_text: &str, directive_inner_text: &str) -> bool {

--- a/tests/specs/General/MaxBlankLines.txt
+++ b/tests/specs/General/MaxBlankLines.txt
@@ -1,0 +1,245 @@
+~~ maxBlankLines: 2 ~~
+!! should keep up to the maximum number of blank lines between paragraphs !!
+a
+
+b
+
+
+c
+
+
+
+d
+
+[expect]
+a
+
+b
+
+
+c
+
+
+d
+
+!! should keep the blank lines between blocks of different kinds !!
+# heading
+
+
+
+text
+
+
+
+```
+code
+```
+
+
+
+> quote
+
+[expect]
+# heading
+
+
+text
+
+
+```
+code
+```
+
+
+> quote
+
+!! should keep the blank lines between the items of a list !!
+- a
+
+
+- b
+  - c
+
+
+  - d
+
+[expect]
+- a
+
+
+- b
+  - c
+
+
+  - d
+
+!! should keep the blank lines within a block quote !!
+> a
+>
+>
+> b
+>
+>
+>
+> c
+
+[expect]
+> a
+>
+>
+> b
+>
+>
+> c
+
+!! should keep the blank lines between link reference definitions !!
+[a]: /a
+
+
+[b]: /b
+
+
+
+[c]: /c
+
+[expect]
+[a]: /a
+
+
+[b]: /b
+
+
+[c]: /c
+
+!! should keep the blank lines between html blocks !!
+<div></div>
+
+
+<div></div>
+
+
+
+<div></div>
+
+[expect]
+<div></div>
+
+
+<div></div>
+
+
+<div></div>
+
+!! should keep the blank lines between the terms of a definition list !!
+a
+
+: b
+
+
+c
+
+: d
+
+[expect]
+a
+
+: b
+
+
+c
+
+: d
+
+!! should keep the blank lines between the blocks within a list item !!
+- a
+
+
+  b
+
+
+  ```
+  code
+  ```
+
+- c
+
+[expect]
+- a
+
+
+  b
+
+
+  ```
+  code
+  ```
+
+- c
+
+!! should remove the blank lines at the start and end of the file !!
+
+
+
+a
+
+
+
+[expect]
+a
+
+!! should keep the blank lines around a table !!
+| a |
+| - |
+| b |
+
+
+text
+
+[expect]
+| a |
+| - |
+| b |
+
+
+text
+
+!! should keep the blank lines between the children of a task list item !!
+- [ ] a
+
+
+  b
+
+[expect]
+- [ ] a
+
+
+  b
+
+!! should keep the blank lines within a footnote definition !!
+[^1]: a
+
+
+    b
+
+[expect]
+[^1]: a
+
+
+    b
+
+!! should keep the blank lines below a yaml header !!
+---
+a: b
+---
+
+
+
+# heading
+
+[expect]
+---
+a: b
+---
+
+
+# heading


### PR DESCRIPTION
Closes #164

Adds a `maxBlankLines` option (number, default `1`) that caps how many consecutive blank lines are kept between blocks, rather than always collapsing them down to a single one. A value below 1 gets a configuration diagnostic and falls back to 1, since a block is always separated from the one above it by a blank line.

`get_leading_blank_lines` replaces `has_leading_blankline` in `generation/utils.rs`, counting the blank lines above a position and stopping at the configured maximum. A `get_blank_lines` helper then writes that many, and every place that separated two siblings with a blank line goes through it: the blank line between two blocks, the one between html blocks within a paragraph, link reference definitions, list items, definition list items, sub lists, and the children of a task list item.

This only covers the blank lines between blocks — the ones inside a fenced code block are still up to `codeBlock.preserveBlankLines`, and the ones at the start and end of the file are still removed.

Specs cover paragraphs, blocks of different kinds, list items, nested lists, block quotes (where the blank lines keep their `>` markers), link reference definitions, html blocks, definition lists, the blocks within a list item, tables, task list items, footnote definitions, and yaml headers.
