### PR TITLE
feat: add `textWrap: "sentence"` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -34,6 +34,9 @@
       }, {
         "const": "never",
         "description": "Never wraps text."
+      }, {
+        "const": "sentence",
+        "description": "Writes one sentence per line, ignoring the line width."
       }]
     },
     "emphasisKind": {

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -54,9 +54,22 @@ pub enum TextWrap {
   Maintain,
   /// Never wraps text.
   Never,
+  /// Writes one sentence per line, ignoring the line width.
+  ///
+  /// This is the part of [semantic line breaks](https://sembr.org/) that can be
+  /// applied without knowing what the text means: a line break is written where
+  /// a sentence ends and nowhere else, which keeps a diff to the sentences that
+  /// were edited.
+  Sentence,
 }
 
-generate_str_to_from![TextWrap, [Always, "always"], [Maintain, "maintain"], [Never, "never"]];
+generate_str_to_from![
+  TextWrap,
+  [Always, "always"],
+  [Maintain, "maintain"],
+  [Never, "never"],
+  [Sentence, "sentence"]
+];
 
 /// The character to use for emphasis/italics.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]

--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -7,8 +7,6 @@ pub trait NodeSurroundings {
   fn has_preceding_whitespace(&self, file_text: &str) -> bool;
   fn starts_with_punctuation(&self, file_text: &str) -> bool;
   fn ends_with_punctuation(&self, file_text: &str) -> bool;
-  fn ends_sentence(&self, file_text: &str) -> bool;
-  fn starts_sentence(&self, file_text: &str) -> bool;
 }
 
 impl<T: Ranged> NodeSurroundings for T {
@@ -30,17 +28,6 @@ impl<T: Ranged> NodeSurroundings for T {
 
   fn ends_with_punctuation(&self, file_text: &str) -> bool {
     matches!(self.span().text(file_text).chars().last(), Some(c) if c.is_ascii_punctuation())
-  }
-
-  /// Whether a sentence ends with this node, which is where a line break is
-  /// written when text is wrapped by sentence.
-  fn ends_sentence(&self, file_text: &str) -> bool {
-    crate::generation::utils::ends_sentence(self.span().text(file_text))
-  }
-
-  /// Whether the node could begin a sentence.
-  fn starts_sentence(&self, file_text: &str) -> bool {
-    crate::generation::utils::starts_sentence(self.span().text(file_text))
   }
 }
 
@@ -93,6 +80,55 @@ impl<'a> Node<'a> {
   /// without spaces between its words.
   pub fn ends_with_unspaced_script(&self) -> bool {
     matches!(self.last_read_char(), Some(c) if crate::generation::utils::is_unspaced_script(c))
+  }
+
+  /// Whether a sentence ends with this node, which is where a line break is
+  /// written when text is wrapped by sentence.
+  pub fn ends_sentence(&self) -> bool {
+    self
+      .last_read_text()
+      .is_some_and(crate::generation::utils::ends_sentence)
+  }
+
+  /// Whether the node could begin a sentence.
+  pub fn starts_sentence(&self) -> bool {
+    self
+      .first_read_text()
+      .is_some_and(crate::generation::utils::starts_sentence)
+  }
+
+  /// The text the node begins with that a reader sees, which is what tells
+  /// whether a sentence could begin with it.
+  ///
+  /// The delimiters a node is written with are looked through the way
+  /// [`Self::first_read_char`] looks through them, and so are the text
+  /// decorations: which character delimits one says nothing about the sentence
+  /// written within it, so a sentence that begins in emphasis (ex. `**Done.**`)
+  /// begins where its text does.
+  fn first_read_text(&self) -> Option<&str> {
+    match self {
+      Node::Text(node) => Some(node.text),
+      Node::Code(node) => Some(&node.code),
+      Node::TextDecoration(node) => node.children.first().and_then(|child| child.first_read_text()),
+      Node::InlineLink(node) => node.children.first().and_then(|child| child.first_read_text()),
+      Node::ReferenceLink(node) => node.children.first().and_then(|child| child.first_read_text()),
+      Node::ShortcutLink(node) => node.children.first().and_then(|child| child.first_read_text()),
+      _ => None,
+    }
+  }
+
+  /// The text the node ends with that a reader sees, which is what tells
+  /// whether a sentence ends with it. See [`Self::first_read_text`].
+  fn last_read_text(&self) -> Option<&str> {
+    match self {
+      Node::Text(node) => Some(node.text),
+      Node::Code(node) => Some(&node.code),
+      Node::TextDecoration(node) => node.children.last().and_then(|child| child.last_read_text()),
+      Node::InlineLink(node) => node.children.last().and_then(|child| child.last_read_text()),
+      Node::ReferenceLink(node) => node.children.last().and_then(|child| child.last_read_text()),
+      Node::ShortcutLink(node) => node.children.last().and_then(|child| child.last_read_text()),
+      _ => None,
+    }
   }
 
   /// Whether the node is text that starts with a word that would become a list

--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -46,29 +46,13 @@ impl<'a> Node<'a> {
   /// whitespace beside it is taken away is decided separately, since which
   /// character delimits it is chosen by what ends up written against it.
   pub fn first_read_char(&self) -> Option<char> {
-    match self {
-      Node::Text(node) => node.text.chars().next(),
-      Node::Code(node) => node.code.chars().next(),
-      Node::TextDecoration(node) => node.children.first().and_then(|child| child.first_read_char()),
-      Node::InlineLink(node) => node.children.first().and_then(|child| child.first_read_char()),
-      Node::ReferenceLink(node) => node.children.first().and_then(|child| child.first_read_char()),
-      Node::ShortcutLink(node) => node.children.first().and_then(|child| child.first_read_char()),
-      _ => None,
-    }
+    self.first_read_text().and_then(|text| text.chars().next())
   }
 
   /// The last character of the node that a reader sees, which is what the
   /// whitespace after the node reads against. See [`Self::first_read_char`].
   pub fn last_read_char(&self) -> Option<char> {
-    match self {
-      Node::Text(node) => node.text.chars().last(),
-      Node::Code(node) => node.code.chars().last(),
-      Node::TextDecoration(node) => node.children.last().and_then(|child| child.last_read_char()),
-      Node::InlineLink(node) => node.children.last().and_then(|child| child.last_read_char()),
-      Node::ReferenceLink(node) => node.children.last().and_then(|child| child.last_read_char()),
-      Node::ShortcutLink(node) => node.children.last().and_then(|child| child.last_read_char()),
-      _ => None,
-    }
+    self.last_read_text().and_then(|text| text.chars().next_back())
   }
 
   /// Whether the character the node begins with belongs to a script written
@@ -98,14 +82,9 @@ impl<'a> Node<'a> {
       .is_some_and(crate::generation::utils::starts_sentence)
   }
 
-  /// The text the node begins with that a reader sees, which is what tells
-  /// whether a sentence could begin with it.
-  ///
-  /// The delimiters a node is written with are looked through the way
-  /// [`Self::first_read_char`] looks through them, and so are the text
-  /// decorations: which character delimits one says nothing about the sentence
-  /// written within it, so a sentence that begins in emphasis (ex. `**Done.**`)
-  /// begins where its text does.
+  /// The text the node begins with that a reader sees, which
+  /// [`Self::first_read_char`] reads its character from and which tells whether
+  /// a sentence could begin with the node.
   fn first_read_text(&self) -> Option<&str> {
     match self {
       Node::Text(node) => Some(node.text),
@@ -118,8 +97,8 @@ impl<'a> Node<'a> {
     }
   }
 
-  /// The text the node ends with that a reader sees, which is what tells
-  /// whether a sentence ends with it. See [`Self::first_read_text`].
+  /// The text the node ends with that a reader sees. See
+  /// [`Self::first_read_text`].
   fn last_read_text(&self) -> Option<&str> {
     match self {
       Node::Text(node) => Some(node.text),

--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -9,6 +9,8 @@ pub trait NodeSurroundings {
   fn ends_with_punctuation(&self, file_text: &str) -> bool;
   fn starts_with_unspaced_script(&self, file_text: &str) -> bool;
   fn ends_with_unspaced_script(&self, file_text: &str) -> bool;
+  fn ends_sentence(&self, file_text: &str) -> bool;
+  fn starts_sentence(&self, file_text: &str) -> bool;
 }
 
 impl<T: Ranged> NodeSurroundings for T {
@@ -30,6 +32,17 @@ impl<T: Ranged> NodeSurroundings for T {
 
   fn ends_with_punctuation(&self, file_text: &str) -> bool {
     matches!(self.span().text(file_text).chars().last(), Some(c) if c.is_ascii_punctuation())
+  }
+
+  /// Whether a sentence ends with this node, which is where a line break is
+  /// written when text is wrapped by sentence.
+  fn ends_sentence(&self, file_text: &str) -> bool {
+    crate::generation::utils::ends_sentence(self.span().text(file_text))
+  }
+
+  /// Whether the node could begin a sentence.
+  fn starts_sentence(&self, file_text: &str) -> bool {
+    crate::generation::utils::starts_sentence(self.span().text(file_text))
   }
 
   /// Whether the node begins with a character of a script written without

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -155,9 +155,15 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               } else if last_node.ends_with_unspaced_script(context.file_text)
                 && node.starts_with_unspaced_script(context.file_text)
               {
-                items.extend(get_unspaced_script_newline_wrapping(context));
+                items.extend(get_unspaced_script_newline_wrapping(
+                  context,
+                  sentence_ends_between(last_node, node, context),
+                ));
               } else {
-                items.extend(get_newline_wrapping_based_on_config(context));
+                items.extend(get_newline_wrapping_based_on_config(
+                  context,
+                  sentence_ends_between(last_node, node, context),
+                ));
               }
             } else if new_line_count > 1 {
               let blank_lines = std::cmp::min(new_line_count - 1, context.configuration.max_blank_lines);
@@ -184,7 +190,10 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
                   // line, so it has to be kept off one
                   items.push_space();
                 } else {
-                  items.extend(get_space_or_newline_based_on_config(context));
+                  items.extend(get_space_or_newline_based_on_config(
+                    context,
+                    sentence_ends_between(last_node, node, context),
+                  ));
                 }
               }
             }
@@ -806,7 +815,7 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
       } else if was_last_newline {
         items.push_signal(Signal::NewLine);
       } else {
-        items.extend(get_space_or_newline_based_on_config(context));
+        items.extend(get_space_or_newline_based_on_config(context, false));
       }
     }
     items.push_string(std::mem::take(word));
@@ -929,7 +938,16 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
         // break that would read as nothing
         return space();
       }
-      get_space_or_newline_based_on_config(self.context)
+      get_space_or_newline_based_on_config(self.context, self.sentence_ends_before(next_word_start, next_word))
+    }
+
+    /// Whether a sentence ends at the space that ran up to the next word,
+    /// which is where a line break is written when text is wrapped by
+    /// sentence.
+    fn sentence_ends_before(&self, next_word_start: usize, next_word: &str) -> bool {
+      self.context.configuration.text_wrap == TextWrap::Sentence
+        && utils::ends_sentence(&self.text[..next_word_start])
+        && utils::starts_sentence(next_word)
     }
 
     /// Whether the space sits between two characters of a script written
@@ -1429,8 +1447,11 @@ fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
   if let Some(line) = lines.next() {
     items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
   }
+  // raw text isn't prose, so a sentence within it says nothing about where its
+  // line breaks belong -- the ones it was written with are kept
+  let keeps_its_breaks = context.configuration.text_wrap == TextWrap::Sentence;
   for line in lines {
-    items.extend(get_newline_wrapping_based_on_config(context));
+    items.extend(get_newline_wrapping_based_on_config(context, keeps_its_breaks));
     // the printer provides the indentation and block quote markers of a
     // continued line, so drop the ones this picked up from the file
     let line = strip_block_quote_markers(line, context);
@@ -1451,6 +1472,29 @@ fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
   line
 }
 
+/// Writes the word, breaking it up at the sentences that end within it.
+///
+/// A run of a script written without spaces between its words holds no space
+/// for the sentences in it to be separated at, so without this they would be
+/// written on the one line however many of them there were.
+fn gen_word_with_sentence_breaks(word: String) -> PrintItems {
+  let mut items = PrintItems::new();
+  let mut segment_start = 0;
+  let mut last_char: Option<char> = None;
+  for (index, character) in word.char_indices() {
+    if matches!(last_char, Some(last) if utils::ends_unspaced_script_sentence(last))
+      && !utils::forbids_line_break_before(character)
+    {
+      items.extend(gen_text_with_tabs(word[segment_start..index].to_string()));
+      items.extend(new_line_or_nothing_if_newlines_disabled());
+      segment_start = index;
+    }
+    last_char = Some(character);
+  }
+  items.extend(gen_text_with_tabs(word[segment_start..].to_string()));
+  items
+}
+
 /// Writes the word, breaking it up where a line can be broken within a script
 /// written without spaces between its words.
 ///
@@ -1459,6 +1503,9 @@ fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
 /// break with one of its characters on either side can be written: anywhere
 /// else the break would be read back as a space that wasn't written.
 fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> PrintItems {
+  if context.configuration.text_wrap == TextWrap::Sentence && !context.is_text_wrap_disabled() {
+    return gen_word_with_sentence_breaks(word);
+  }
   if context.configuration.text_wrap != TextWrap::Always || context.is_text_wrap_disabled() {
     return gen_text_with_tabs(word);
   }
@@ -2180,20 +2227,57 @@ fn get_blank_lines(count: u32) -> PrintItems {
   items
 }
 
+/// Whether a sentence ends between the two nodes, which is where a line break
+/// is written when text is wrapped by sentence.
+fn sentence_ends_between(last_node: &Node, node: &Node, context: &Context) -> bool {
+  context.configuration.text_wrap == TextWrap::Sentence
+    && last_node.ends_sentence(context.file_text)
+    && node.starts_sentence(context.file_text)
+}
+
 /// Whether the text after a word can be wrapped onto the line below it, which
 /// is what would leave the word by itself on a line of its own.
 fn text_can_be_wrapped_away(context: &Context) -> bool {
   context.configuration.text_wrap == TextWrap::Always && !context.is_text_wrap_disabled()
 }
 
-fn get_space_or_newline_based_on_config(context: &Context) -> PrintItems {
+fn get_space_or_newline_based_on_config(context: &Context, ends_sentence: bool) -> PrintItems {
   if context.is_text_wrap_disabled() {
     return space();
   }
   match context.configuration.text_wrap {
     TextWrap::Always => Signal::SpaceOrNewLine.into(),
-    TextWrap::Never | TextWrap::Maintain => space(),
+    TextWrap::Sentence if ends_sentence => new_line_or_space_if_newlines_disabled(),
+    TextWrap::Sentence | TextWrap::Never | TextWrap::Maintain => space(),
   }
+}
+
+/// A line break, written as nothing where newlines are being forced off
+/// (ex. within a heading).
+///
+/// This is what separates the sentences of a script written without spaces
+/// between its words, where a line break reads as nothing and a space would
+/// read as a space that wasn't written.
+fn new_line_or_nothing_if_newlines_disabled() -> PrintItems {
+  if_true_or(
+    "newLineIfNewlinesEnabled",
+    condition_resolvers::is_forcing_no_newlines(),
+    PrintItems::new(),
+    Signal::NewLine.into(),
+  )
+  .into()
+}
+
+/// A line break, written as a space where newlines are being forced off
+/// (ex. within a heading).
+fn new_line_or_space_if_newlines_disabled() -> PrintItems {
+  if_true_or(
+    "newLineOrSpaceIfNewlinesDisabled",
+    condition_resolvers::is_forcing_no_newlines(),
+    space(),
+    Signal::NewLine.into(),
+  )
+  .into()
 }
 
 fn space() -> PrintItems {
@@ -2205,12 +2289,17 @@ fn space() -> PrintItems {
 /// What takes the place of a line break that falls between two characters of
 /// a script written without spaces between its words, where the break isn't
 /// rendered as a space and so is dropped rather than turned into one.
-fn get_unspaced_script_newline_wrapping(context: &Context) -> PrintItems {
+fn get_unspaced_script_newline_wrapping(context: &Context, ends_sentence: bool) -> PrintItems {
   match context.configuration.text_wrap {
     // the line may still be broken where it was, since the break isn't read
     // as anything either way
     TextWrap::Always if !context.is_text_wrap_disabled() => Signal::PossibleNewLine.into(),
-    TextWrap::Always | TextWrap::Never => PrintItems::new(),
+    // the break stands for nothing, so it is dropped rather than written as
+    // the space an end of sentence takes where newlines are forced off
+    TextWrap::Sentence if ends_sentence && !context.is_text_wrap_disabled() => {
+      new_line_or_nothing_if_newlines_disabled()
+    }
+    TextWrap::Always | TextWrap::Never | TextWrap::Sentence => PrintItems::new(),
     // where newlines are being forced off (ex. within a heading) the printer
     // drops this one, which is what should take the place of a break that read
     // as nothing anyway
@@ -2218,34 +2307,26 @@ fn get_unspaced_script_newline_wrapping(context: &Context) -> PrintItems {
   }
 }
 
-fn get_newline_wrapping_based_on_config(context: &Context) -> PrintItems {
+fn get_newline_wrapping_based_on_config(context: &Context, ends_sentence: bool) -> PrintItems {
   if context.is_text_wrap_disabled() {
     // ex. within a link, whose text is moved onto a single line when text is
     // being wrapped, but keeps the line breaks it has when text is maintained
     return match context.configuration.text_wrap {
-      TextWrap::Always | TextWrap::Never => space(),
-      TextWrap::Maintain => if_true_or(
-        "newLineOrSpaceIfNewlinesDisabled",
-        condition_resolvers::is_forcing_no_newlines(),
-        space(),
-        Signal::NewLine.into(),
-      )
-      .into(),
+      TextWrap::Always | TextWrap::Never | TextWrap::Sentence => space(),
+      TextWrap::Maintain => new_line_or_space_if_newlines_disabled(),
     };
   }
   match context.configuration.text_wrap {
     TextWrap::Always => Signal::SpaceOrNewLine.into(),
     TextWrap::Never => space(),
+    // the break the file has is only kept where the sentence it follows ends,
+    // which is what draws the rest of the sentence back onto one line
+    TextWrap::Sentence if ends_sentence => new_line_or_space_if_newlines_disabled(),
+    TextWrap::Sentence => space(),
     // a line break can't be written where newlines are being forced off
     // (ex. within a heading), where it stands for the space between the words
     // it separated
-    TextWrap::Maintain => if_true_or(
-      "newLineOrSpaceIfNewlinesDisabled",
-      condition_resolvers::is_forcing_no_newlines(),
-      space(),
-      Signal::NewLine.into(),
-    )
-    .into(),
+    TextWrap::Maintain => new_line_or_space_if_newlines_disabled(),
   }
 }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1448,11 +1448,10 @@ fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
   if let Some(line) = lines.next() {
     items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
   }
-  // raw text isn't prose, so a sentence within it says nothing about where its
-  // line breaks belong -- the ones it was written with are kept
-  let keeps_its_breaks = context.configuration.text_wrap == TextWrap::Sentence;
   for line in lines {
-    items.extend(get_newline_wrapping_based_on_config(context, keeps_its_breaks));
+    // a label, a title, and an image's alt text are not prose, so a sentence
+    // within one says nothing about where its line breaks belong
+    items.extend(get_newline_wrapping_based_on_config(context, false));
     // the printer provides the indentation and block quote markers of a
     // continued line, so drop the ones this picked up from the file
     let line = strip_block_quote_markers(line, context);
@@ -1478,14 +1477,17 @@ fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
 /// A run of a script written without spaces between its words holds no space
 /// for the sentences in it to be separated at, so without this they would be
 /// written on the one line however many of them there were.
+///
+/// Only a break with one of that script's characters on either side can be
+/// written, the same as in [`gen_word_with_unspaced_script_breaks`]: anywhere
+/// else the break would be read back as a space that wasn't written, and the
+/// text after it could begin a block of its own at the start of the line.
 fn gen_word_with_sentence_breaks(word: String) -> PrintItems {
   let mut items = PrintItems::new();
   let mut segment_start = 0;
   let mut last_char: Option<char> = None;
   for (index, character) in word.char_indices() {
-    if matches!(last_char, Some(last) if utils::ends_unspaced_script_sentence(last))
-      && !utils::forbids_line_break_before(character)
-    {
+    if matches!(last_char, Some(last) if breaks_between_sentences(last, character)) {
       items.extend(gen_text_with_tabs(word[segment_start..index].to_string()));
       items.extend(new_line_or_nothing_if_newlines_disabled());
       segment_start = index;
@@ -1493,7 +1495,19 @@ fn gen_word_with_sentence_breaks(word: String) -> PrintItems {
     last_char = Some(character);
   }
   items.extend(gen_text_with_tabs(word[segment_start..].to_string()));
-  items
+  return items;
+
+  /// Only the character beside the terminator decides this. What a longer look
+  /// ahead would read stops at the end of the word, which the line below can be
+  /// drawn up into, so the same text would be read two ways on two passes.
+  fn breaks_between_sentences(last: char, next: char) -> bool {
+    utils::ends_unspaced_script_sentence(last)
+      && utils::is_unspaced_script(next)
+      && !utils::forbids_line_break_before(next)
+      // a mark that opens a phrase says nothing about whether a sentence begins
+      // after it, so it stays with the sentence it was written against
+      && !utils::forbids_line_break_after(next)
+  }
 }
 
 /// Writes the word, breaking it up where a line can be broken within a script
@@ -2232,14 +2246,22 @@ fn get_blank_lines(count: u32) -> PrintItems {
 /// is written when text is wrapped by sentence.
 fn sentence_ends_between(last_node: &Node, node: &Node, context: &Context) -> bool {
   context.configuration.text_wrap == TextWrap::Sentence
-    && last_node.ends_sentence(context.file_text)
-    && node.starts_sentence(context.file_text)
+    && last_node.ends_sentence()
+    && node.starts_sentence()
+    // a break writes the node at the start of a line, where a marker fuses with
+    // whatever is drawn up beside it into a list of its own
+    && !node.starts_with_list_word()
 }
 
-/// Whether the text after a word can be wrapped onto the line below it, which
-/// is what would leave the word by itself on a line of its own.
+/// Whether the text after a word can be written on the line below it, which is
+/// what would leave the word by itself at the start of a line.
+///
+/// Wrapping moves whatever doesn't fit; a sentence break moves whatever follows
+/// the sentence. Either way the word can be left where a block begins, so the
+/// checks that keep it off one read the word on its own rather than the line
+/// the file happened to write it on.
 fn text_can_be_wrapped_away(context: &Context) -> bool {
-  context.configuration.text_wrap == TextWrap::Always && !context.is_text_wrap_disabled()
+  matches!(context.configuration.text_wrap, TextWrap::Always | TextWrap::Sentence) && !context.is_text_wrap_disabled()
 }
 
 fn get_space_or_newline_based_on_config(context: &Context, ends_sentence: bool) -> PrintItems {

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -109,25 +109,44 @@ pub fn starts_block_at_line_start(line_text: &str, word_can_be_left_alone: bool)
 pub fn ends_sentence(text: &str) -> bool {
   let text = text.trim_end();
   let word = text.rsplit([' ', '\n', '\t']).next().unwrap_or(text);
+  // the line is broken after a terminator of a script written without spaces
+  // between its words, so the word that ends the text begins after the last of
+  // those as surely as it begins after a space
+  let word = match word
+    .char_indices()
+    .rev()
+    .find(|(_, c)| ends_unspaced_script_sentence(*c))
+  {
+    Some((index, terminator)) if index + terminator.len_utf8() < word.len() => &word[index + terminator.len_utf8()..],
+    _ => word,
+  };
   let word = word.trim_end_matches(SENTENCE_TRAILING);
   let Some(last_char) = word.chars().next_back() else {
     return false;
   };
-  if matches!(last_char, '!' | '?' | '…' | '‼' | '⁇' | '⁈' | '⁉' | '。' | '！' | '？') {
+  if matches!(last_char, '!' | '?' | '…' | '‼' | '⁇' | '⁈' | '⁉') || ends_unspaced_script_sentence(last_char)
+  {
     return true;
   }
   if last_char != '.' {
     return false;
   }
   // a run of periods is the one terminator, which is what an ellipsis is
-  // written as
-  let stem = word.trim_end_matches('.');
-  // ex. `e.g.` or `U.S.`, whose periods belong to the word
-  if stem.contains('.') {
+  // written as, and a backslash before one only escapes it
+  let stem = word.trim_end_matches('.').trim_end_matches('\\');
+  // ex. `e.g.` or `U.S.`, whose periods belong to the word. Only a word written
+  // in parts that short is one: a longer part makes it a domain or a file name
+  // (ex. `example.com`), which a sentence ends with like any other word
+  if stem.contains('.') && stem.split('.').all(|part| part.chars().count() <= 2) {
     return false;
   }
-  // ex. the `J.` of a name, which is only an initial
-  if stem.chars().count() == 1 && stem.chars().all(char::is_alphabetic) {
+  // ex. the `J.` of a name, which is only an initial. A mark that combines with
+  // a letter is written as part of it rather than as a letter of its own, and
+  // an initial is written in an alphabet that has a case -- a word of a script
+  // without one (ex. a single ideograph) is a whole word
+  let mut letters = stem.chars().filter(|c| !is_combining_mark(*c));
+  if matches!((letters.next(), letters.next()), (Some(letter), None) if letter.is_uppercase() || letter.is_lowercase())
+  {
     return false;
   }
   // ex. the `1.` of a step written within a line, which is a marker rather
@@ -135,9 +154,9 @@ pub fn ends_sentence(text: &str) -> bool {
   if !stem.is_empty() && stem.chars().all(|c| c.is_numeric()) {
     return false;
   }
-  !ABBREVIATIONS
-    .iter()
-    .any(|abbreviation| abbreviation.eq_ignore_ascii_case(stem))
+  // an abbreviation is matched as it is written, so that the ordinary word a
+  // shorter one spells (ex. `no` beside `No.`) still ends a sentence
+  !ABBREVIATIONS.contains(&stem)
 }
 
 /// Whether the text could begin a sentence, which is what tells a period that
@@ -167,19 +186,32 @@ const SENTENCE_TRAILING: [char; 18] = [
 
 /// The characters written before a sentence's first word, which are the markup
 /// that opens around it and the marks that open a phrase.
-const SENTENCE_LEADING: [char; 17] = [
-  '*', '_', '~', '`', '(', '[', '{', '"', '\'', '«', '‹', '“', '‘', '（', '〔', '「', '『',
+const SENTENCE_LEADING: [char; 18] = [
+  '*', '_', '~', '`', '(', '[', '{', '"', '\'', '«', '‹', '“', '‘', '（', '〔', '「', '『', '【',
 ];
 
-/// The words whose trailing period doesn't end a sentence.
+/// The words whose trailing period doesn't end a sentence, written the way a
+/// document writes them.
 ///
 /// Only the ones written often enough in prose to be worth the false break are
 /// listed. An abbreviation with a period within it (ex. `e.g.`) doesn't need
 /// one, since the period inside it is what gives it away.
 const ABBREVIATIONS: &[&str] = &[
-  "al", "approx", "ca", "cf", "co", "corp", "dept", "dr", "ed", "eds", "est", "etc", "fig", "figs", "inc", "jr", "ltd",
-  "mr", "mrs", "ms", "no", "nos", "pp", "prof", "resp", "sr", "st", "vol", "vols", "vs",
+  "Ch", "Co", "Corp", "Dept", "Dr", "Ed", "Eds", "Fig", "Figs", "Inc", "Jr", "Ltd", "Mr", "Mrs", "Ms", "No", "Nos",
+  "Prof", "Sec", "Sr", "St", "Vol", "Vols", "al", "approx", "ca", "cf", "est", "etc", "pp", "resp", "vs",
 ];
+
+/// Whether the character is a mark that combines with the character before it,
+/// which is written as part of that character rather than as one of its own.
+fn is_combining_mark(c: char) -> bool {
+  matches!(
+    c as u32,
+    // combining diacritical marks, and the extended and supplement blocks
+    0x0300..=0x036F | 0x1AB0..=0x1AFF | 0x1DC0..=0x1DFF
+    // combining diacritical marks for symbols, and the half marks
+    | 0x20D0..=0x20FF | 0xFE20..=0xFE2F
+  )
+}
 
 /// Whether the text would start a block of its own if the word that begins it
 /// were moved to the start of a line by wrapping.
@@ -472,6 +504,26 @@ mod test {
     // the terminator on its own, which is what a sentence that ends in a link
     // leaves behind
     assert!(ends_sentence("."));
+    // the halfwidth full stop, which ends a sentence like the full width one
+    assert!(ends_sentence("あ｡"));
+    // a domain or a file name is a word like any other, however many periods
+    // are written within it
+    assert!(ends_sentence("Visit example.com."));
+    assert!(ends_sentence("The file is foo.md."));
+    // ...but the parts of an abbreviation are short
+    assert!(!ends_sentence("It happened at 5 p.m."));
+    assert!(!ends_sentence("It is version 1.2."));
+    // an abbreviation is read as it is written, so the ordinary word a shorter
+    // one spells still ends a sentence
+    assert!(ends_sentence("The answer is no."));
+    assert!(!ends_sentence("See No."));
+    assert!(ends_sentence("I ate the figs."));
+    assert!(!ends_sentence("See Figs."));
+    // an escaped period is read as the period it writes
+    assert!(!ends_sentence("Step 2\\."));
+    // however the letter and its marks are written
+    assert!(!ends_sentence("It was É."));
+    assert!(!ends_sentence("It was É."));
   }
 
   #[test]

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -174,15 +174,13 @@ pub fn leading_block_words_end(text: &str) -> Option<usize> {
 pub fn ends_sentence(text: &str) -> bool {
   let text = text.trim_end();
   let word = text.rsplit([' ', '\n', '\t']).next().unwrap_or(text);
-  // the line is broken after a terminator of a script written without spaces
-  // between its words, so the word that ends the text begins after the last of
-  // those as surely as it begins after a space
-  let word = match word
-    .char_indices()
-    .rev()
-    .find(|(_, c)| ends_unspaced_script_sentence(*c))
-  {
-    Some((index, terminator)) if index + terminator.len_utf8() < word.len() => &word[index + terminator.len_utf8()..],
+  // a script written without spaces between its words holds none for the word
+  // to begin after, and the line may be broken between any two of its
+  // characters, so the word that ends the text begins after the last of them.
+  // Where one ends the text it is the word, since that is what a sentence of
+  // that script ends with
+  let word = match word.char_indices().rev().find(|(_, c)| is_unspaced_script(*c)) {
+    Some((index, character)) if index + character.len_utf8() < word.len() => &word[index + character.len_utf8()..],
     _ => word,
   };
   let word = word.trim_end_matches(SENTENCE_TRAILING);
@@ -230,6 +228,9 @@ pub fn starts_sentence(text: &str) -> bool {
   let word = text.split([' ', '\n', '\t']).next().unwrap_or(text);
   let word = word.trim_start_matches(SENTENCE_LEADING);
   match word.chars().next() {
+    // a mark that closes or trails a phrase can't open one, and a line can't
+    // even be broken before some of them
+    Some(c) if SENTENCE_TRAILING.contains(&c) || forbids_line_break_before(c) => false,
     // a word that begins in lowercase carries on the sentence written before
     // it, whatever the word before it ended with
     Some(c) => !c.is_lowercase(),
@@ -588,6 +589,16 @@ mod test {
     assert!(!ends_sentence("See Figs."));
     // an escaped period is read as the period it writes
     assert!(!ends_sentence("Step 2\\."));
+    // the word begins after a script written without spaces between its words,
+    // whose characters the line may be broken between, so however much of one
+    // is drawn up in front of the word it reads the same
+    assert!(!ends_sentence("あe.g."));
+    assert!(!ends_sentence("ああe.g."));
+    assert!(ends_sentence("これは。Rust."));
+    // ...and a character of that script ending the text is the word, since
+    // that is what a sentence of it ends with
+    assert!(ends_sentence("あ。"));
+    assert!(!ends_sentence("あ"));
     // however the letter and its marks are written
     assert!(!ends_sentence("It was É."));
     assert!(!ends_sentence("It was É."));
@@ -606,6 +617,12 @@ mod test {
     assert!(!starts_sentence("then more text."));
     assert!(!starts_sentence("**bold** text."));
     assert!(!starts_sentence(""));
+    // a mark that closes or trails a phrase can't open one
+    assert!(!starts_sentence("」です"));
+    assert!(!starts_sentence("、==="));
+    assert!(!starts_sentence(")x"));
+    // ...but a mark that opens one is written before the word it opens
+    assert!(starts_sentence("「こんにちは"));
   }
 
   #[test]

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -100,6 +100,87 @@ pub fn starts_block_at_line_start(line_text: &str, word_can_be_left_alone: bool)
     || crate::parser::starts_block_in_paragraph(line_text)
 }
 
+/// Whether the text ends a sentence, which is where a line break is written
+/// when text is wrapped by sentence.
+///
+/// Only the word the text ends with decides it. Markup and the marks that close
+/// a phrase (ex. the `**` of `**Done.**`) are written after the terminator, so
+/// the check looks past them.
+pub fn ends_sentence(text: &str) -> bool {
+  let text = text.trim_end();
+  let word = text.rsplit([' ', '\n', '\t']).next().unwrap_or(text);
+  let word = word.trim_end_matches(SENTENCE_TRAILING);
+  let Some(last_char) = word.chars().next_back() else {
+    return false;
+  };
+  if matches!(last_char, '!' | '?' | '…' | '‼' | '⁇' | '⁈' | '⁉' | '。' | '！' | '？') {
+    return true;
+  }
+  if last_char != '.' {
+    return false;
+  }
+  // a run of periods is the one terminator, which is what an ellipsis is
+  // written as
+  let stem = word.trim_end_matches('.');
+  // ex. `e.g.` or `U.S.`, whose periods belong to the word
+  if stem.contains('.') {
+    return false;
+  }
+  // ex. the `J.` of a name, which is only an initial
+  if stem.chars().count() == 1 && stem.chars().all(char::is_alphabetic) {
+    return false;
+  }
+  // ex. the `1.` of a step written within a line, which is a marker rather
+  // than the end of anything
+  if !stem.is_empty() && stem.chars().all(|c| c.is_numeric()) {
+    return false;
+  }
+  !ABBREVIATIONS
+    .iter()
+    .any(|abbreviation| abbreviation.eq_ignore_ascii_case(stem))
+}
+
+/// Whether the text could begin a sentence, which is what tells a period that
+/// ends one apart from a period written in the middle of one.
+pub fn starts_sentence(text: &str) -> bool {
+  let word = text.split([' ', '\n', '\t']).next().unwrap_or(text);
+  let word = word.trim_start_matches(SENTENCE_LEADING);
+  match word.chars().next() {
+    // a word that begins in lowercase carries on the sentence written before
+    // it, whatever the word before it ended with
+    Some(c) => !c.is_lowercase(),
+    None => false,
+  }
+}
+
+/// Whether the character ends a sentence of a script written without spaces
+/// between its words, where there is no space for the line to be broken at.
+pub fn ends_unspaced_script_sentence(c: char) -> bool {
+  matches!(c, '。' | '！' | '？' | '｡')
+}
+
+/// The characters written after a sentence's terminator, which are the markup
+/// that closes around it and the marks that close a phrase.
+const SENTENCE_TRAILING: [char; 18] = [
+  '*', '_', '~', '`', ')', ']', '}', '"', '\'', '»', '›', '”', '’', '）', '〕', '」', '』', '】',
+];
+
+/// The characters written before a sentence's first word, which are the markup
+/// that opens around it and the marks that open a phrase.
+const SENTENCE_LEADING: [char; 17] = [
+  '*', '_', '~', '`', '(', '[', '{', '"', '\'', '«', '‹', '“', '‘', '（', '〔', '「', '『',
+];
+
+/// The words whose trailing period doesn't end a sentence.
+///
+/// Only the ones written often enough in prose to be worth the false break are
+/// listed. An abbreviation with a period within it (ex. `e.g.`) doesn't need
+/// one, since the period inside it is what gives it away.
+const ABBREVIATIONS: &[&str] = &[
+  "al", "approx", "ca", "cf", "co", "corp", "dept", "dr", "ed", "eds", "est", "etc", "fig", "figs", "inc", "jr", "ltd",
+  "mr", "mrs", "ms", "no", "nos", "pp", "prof", "resp", "sr", "st", "vol", "vols", "vs",
+];
+
 /// Whether the text would start a block of its own if the word that begins it
 /// were moved to the start of a line by wrapping.
 ///
@@ -361,6 +442,51 @@ mod test {
     assert_eq!(starts_block_at_line_start("-- text", false), false);
     assert_eq!(starts_block_at_line_start("--", false), true);
     assert_eq!(starts_block_at_line_start("=== not a heading", false), false);
+  }
+
+  #[test]
+  fn should_find_where_a_sentence_ends() {
+    assert!(ends_sentence("This is a sentence."));
+    assert!(ends_sentence("Is it?"));
+    assert!(ends_sentence("It is!"));
+    assert!(ends_sentence("It ended..."));
+    // the space up to the next word is written before the check runs
+    assert!(ends_sentence("This is a sentence.  "));
+    // the markup and the marks that close a phrase are written after the
+    // terminator
+    assert!(ends_sentence("It was **bold.**"));
+    assert!(ends_sentence(r#"He said "hi.""#));
+    assert!(ends_sentence("(An aside.)"));
+    // an abbreviation, which is written mid-sentence
+    assert!(!ends_sentence("See e.g."));
+    assert!(!ends_sentence("It is in the U.S."));
+    assert!(!ends_sentence("Ask Dr."));
+    assert!(!ends_sentence("Foo, bar, etc."));
+    assert!(!ends_sentence("Written by J."));
+    // a marker rather than the end of anything
+    assert!(!ends_sentence("Step 1."));
+    // a period is only the end of a sentence at the end of a word
+    assert!(!ends_sentence("The file is foo.md"));
+    assert!(!ends_sentence("No terminator here"));
+    assert!(!ends_sentence(""));
+    // the terminator on its own, which is what a sentence that ends in a link
+    // leaves behind
+    assert!(ends_sentence("."));
+  }
+
+  #[test]
+  fn should_find_what_could_begin_a_sentence() {
+    assert!(starts_sentence("This"));
+    assert!(starts_sentence("Then more text."));
+    assert!(starts_sentence("42 is the answer."));
+    // the markup and the marks that open a phrase are written before the word
+    assert!(starts_sentence("**Bold** text."));
+    assert!(starts_sentence("[A link](https://example.com/)"));
+    assert!(starts_sentence("これは"));
+    // a word written in lowercase carries on the sentence before it
+    assert!(!starts_sentence("then more text."));
+    assert!(!starts_sentence("**bold** text."));
+    assert!(!starts_sentence(""));
   }
 
   #[test]

--- a/tests/specs/Text/Text_TextWrap_Sentence.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence.txt
@@ -1,0 +1,125 @@
+~~ lineWidth: 40, textWrap: sentence ~~
+!! should write one sentence per line !!
+This is a sentence. This is another one that runs past the line width.
+A third one
+was written over
+two lines.
+
+[expect]
+This is a sentence.
+This is another one that runs past the line width.
+A third one was written over two lines.
+
+!! should keep a sentence on one line when the next word is lowercase !!
+The file is called foo.md so it is not a sentence end. more text here.
+
+[expect]
+The file is called foo.md so it is not a sentence end. more text here.
+
+!! should not break after an abbreviation or an initial !!
+Dr. Smith met J. Doe at 5 p.m. They talked about the U.S. economy.
+See the docs, e.g. the readme. Then continue.
+
+[expect]
+Dr. Smith met J. Doe at 5 p.m. They talked about the U.S. economy.
+See the docs, e.g. the readme.
+Then continue.
+
+!! should break after a sentence that ends in markup !!
+A sentence ending in **bold.** Then more text.
+See [the docs](https://example.com/a.md). Then continue.
+Run `format.` Then check.
+
+[expect]
+A sentence ending in **bold.**
+Then more text.
+See [the docs](https://example.com/a.md).
+Then continue.
+Run `format.`
+Then check.
+
+!! should break after other terminators !!
+Is this a sentence? Yes it is! Really...
+It is.
+
+[expect]
+Is this a sentence?
+Yes it is!
+Really...
+It is.
+
+!! should keep a heading on one line !!
+# One sentence. Another sentence.
+
+[expect]
+# One sentence. Another sentence.
+
+!! should not move text that would start a block to the start of a line !!
+A sentence. # Not a heading.
+
+A sentence. 1. Not a list.
+
+[expect]
+A sentence. # Not a heading.
+
+A sentence. 1. Not a list.
+
+!! should not break within a link !!
+[A sentence. Another one.](https://example.com/) Then more.
+
+[expect]
+[A sentence. Another one.](https://example.com/) Then more.
+
+!! should keep the blank lines between paragraphs !!
+One. Two.
+
+Three. Four.
+
+[expect]
+One.
+Two.
+
+Three.
+Four.
+
+!! should write one sentence per line within a block quote and a list !!
+> One. Two.
+
+- One. Two.
+  Three.
+
+[expect]
+> One.
+> Two.
+
+- One.
+  Two.
+  Three.
+
+!! should keep a table cell on one line !!
+| a | b |
+|---|---|
+| One. Two. | Three. Four. |
+
+[expect]
+| a         | b            |
+| --------- | ------------ |
+| One. Two. | Three. Four. |
+
+!! should break after a sentence of an unspaced script !!
+これは文です。これも文です。
+続き。
+
+[expect]
+これは文です。
+これも文です。
+続き。
+
+!! should keep a hard break !!
+One.\
+Two. Three.
+
+[expect]
+One.\
+Two.
+Three.

--- a/tests/specs/Text/Text_TextWrap_Sentence.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence.txt
@@ -64,11 +64,12 @@ A sentence. # Not a heading.
 
 A sentence. 1. Not a list.
 
-!! should not break within a link !!
+!! should not break within a link, and read the sentence through it !!
 [A sentence. Another one.](https://example.com/) Then more.
 
 [expect]
-[A sentence. Another one.](https://example.com/) Then more.
+[A sentence. Another one.](https://example.com/)
+Then more.
 
 !! should keep the blank lines between paragraphs !!
 One. Two.

--- a/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
@@ -120,3 +120,10 @@ It was É. Then more.
 It was É. Then more.
 
 It was É. Then more.
+
+!! should read the word a sentence ends with off the script written without spaces !!
+あ
+ あe.g.   2.」
+
+[expect]
+ああe.g. 2.」

--- a/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
@@ -1,0 +1,122 @@
+~~ lineWidth: 40, textWrap: sentence ~~
+!! should not break a word where the break would read as a space !!
+これはテストです。Rustで書かれています。
+
+[expect]
+これはテストです。Rustで書かれています。
+
+!! should not break a word where the text after it would start a block !!
+あ。---
+
+あ。# H
+
+あ。- item
+
+あ。> quoted
+
+あ。|---|
+
+Done。---
+
+[expect]
+あ。---
+
+あ。# H
+
+あ。- item
+
+あ。> quoted
+
+あ。|---|
+
+Done。---
+
+!! should break a word at the halfwidth full stop as at the full width one !!
+あ｡い｡
+
+あ。い。
+
+[expect]
+あ｡
+い｡
+
+あ。
+い。
+
+!! should not break before a marker that would fuse into a list !!
+Foo.
+1.
+Trailing
+
+[expect]
+Foo. 1. Trailing
+
+!! should keep the line the same however the text after a block shape is written !!
+Foo. ---
+Trailing text
+
+[expect]
+Foo. --- Trailing text
+
+!! should read a sentence through the delimiters a node is written with !!
+See [the guide.](https://x.com/) Next sentence.
+
+[a](https://example.com/ "T.") Next sentence.
+
+Run `1.` Then stop.
+
+Run `format.` Then check.
+
+[expect]
+See [the guide.](https://x.com/)
+Next sentence.
+
+[a](https://example.com/ "T.") Next sentence.
+
+Run `1.` Then stop.
+
+Run `format.`
+Then check.
+
+!! should end a sentence at a domain or a file name !!
+Visit example.com. Then continue.
+
+See foo.md. Then continue.
+
+[expect]
+Visit example.com.
+Then continue.
+
+See foo.md.
+Then continue.
+
+!! should end a sentence at a word an abbreviation only spells !!
+The answer is no. Then continue.
+
+See No. 5 below.
+
+[expect]
+The answer is no.
+Then continue.
+
+See No. 5 below.
+
+!! should write a period the same however it is escaped !!
+Step 2. Then more.
+
+Step 2\. Then more.
+
+[expect]
+Step 2. Then more.
+
+Step 2\. Then more.
+
+!! should not depend on how a letter and its marks are written !!
+It was É. Then more.
+
+It was É. Then more.
+
+[expect]
+It was É. Then more.
+
+It was É. Then more.


### PR DESCRIPTION
Closes #46.

Adds a fourth `textWrap` value, `"sentence"`, which writes one sentence per line and ignores `lineWidth`. This is the part of [semantic line breaks](https://sembr.org/) that can be applied without knowing what the text means: a line break goes where a sentence ends and nowhere else, so a diff stays scoped to the sentences that were edited.

```markdown
This is a sentence. This is another one that runs past the line width.
A third one
was written over
two lines.
```

becomes

```markdown
This is a sentence.
This is another one that runs past the line width.
A third one was written over two lines.
```

## How it works

It behaves like `never` — everything joins, nothing wraps to fit the line width — plus a forced break where a sentence ends. The three helpers that decide what goes between two words (`get_space_or_newline_based_on_config`, `get_newline_wrapping_based_on_config`, `get_unspaced_script_newline_wrapping`) take a `ends_sentence` flag, and the three places that know the surrounding text work it out.

The existing guards all run before the config check, so they still win: text that would start a block at the start of a line is kept off one, and a heading, a table cell, or a link's text stays on the single line it is forced onto.

## What counts as the end of a sentence

`ends_sentence` and `starts_sentence` in `src/generation/utils.rs`. The heuristic leans toward writing too few breaks rather than too many, since a break in the wrong place is the one that reads badly:

- the terminator is `.`, `!`, `?`, `…`, or one of the CJK forms, looked at past the markup and the marks that close a phrase (`**Done.**`, `"hi."`, `(An aside.)`)
- a period doesn't end a sentence after a word with a period within it (`e.g.`, `U.S.`, `p.m.`), after an initial (`J.`), after a bare number (`Step 1.`), or after one of a short list of abbreviations
- the next word has to not begin in lowercase, which is what keeps `foo.md so it is` on the one line

A run of a script written without spaces between its words holds no space to break at, so `。！？` split the word itself.

## Tests

13 spec cases in `tests/specs/Text/Text_TextWrap_Sentence.txt` (the spec runner formats twice, so idempotency is covered) and unit tests for the two predicates.

I also ran the corpus check over 3602 `.md` files with the option on: no panics, no lost text, and the 10 files that don't come out the same the second time are the same 10 that `textWrap: "never"` already fails on today (an inline `<!-- comment -->` followed by link reference definitions, which every joining mode collapses onto one line). That looks like a separate bug in `never`, so I left it alone here.
