### PR TITLE
fix: keep the words of a thematic break off a line of their own

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -105,13 +105,16 @@ impl<'a> Node<'a> {
   /// Unlike [`Self::starts_block_in_paragraph`] this counts what the node's
   /// first word would start on its own, since the text after it can wrap onto
   /// the line below and leave it there alone.
-  pub fn starts_block_at_line_start(&self, word_can_be_left_alone: bool) -> bool {
+  pub fn starts_block_at_line_start(&self, following_text: &str, word_can_be_left_alone: bool) -> bool {
     match self {
-      Node::Text(text) => crate::generation::utils::starts_block_at_line_start(text.text, word_can_be_left_alone),
+      Node::Text(text) => {
+        crate::generation::utils::starts_block_at_line_start(text.text, following_text, word_can_be_left_alone)
+      }
       // a block of html already stands on its own, so nothing about where it
       // is written can turn it into one
       Node::Html(html) => {
-        !html.is_block && crate::generation::utils::starts_block_at_line_start(&html.text, word_can_be_left_alone)
+        !html.is_block
+          && crate::generation::utils::starts_block_at_line_start(&html.text, following_text, word_can_be_left_alone)
       }
       _ => false,
     }

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -67,6 +67,11 @@ pub struct Context<'a> {
   /// when it has to be escaped so that it isn't read as the start of a block
   /// of its own.
   escaped_block_starts: Vec<(usize, usize)>,
+  /// Where each bit of text written at the start of a line starts.
+  line_start_texts: Vec<usize>,
+  /// Where the block being written ends, which bounds how far the text of one
+  /// of its lines can run.
+  block_end: Option<usize>,
   /// The delimiter each text decoration is written with, by where it starts.
   decoration_delimiters: std::cell::RefCell<HashMap<usize, &'static str>>,
   /// The character the list item being generated is marked with.
@@ -116,6 +121,8 @@ impl<'a> Context<'a> {
       enclosing_decoration: None,
       escaped_closing_hashes: None,
       escaped_block_starts: Vec::new(),
+      line_start_texts: Vec::new(),
+      block_end: None,
       decoration_delimiters: std::cell::RefCell::new(HashMap::new()),
       list_marker_char: None,
       list_marker_lines_up: true,
@@ -325,12 +332,31 @@ impl<'a> Context<'a> {
   pub fn with_escaped_block_starts<T>(
     &mut self,
     starts: Vec<(usize, usize)>,
+    line_starts: Vec<usize>,
+    block_end: usize,
     func: impl FnOnce(&mut Context) -> T,
   ) -> T {
     let previous = std::mem::replace(&mut self.escaped_block_starts, starts);
+    let previous_line_starts = std::mem::replace(&mut self.line_start_texts, line_starts);
+    let previous_end = self.block_end.replace(block_end);
     let result = func(self);
     self.escaped_block_starts = previous;
+    self.line_start_texts = previous_line_starts;
+    self.block_end = previous_end;
     result
+  }
+
+  /// The text from `start` through to the end of the block being written,
+  /// which is how far a line of it can run on.
+  pub fn text_from(&self, start: usize, fallback_end: usize) -> &str {
+    let end = self.block_end.filter(|end| *end >= start).unwrap_or(fallback_end);
+    &self.file_text[start..end]
+  }
+
+  /// Whether the text starting here is written at the start of a line, which
+  /// is where nothing precedes it that a line break could be written at.
+  pub fn is_line_start_text(&self, start: usize) -> bool {
+    self.line_start_texts.contains(&start)
   }
 
   /// Where a backslash goes in the text starting here, when it is written

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -146,7 +146,9 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               // > Some note.
               if is_callout_node(last_node, context) && !context.is_text_wrap_disabled() {
                 items.push_signal(Signal::NewLine); // force a newline
-              } else if node.starts_block_at_line_start(text_can_be_wrapped_away(context)) {
+              } else if node
+                .starts_block_at_line_start(following_text(node, context), text_can_be_wrapped_away(context))
+              {
                 // text that would start a block can't be moved to the start of
                 // a line without changing what it means
                 items.push_space();
@@ -180,7 +182,9 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               };
 
               if needs_space {
-                if node.starts_block_at_line_start(text_can_be_wrapped_away(context)) || node.starts_with_list_word() {
+                if node.starts_block_at_line_start(following_text(node, context), text_can_be_wrapped_away(context))
+                  || node.starts_with_list_word()
+                {
                   // the node would start a block of its own at the start of a
                   // line, so it has to be kept off one
                   items.push_space();
@@ -385,16 +389,19 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
   // a paragraph begins where a block does, and a hard break puts what follows
   // it at the start of a line too, so neither can be left to read as the start
   // of a block of its own
-  let escaped = escaped_block_starts(&paragraph.children);
-  items.extend(context.with_escaped_block_starts(escaped, |context| {
-    gen_task_list_marker_children(&paragraph.children, paragraph.marker.as_ref(), context)
-  }));
+  let (escaped, line_starts) = escaped_block_starts(&paragraph.children);
+  items.extend(
+    context.with_escaped_block_starts(escaped, line_starts, paragraph.span.end, |context| {
+      gen_task_list_marker_children(&paragraph.children, paragraph.marker.as_ref(), context)
+    }),
+  );
   return items;
 
   /// Where each bit of the paragraph's text that is written at the start of a
   /// line starts, when it would be read as the start of a block.
-  fn escaped_block_starts(children: &[Node]) -> Vec<(usize, usize)> {
+  fn escaped_block_starts(children: &[Node]) -> (Vec<(usize, usize)>, Vec<usize>) {
     let mut starts = Vec::new();
+    let mut line_starts = Vec::new();
     // the first line of a paragraph has nothing above it to be read together
     // with, so less of what it holds is markup than on the lines after it
     let mut escape: fn(&str) -> Option<usize> = block_start_escape;
@@ -402,6 +409,7 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
     for child in children {
       if at_line_start {
         if let Node::Text(text) = child {
+          line_starts.push(text.span.start);
           if let Some(position) = escape(text.text) {
             starts.push((text.span.start, position));
           }
@@ -412,7 +420,7 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
         escape = line_start_escape;
       }
     }
-    starts
+    (starts, line_starts)
   }
 }
 
@@ -802,7 +810,7 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
     if !items.is_empty() {
       // only the chunk is looked at, since a code span's text is written out
       // in chunks rather than a line at a time
-      if utils::wrapping_word_starts_block(word, text_can_be_wrapped_away(context)) {
+      if utils::wrapping_word_starts_block(word, word, text_can_be_wrapped_away(context)) {
         items.push_space();
       } else if was_last_newline {
         items.push_signal(Signal::NewLine);
@@ -817,7 +825,7 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {
   if let Some(position) = context.block_start_escape_at(text.span.start) {
     let escaped = format!("{}\\{}", &text.text[..position], &text.text[position..]);
-    return gen_str(&escaped, context);
+    return gen_str(&escaped, None, context);
   }
   if context.is_escaping_closing_hashes(text.span.start) {
     // the hashes are escaped where they start, which is enough to keep the
@@ -828,9 +836,9 @@ fn gen_text(text: &Text, context: &mut Context) -> PrintItems {
       &text.text[..text.text.len() - hashes],
       &text.text[text.text.len() - hashes..]
     );
-    return gen_str(&escaped, context);
+    return gen_str(&escaped, None, context);
   }
-  gen_str(text.text, context)
+  gen_str(text.text, Some(text.span.start), context)
 }
 
 /// Whether the node is a callout header (ex. `[!NOTE]`), which is only
@@ -850,8 +858,14 @@ fn is_callout_text(text: &str) -> bool {
   !kind.is_empty() && kind.chars().all(|c| c.is_ascii_uppercase())
 }
 
-fn gen_str(text: &str, context: &mut Context) -> PrintItems {
-  let mut text_builder = TextBuilder::new(text, context);
+/// Writes out text as the words it wraps at.
+///
+/// `text_start` is where the text was read from, which lets a word be looked at
+/// together with what follows it in the file rather than only what follows it
+/// in this node. It's left out where the text isn't what the file holds (ex.
+/// where a character has been escaped).
+fn gen_str(text: &str, text_start: Option<usize>, context: &mut Context) -> PrintItems {
+  let mut text_builder = TextBuilder::new(text, text_start, context);
 
   for (index, c) in text.char_indices() {
     text_builder.add_char(index, c);
@@ -864,6 +878,17 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
     /// The text being written, which the words are read back out of in order
     /// to work out what a line would begin with.
     text: &'a str,
+    /// Where the text was read from, which a word is looked at from so that
+    /// what follows it in the file counts as well as what follows it here.
+    text_start: Option<usize>,
+    /// How far the words the text begins with run, where they would start a
+    /// block of their own on a line by themselves. Nothing before the end of
+    /// them can be written as a line break, since the text after them can be
+    /// wrapped away and leave them there alone.
+    leading_block_words_end: usize,
+    /// Where the last word written began, which says whether it belongs to
+    /// those leading words.
+    last_word_start: usize,
     /// The last character written, which decides how the space that follows it
     /// reads.
     last_char: Option<char>,
@@ -872,10 +897,13 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
   }
 
   impl<'a> TextBuilder<'a> {
-    pub fn new(text: &'a str, context: &'a Context) -> TextBuilder<'a> {
+    pub fn new(text: &'a str, text_start: Option<usize>, context: &'a Context) -> TextBuilder<'a> {
       TextBuilder {
         items: PrintItems::new(),
         text,
+        text_start,
+        leading_block_words_end: utils::leading_block_words_end(text).unwrap_or(0),
+        last_word_start: 0,
         last_char: None,
         current_word: None,
         context,
@@ -910,6 +938,7 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
           self.items.extend(self.space_items(start, &current_word));
         }
 
+        self.last_word_start = start;
         self.last_char = current_word.chars().last();
         self
           .items
@@ -919,7 +948,19 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
 
     /// What to write in place of the space that ran up to the next word.
     fn space_items(&self, next_word_start: usize, next_word: &str) -> PrintItems {
-      if utils::wrapping_word_starts_block(&self.text[next_word_start..], text_can_be_wrapped_away(self.context)) {
+      if self.last_word_start < self.leading_block_words_end && self.is_at_line_start() {
+        // the word before this one is one of the leading words, which have to
+        // be kept off a line of their own
+        return space();
+      }
+      let line_text = &self.text[next_word_start..];
+      // the words the line begins with can run on past the end of this node,
+      // since a line break within a block is written as a break of its own
+      let following_text = match self.text_start {
+        Some(start) => self.context.text_from(start + next_word_start, start + self.text.len()),
+        None => line_text,
+      };
+      if utils::wrapping_word_starts_block(line_text, following_text, text_can_be_wrapped_away(self.context)) {
         // the text would start a block of its own at the start of a line, so
         // it has to be kept off one
         return space();
@@ -931,6 +972,12 @@ fn gen_str(text: &str, context: &mut Context) -> PrintItems {
         return space();
       }
       get_space_or_newline_based_on_config(self.context)
+    }
+
+    /// Whether the text was written at the start of a line, which is where a
+    /// line break can't have been written before the words it begins with.
+    fn is_at_line_start(&self) -> bool {
+      matches!(self.text_start, Some(start) if self.context.is_line_start_text(start))
     }
 
     /// Whether the space sits between two characters of a script written
@@ -2179,6 +2226,13 @@ fn get_blank_lines(count: u32) -> PrintItems {
     items.push_signal(Signal::NewLine);
   }
   items
+}
+
+/// The node's text through to the end of the block it's written in, which is
+/// how far the line it begins can run on.
+fn following_text<'a>(node: &Node, context: &'a Context) -> &'a str {
+  let span = node.span();
+  context.text_from(span.start, span.end)
 }
 
 /// Whether the text after a word can be wrapped onto the line below it, which

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -94,10 +94,75 @@ pub fn forbids_line_break_after(c: char) -> bool {
 /// makes what the word would start on its own count as well. Where text isn't
 /// being wrapped it can't, and holding the word back would only join lines the
 /// document was written with.
-pub fn starts_block_at_line_start(line_text: &str, word_can_be_left_alone: bool) -> bool {
-  let leading_word = line_text.split(' ').next().unwrap_or(line_text);
-  word_can_be_left_alone && crate::parser::starts_block_in_paragraph(leading_word)
-    || crate::parser::starts_block_in_paragraph(line_text)
+pub fn starts_block_at_line_start(line_text: &str, following_text: &str, word_can_be_left_alone: bool) -> bool {
+  if crate::parser::starts_block_in_paragraph(line_text) {
+    return true;
+  }
+  if !word_can_be_left_alone {
+    return false;
+  }
+  crate::parser::starts_block_in_paragraph(leading_word(line_text)) || leading_block_words_end(following_text).is_some()
+}
+
+/// The word the text begins with, which ends at the space after it -- a line
+/// break included, since the text may run on past the end of the line. Only a
+/// space breaks a word, so a tab is part of one.
+fn leading_word(line_text: &str) -> &str {
+  let end = line_text.find([' ', '\n', '\r']).unwrap_or(line_text.len());
+  &line_text[..end]
+}
+
+/// How far the words the text begins with run, where some of those words would
+/// start a block of their own on a line by themselves.
+///
+/// A thematic break and a table's delimiter row are written as several words
+/// (ex. `* * *`), so neither the first word nor the whole line reads as one and
+/// only the words in between do. A line break written within the run, or
+/// directly after it, would leave them on a line of their own.
+///
+/// The line breaks already written count as the spaces they're read as, since
+/// the words on either side of one can be brought together onto a line. What a
+/// line begins with that belongs to the block rather than the text (ex. a block
+/// quote's markers) is read past.
+pub fn leading_block_words_end(text: &str) -> Option<usize> {
+  // the characters those two are written with, which the first character of
+  // almost every word rules out
+  const MARKS: [char; 6] = ['*', '-', '_', '|', ':', '='];
+
+  let mut line = String::new();
+  let mut marks_end = 0;
+  let mut starts_block = false;
+  let mut ended_within_a_word = false;
+  let mut characters = text.char_indices().peekable();
+  while let Some((index, character)) = characters.next() {
+    if MARKS.contains(&character) {
+      line.push(character);
+      marks_end = index + character.len_utf8();
+      continue;
+    }
+    // a tab doesn't break a word, so the marks are within one
+    if !matches!(character, ' ' | '\n' | '\r') {
+      ended_within_a_word = true;
+      break;
+    }
+    if matches!(character, '\n' | '\r') {
+      // a line ending is one break however it's written
+      if character == '\r' {
+        characters.next_if(|(_, next)| *next == '\n');
+      }
+      // what a line begins with that belongs to the block rather than the text
+      while characters.next_if(|(_, next)| matches!(next, ' ' | '>')).is_some() {}
+      // a blank line ends the block, and what follows it is never brought up
+      if characters.peek().is_some_and(|(_, next)| matches!(next, '\n' | '\r')) {
+        break;
+      }
+    }
+    // the line could end here, leaving the words before it on their own
+    starts_block |= !line.is_empty() && crate::parser::starts_block_in_paragraph(&line);
+    line.push(' ');
+  }
+  starts_block |= !ended_within_a_word && !line.is_empty() && crate::parser::starts_block_in_paragraph(&line);
+  starts_block.then_some(marks_end)
 }
 
 /// Whether the text would start a block of its own if the word that begins it
@@ -106,9 +171,8 @@ pub fn starts_block_at_line_start(line_text: &str, word_can_be_left_alone: bool)
 /// A word that would become a list marker counts as well as what
 /// [`starts_block_at_line_start`] finds, since the text that wraps onto the
 /// line after the marker is what would turn it into a real one.
-pub fn wrapping_word_starts_block(line_text: &str, word_can_be_left_alone: bool) -> bool {
-  let leading_word = line_text.split(' ').next().unwrap_or(line_text);
-  is_list_word(leading_word) || starts_block_at_line_start(line_text, word_can_be_left_alone)
+pub fn wrapping_word_starts_block(line_text: &str, following_text: &str, word_can_be_left_alone: bool) -> bool {
+  is_list_word(leading_word(line_text)) || starts_block_at_line_start(line_text, following_text, word_can_be_left_alone)
 }
 
 /// Checks if the provided word is a word that could be a list.
@@ -318,49 +382,52 @@ mod test {
 
   #[test]
   fn it_should_find_text_that_starts_a_block_at_a_line_start() {
-    assert_eq!(starts_block_at_line_start("test", true), false);
-    assert_eq!(wrapping_word_starts_block("-", true), true);
-    assert_eq!(wrapping_word_starts_block("1.", true), true);
-    assert_eq!(starts_block_at_line_start(">", true), true);
-    assert_eq!(starts_block_at_line_start(">text", true), true);
-    assert_eq!(starts_block_at_line_start("#", true), true);
-    assert_eq!(starts_block_at_line_start("######", true), true);
-    assert_eq!(starts_block_at_line_start("#######", true), false);
-    assert_eq!(starts_block_at_line_start("#text", true), false);
-    assert_eq!(starts_block_at_line_start("=", true), true);
-    assert_eq!(starts_block_at_line_start("===", true), true);
-    assert_eq!(starts_block_at_line_start("=text", true), false);
-    assert_eq!(starts_block_at_line_start("---", true), true);
-    assert_eq!(starts_block_at_line_start("***", true), true);
-    assert_eq!(starts_block_at_line_start("___", true), true);
-    assert_eq!(starts_block_at_line_start("~~~", true), true);
-    assert_eq!(starts_block_at_line_start("```", true), true);
-    assert_eq!(starts_block_at_line_start("~~", true), false);
-    assert_eq!(starts_block_at_line_start("---a", true), false);
+    assert_eq!(starts_block_at_line_start("test", "test", true), false);
+    assert_eq!(wrapping_word_starts_block("-", "-", true), true);
+    assert_eq!(wrapping_word_starts_block("1.", "1.", true), true);
+    assert_eq!(starts_block_at_line_start(">", ">", true), true);
+    assert_eq!(starts_block_at_line_start(">text", ">text", true), true);
+    assert_eq!(starts_block_at_line_start("#", "#", true), true);
+    assert_eq!(starts_block_at_line_start("######", "######", true), true);
+    assert_eq!(starts_block_at_line_start("#######", "#######", true), false);
+    assert_eq!(starts_block_at_line_start("#text", "#text", true), false);
+    assert_eq!(starts_block_at_line_start("=", "=", true), true);
+    assert_eq!(starts_block_at_line_start("===", "===", true), true);
+    assert_eq!(starts_block_at_line_start("=text", "=text", true), false);
+    assert_eq!(starts_block_at_line_start("---", "---", true), true);
+    assert_eq!(starts_block_at_line_start("***", "***", true), true);
+    assert_eq!(starts_block_at_line_start("___", "___", true), true);
+    assert_eq!(starts_block_at_line_start("~~~", "~~~", true), true);
+    assert_eq!(starts_block_at_line_start("```", "```", true), true);
+    assert_eq!(starts_block_at_line_start("~~", "~~", true), false);
+    assert_eq!(starts_block_at_line_start("---a", "---a", true), false);
     // two dashes underline the line above into a heading
-    assert_eq!(starts_block_at_line_start("--", true), true);
+    assert_eq!(starts_block_at_line_start("--", "--", true), true);
     // html, a footnote definition, and a table's delimiter row
-    assert_eq!(starts_block_at_line_start("<div>", true), true);
-    assert_eq!(starts_block_at_line_start("<!-- x -->", true), true);
-    assert_eq!(starts_block_at_line_start("[^note]:", true), true);
-    assert_eq!(starts_block_at_line_start("|---|", true), true);
+    assert_eq!(starts_block_at_line_start("<div>", "<div>", true), true);
+    assert_eq!(starts_block_at_line_start("<!-- x -->", "<!-- x -->", true), true);
+    assert_eq!(starts_block_at_line_start("[^note]:", "[^note]:", true), true);
+    assert_eq!(starts_block_at_line_start("|---|", "|---|", true), true);
     // the word decides it even where the rest of the line reads as text, since
     // that text can wrap onto the line below and leave the word alone
-    assert_eq!(starts_block_at_line_start("-- text", true), true);
-    assert_eq!(starts_block_at_line_start("--- text", true), true);
-    assert_eq!(starts_block_at_line_start("text --", true), false);
+    assert_eq!(starts_block_at_line_start("-- text", "-- text", true), true);
+    assert_eq!(starts_block_at_line_start("--- text", "--- text", true), true);
+    assert_eq!(starts_block_at_line_start("text --", "text --", true), false);
     // a list marker is only a marker once text follows it on the line, so it
     // counts for a word that wrapping would move but not for a node that
     // already begins a line
-    assert_eq!(starts_block_at_line_start("40.", true), false);
-    assert_eq!(wrapping_word_starts_block("40.", true), true);
-    assert_eq!(starts_block_at_line_start("6. Test", true), false);
-    assert_eq!(wrapping_word_starts_block("6. Test", true), true);
+    assert_eq!(starts_block_at_line_start("40.", "40.", true), false);
+    assert_eq!(wrapping_word_starts_block("40.", "40.", true), true);
+    assert_eq!(starts_block_at_line_start("6. Test", "6. Test", true), false);
+    assert_eq!(wrapping_word_starts_block("6. Test", "6. Test", true), true);
     // where the text after the word can't be wrapped away the word is never
     // left alone, so only what the whole line starts counts
-    assert_eq!(starts_block_at_line_start("-- text", false), false);
-    assert_eq!(starts_block_at_line_start("--", false), true);
-    assert_eq!(starts_block_at_line_start("=== not a heading", false), false);
+    assert_eq!(starts_block_at_line_start("-- text", "-- text", false), false);
+    assert_eq!(starts_block_at_line_start("--", "--", false), true);
+    assert_eq!(
+      starts_block_at_line_start("=== not a heading", "=== not a heading", false),
+      false
+    );
   }
 
   #[test]

--- a/tests/specs/Text/Text_BlockStarts_MultipleWords.txt
+++ b/tests/specs/Text/Text_BlockStarts_MultipleWords.txt
@@ -1,0 +1,28 @@
+~~ textWrap: always, lineWidth: 6 ~~
+!! should not leave the words of a thematic break on a line of their own !!
+aaaaaaaa _ _ _ zz
+
+[expect]
+aaaaaaaa _
+_ _ zz
+
+!! should not leave them there when they begin the paragraph !!
+__ __ bbbb
+
+[expect]
+__ __ bbbb
+
+!! should still wrap words that only look like them !!
+aaaaaaaa _ _ zz
+
+[expect]
+aaaaaaaa
+_ _ zz
+
+!! should not hold back a word the marks are written within, which a tab doesn't break !!
+aaaa ___	bb cc
+
+[expect]
+aaaa
+___	bb
+cc

--- a/tests/specs/Text/Text_BlockStarts_MultipleWords_LineWidth7.txt
+++ b/tests/specs/Text/Text_BlockStarts_MultipleWords_LineWidth7.txt
@@ -1,0 +1,16 @@
+~~ textWrap: always, lineWidth: 7 ~~
+!! should read the words past the markers a line within a block quote begins with !!
+> aaaaaaaa _ _ _ zz
+
+[expect]
+> aaaaaaaa _
+> _ _
+> zz
+
+!! should read them past the indentation of a list item !!
+- aaaaaaaa _ _ _ zz
+
+[expect]
+- aaaaaaaa _
+  _ _
+  zz

--- a/tests/specs/Text/Text_BlockStarts_MultipleWords_LineWidth8.txt
+++ b/tests/specs/Text/Text_BlockStarts_MultipleWords_LineWidth8.txt
@@ -1,0 +1,14 @@
+~~ textWrap: always, lineWidth: 8 ~~
+!! should not leave the words of a table's delimiter row on a line of their own !!
+aa|bb | - | - | zz
+
+[expect]
+aa|bb | - | -
+| zz
+
+!! should still wrap a word the marks are written within !!
+aaaaaaaa =text zz
+
+[expect]
+aaaaaaaa
+=text zz


### PR DESCRIPTION
A thematic break and a table's delimiter row are written as **several words** — `* * *`, `| - | - |`. The check for text that can't be wrapped to the start of a line looks at the first word and at the whole line, and neither of those reads as one, so wrapping could leave exactly those words on a line by themselves:

```md
aaaaaaaa _ _ _ zz
```

at `{"textWrap": "always", "lineWidth": 6}`, formatted until it settles, becomes

```md
aaaaaaaa

---

zz
```

— a paragraph, a **thematic break**, and another paragraph. `aa|bb | - | - | zz` at width 8 becomes a **table**. `* * *` and `- - -` escape today only by accident, because `is_list_word("*")` happens to be true; `_ _ _` and `| :-: | :-: |` have no such cover.

The words those two are written with are now read together — across the line breaks already written (which are read as the spaces they render as), and past what a line within a block quote or list begins with, since those markers belong to the block rather than the text. Where the run begins a line, no break is written within it or directly after it either: there's no break before it to hold it back.

### Verification

Formatting to convergence and comparing rendered structure and text against the source through the `commonmark` reference implementation:

| corpus | main corrupts | this branch | branch only |
| --- | --- | --- | --- |
| mark-heavy paragraphs, 4 widths (1600 runs) | 30 | **0** | 0 |
| in a block quote (750) | 56 | **0** | 0 |
| in a nested block quote (750) | 65 | **0** | 0 |
| in a list item (750) | 68 | 9 | 0 |
| plain (750) | 52 | 9 | 0 |

The 9 that remain are a run that begins at an inline node boundary (`[a](b) _ _` / `_ zz`), where the break is decided before the text is reached; `main` corrupts those too.

Under `maintain` and `never`, and at `lineWidth: 80`, output is byte-identical to `main` — the rule only applies where text is actually being wrapped.

### Notes

- The text read is bounded by the block it's written in rather than running to the end of the file. Without that bound, `is_table_delimiter_shape` rescans the remainder of the document once per word: a 1.4 MB file took 33s. It's 0.78s against `main`'s 0.65s now, and a paragraph of 8000 mark-words is *faster* than `main`.
- The check made for a word and the check made for a node read the same text. When they read different text they disagreed about where a line could break, and the formatter oscillated forever — including on an unmodified upstream `bytemuck_derive` CHANGELOG line at width 80.
- A tab doesn't break a word, so the marks around one are part of it and aren't held back.
- `\r\n` is one line ending; treating the two characters separately made the run look like it ended at a blank line.