### PR TITLE
fix: read a line break between scripts written without spaces through a link

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -7,8 +7,6 @@ pub trait NodeSurroundings {
   fn has_preceding_whitespace(&self, file_text: &str) -> bool;
   fn starts_with_punctuation(&self, file_text: &str) -> bool;
   fn ends_with_punctuation(&self, file_text: &str) -> bool;
-  fn starts_with_unspaced_script(&self, file_text: &str) -> bool;
-  fn ends_with_unspaced_script(&self, file_text: &str) -> bool;
 }
 
 impl<T: Ranged> NodeSurroundings for T {
@@ -31,21 +29,59 @@ impl<T: Ranged> NodeSurroundings for T {
   fn ends_with_punctuation(&self, file_text: &str) -> bool {
     matches!(self.span().text(file_text).chars().last(), Some(c) if c.is_ascii_punctuation())
   }
-
-  /// Whether the node begins with a character of a script written without
-  /// spaces between its words.
-  fn starts_with_unspaced_script(&self, file_text: &str) -> bool {
-    matches!(self.span().text(file_text).chars().next(), Some(c) if crate::generation::utils::is_unspaced_script(c))
-  }
-
-  /// Whether the node ends with a character of a script written without spaces
-  /// between its words.
-  fn ends_with_unspaced_script(&self, file_text: &str) -> bool {
-    matches!(self.span().text(file_text).chars().last(), Some(c) if crate::generation::utils::is_unspaced_script(c))
-  }
 }
 
 impl<'a> Node<'a> {
+  /// The first character of the node that a reader sees, which is what the
+  /// whitespace before the node reads against.
+  ///
+  /// The delimiters a node is written with (ex. the `[` and `](url)` around a
+  /// link) say how it's read rather than being read themselves, so they're
+  /// looked through to the text within them. A node that isn't read as text of
+  /// its own (ex. an image, which stands in the line as a picture) has none,
+  /// and so does a link whose text begins with one -- what's read there is the
+  /// text of that node, not of the one after it.
+  ///
+  /// Emphasis and the rest of the text decorations are not looked through:
+  /// which character delimits one is chosen from the whitespace beside it, so
+  /// taking that whitespace away would leave a delimiter that no longer reads
+  /// as one.
+  pub fn first_read_char(&self) -> Option<char> {
+    match self {
+      Node::Text(node) => node.text.chars().next(),
+      Node::Code(node) => node.code.chars().next(),
+      Node::InlineLink(node) => node.children.first().and_then(|child| child.first_read_char()),
+      Node::ReferenceLink(node) => node.children.first().and_then(|child| child.first_read_char()),
+      Node::ShortcutLink(node) => node.children.first().and_then(|child| child.first_read_char()),
+      _ => None,
+    }
+  }
+
+  /// The last character of the node that a reader sees, which is what the
+  /// whitespace after the node reads against. See [`Self::first_read_char`].
+  pub fn last_read_char(&self) -> Option<char> {
+    match self {
+      Node::Text(node) => node.text.chars().last(),
+      Node::Code(node) => node.code.chars().last(),
+      Node::InlineLink(node) => node.children.last().and_then(|child| child.last_read_char()),
+      Node::ReferenceLink(node) => node.children.last().and_then(|child| child.last_read_char()),
+      Node::ShortcutLink(node) => node.children.last().and_then(|child| child.last_read_char()),
+      _ => None,
+    }
+  }
+
+  /// Whether the character the node begins with belongs to a script written
+  /// without spaces between its words.
+  pub fn starts_with_unspaced_script(&self) -> bool {
+    matches!(self.first_read_char(), Some(c) if crate::generation::utils::is_unspaced_script(c))
+  }
+
+  /// Whether the character the node ends with belongs to a script written
+  /// without spaces between its words.
+  pub fn ends_with_unspaced_script(&self) -> bool {
+    matches!(self.last_read_char(), Some(c) if crate::generation::utils::is_unspaced_script(c))
+  }
+
   /// Whether the node is text that starts with a word that would become a list
   /// marker if it were moved to the start of a line.
   pub fn starts_with_list_word(&self) -> bool {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -152,8 +152,9 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
                 items.push_space();
               } else if matches!(node, Node::Html(_)) {
                 items.push_signal(Signal::NewLine);
-              } else if last_node.ends_with_unspaced_script(context.file_text)
-                && node.starts_with_unspaced_script(context.file_text)
+              } else if last_node.ends_with_unspaced_script()
+                && node.starts_with_unspaced_script()
+                && can_be_written_beside(last_node, node, context.file_text)
               {
                 items.extend(get_unspaced_script_newline_wrapping(context));
               } else {
@@ -2200,6 +2201,18 @@ fn space() -> PrintItems {
   let mut items = PrintItems::new();
   items.push_space();
   items
+}
+
+/// Whether the two nodes can be written directly beside each other without
+/// what they're written with running together into something else (ex. the
+/// `]` of one link meeting the `[` of the next and reading as a reference).
+///
+/// Only the characters actually written count here, rather than the ones a
+/// reader sees: it's the delimiters that would end up side by side.
+fn can_be_written_beside(last_node: &Node, node: &Node, file_text: &str) -> bool {
+  let last = last_node.span().text(file_text).chars().last();
+  let next = node.span().text(file_text).chars().next();
+  !matches!((last, next), (Some(last), Some(next)) if last.is_ascii_punctuation() && next.is_ascii_punctuation())
 }
 
 /// What takes the place of a line break that falls between two characters of

--- a/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
@@ -1,0 +1,79 @@
+~~ textWrap: never ~~
+!! should drop a line break between a link and such a script !!
+[日](https://dprint.dev)
+日本語
+
+日本語
+[日](https://dprint.dev)
+
+[expect]
+[日](https://dprint.dev)日本語
+
+日本語[日](https://dprint.dev)
+
+!! should drop a line break between a code span and such a script !!
+`日`
+日本語
+
+日本語
+`日`
+
+[expect]
+`日`日本語
+
+日本語`日`
+
+!! should keep the line break beside an image, which isn't read as text !!
+![日](https://dprint.dev/a.png)
+日本語
+
+[expect]
+![日](https://dprint.dev/a.png) 日本語
+
+!! should keep the line break beside a text decoration, whose delimiter is chosen from the whitespace around it !!
+日本語
+*テスト*
+
+実行**します**
+そして次へ
+
+[expect]
+日本語 _テスト_
+
+実行**します** そして次へ
+
+!! should keep the line break where the delimiters would run together !!
+**日本語**
+**テスト**
+
+`日本語`
+`テスト`
+
+[expect]
+**日本語** **テスト**
+
+`日本語` `テスト`
+
+!! should keep the line break where a link's text begins or ends with something not read as text !!
+日本語
+[*a*日](https://dprint.dev)
+
+[日*a*](https://dprint.dev)
+日本語
+
+日本語
+[![i](https://dprint.dev/a.png)日](https://dprint.dev)
+
+[expect]
+日本語 [*a*日](https://dprint.dev)
+
+[日*a*](https://dprint.dev) 日本語
+
+日本語 [![i](https://dprint.dev/a.png)日](https://dprint.dev)
+
+!! should keep the line break beside an autolink, whose text is a url rather than prose !!
+日本語
+<https://例え.jp>
+
+[expect]
+日本語 <https://例え.jp>


### PR DESCRIPTION
#230 drops a line break between two characters of a script written without word separators, as [line-break-transform](https://drafts.csswg.org/css-text-4/#line-break-transform) requires. It reads the characters a node is *written* with, though, and every inline node's span includes its delimiters — so the character it saw was `)`, `` ` `` or `]`, never CJK:

```md
日本語        →  日本語日本語                  ✓
日本語

日本語        →  日本語 [日](https://a.com)    ✗ a space CSS says to remove
[日](https://a.com)
```

A link's and a code span's delimiters are now looked through to the text within them.

### Three things are deliberately left alone

**Text decorations.** Looking through them destroys emphasis, and silently:

```md
日本語     →  日本語_テスト_
*テスト*
```

`decoration_delimiter` picks `_` over `*` because the character before the node *in the source* is a newline — the very newline the join then removes. The underscores end up intraword, where they don't read as delimiters at all, and reformatting with `emphasisKind: asterisks` leaves them as literal underscores. There's a second, independent version: a closing `**` preceded by punctuation (`**日本、**`) stops being right-flanking once a letter follows it instead of whitespace. Fixing either means teaching delimiter selection to use written rather than source adjacency, which belongs in its own change.

**Autolinks**, whose text is a URL rather than prose. A URI autolink's first character is always an ASCII scheme letter, so this only ever reached the tail of an IDN URL.

**Anything that would run together.** `can_be_written_beside` refuses the join when both nodes' written boundary characters are ASCII punctuation, so `**日本語**` above `**テスト**` can't become `**日本語****テスト**`, and two code spans can't merge their backticks. Since a Text node's read character *is* its written character, this reduces to "at least one side is plain text", which leaves only pairs like `CJK│[` and `)│CJK` — none of which change a parse.

The character read for a link is the one its **first or last child** reads, not the first child that reads one at all: the text of `[*a*日](url)` begins with `a`, so the break beside it has to stay.

### Verification

Every ordered pair of 29 inline pieces (links whose text starts or ends with a decoration, image, math or code span; reference and shortcut links; code spans with and without padding spaces; autolinks; escapes; fullwidth punctuation) at three configs — 2523 comparisons — rendered through the `commonmark` reference implementation and compared against the source's rendering:

| | main | this branch | branch only |
| --- | --- | --- | --- |
| rendered structure differs | 0 | 0 | **0** |
| rendered text differs | 338 | 218 | **0** |

No parse ever changes, and the branch never changes the rendered text where main didn't — it fixes 120 cases where main did.