### PR TITLE
fix: don't underline a setext heading whose text begins a block

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -52,14 +52,13 @@ impl<'a> Node<'a> {
     self.first_word().is_some_and(crate::generation::utils::is_list_word)
   }
 
-  /// Whether the node is text that would start a new block if it were moved to
-  /// the start of a line, which the formatter can't do to it.
-  pub fn starts_block_in_paragraph(&self) -> bool {
+  /// Whether the node would begin a block of its own where a block begins,
+  /// rather than being read as the paragraph it's written as (ex. the text a
+  /// setext heading's underline is written below).
+  pub fn starts_block_at_block_start(&self) -> bool {
     match self {
-      Node::Text(text) => crate::parser::starts_block_in_paragraph(text.text),
-      // a block of html already stands on its own, so nothing about where it
-      // is written can turn it into one
-      Node::Html(html) => !html.is_block && crate::parser::starts_block_in_paragraph(&html.text),
+      Node::Text(text) => crate::parser::starts_block_at_block_start(text.text),
+      Node::Html(html) => !html.is_block && crate::parser::starts_block_at_block_start(&html.text),
       _ => false,
     }
   }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -306,13 +306,14 @@ fn gen_heading(heading: &Heading, context: &mut Context) -> PrintItems {
   // setext headings only apply to level 1 and level 2, and only where the text
   // they underline reads as the paragraph a heading is made of -- an html
   // comment at the start of a line is a block of its own, which nothing can
-  // underline
+  // underline. The heading's text begins a block rather than interrupting one,
+  // so it's what a block start reads that decides this
   if heading.level < 3
     && context.configuration.heading_kind == HeadingKind::Setext
     && !heading
       .children
       .first()
-      .is_some_and(|child| child.starts_block_in_paragraph())
+      .is_some_and(|child| child.starts_block_at_block_start())
   {
     let children = gen_nodes(&heading.children, context);
     let (children, cloned_children) = clone_items(children);

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -880,6 +880,47 @@ pub fn starts_block_in_paragraph(text: &str) -> bool {
   }
 }
 
+/// Whether the text would begin a block of its own where a block begins,
+/// rather than being read as the paragraph it's written as.
+///
+/// This is stricter than what can interrupt a paragraph, which is what
+/// [`starts_block_in_paragraph`] answers: a complete html tag opens a block
+/// where one begins, a list marker opens a list whatever it counts from and
+/// with nothing written after it, and a link reference definition is read as
+/// one rather than as text.
+pub fn starts_block_at_block_start(text: &str) -> bool {
+  if starts_block_in_paragraph(text) {
+    return true;
+  }
+  let text = text.trim_start_matches([' ', '\t']);
+  match text.as_bytes().first() {
+    None => false,
+    Some(b'<') => html_block_kind(text, false).is_some(),
+    Some(b'[') => opens_link_reference_definition(text),
+    Some(_) => list_marker(text).is_some(),
+  }
+}
+
+/// Whether the text opens with a link label followed by the colon that makes
+/// it a definition, which is as much of one as has to be read to know that the
+/// line isn't the paragraph it would otherwise be.
+fn opens_link_reference_definition(text: &str) -> bool {
+  let mut is_escaped = false;
+  for (index, character) in text.char_indices().skip(1) {
+    if is_escaped {
+      is_escaped = false;
+      continue;
+    }
+    match character {
+      '\\' => is_escaped = true,
+      ']' => return text[index + 1..].starts_with(':'),
+      '\n' => return false,
+      _ => {}
+    }
+  }
+  false
+}
+
 /// Where a backslash has to be written for the text not to start a block of its
 /// own, when the text is written where a block starts.
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,6 +26,7 @@ pub use ast::*;
 
 pub use block::block_start_escape;
 pub use block::line_start_escape;
+pub use block::starts_block_at_block_start;
 pub use block::starts_block_in_paragraph;
 pub use source::SPACES;
 pub use source::WHITESPACE;

--- a/tests/specs/headers/Headers_Setext_BlockStarts.txt
+++ b/tests/specs/headers/Headers_Setext_BlockStarts.txt
@@ -1,0 +1,42 @@
+~~ headingKind: setext ~~
+!! should not underline html, which begins a block of its own !!
+# <a>
+
+## <a href="y">
+
+[expect]
+# <a>
+
+## <a href="y">
+
+!! should not underline a list marker, which counts from anywhere where a block begins !!
+# 6. x
+
+## 6. x
+
+# - item
+
+[expect]
+# 6. x
+
+## 6. x
+
+# - item
+
+!! should not underline a link reference definition !!
+# [a]: /u
+
+[expect]
+# [a]: /u
+
+!! should still underline text that only looks like one of them !!
+# [a]
+
+# not: a definition
+
+[expect]
+[a]
+===
+
+not: a definition
+=================


### PR DESCRIPTION
With `headingKind: setext`, a heading whose text would begin a block of its own is silently lost:

```md
# <a>
```
```md
<a>
===
```

which reads back as an html block above a paragraph — no heading. Reformatting with `headingKind: atx` confirms it: the `#` never comes back. The same happens for a list marker counting from anything but one (`# 6. x` → `6. x` above `====`, which is a list item whose text swallows the underline), and for a link reference definition (`# [a]: /u`).

A setext heading's text is written **where a block begins**, but whether it could be underlined was decided by `starts_block_in_paragraph` — what can *interrupt* a paragraph, which is a weaker rule. Three things only a block start reads:

| | interrupts a paragraph | begins a block |
| --- | --- | --- |
| `<a>` (a complete tag) | no | yes, html block type 7 |
| `6. x` | no, an ordered list must count from 1 | yes |
| `[a]: /u` | no | yes, a definition |

So the parser gained `starts_block_at_block_start`, which is `starts_block_in_paragraph` plus those three. `Node::starts_block_in_paragraph` had no other caller and is gone.

Across 1200 generated documents of headings at all three levels over 21 kinds of leading text, `main` loses the heading in **300**; this branch loses **none**, and the 300 differing outputs are exactly those.

Text that only looks like one of them is still underlined:

```md
# [a]
# not: a definition
```
```md
[a]
===

not: a definition
=================
```