### PR TITLE
fix: read a line break between scripts written without spaces through emphasis

### DIFF
--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -42,14 +42,14 @@ impl<'a> Node<'a> {
   /// and so does a link whose text begins with one -- what's read there is the
   /// text of that node, not of the one after it.
   ///
-  /// Emphasis and the rest of the text decorations are not looked through:
-  /// which character delimits one is chosen from the whitespace beside it, so
-  /// taking that whitespace away would leave a delimiter that no longer reads
-  /// as one.
+  /// Whether a decoration read through this way keeps reading as one once the
+  /// whitespace beside it is taken away is decided separately, since which
+  /// character delimits it is chosen by what ends up written against it.
   pub fn first_read_char(&self) -> Option<char> {
     match self {
       Node::Text(node) => node.text.chars().next(),
       Node::Code(node) => node.code.chars().next(),
+      Node::TextDecoration(node) => node.children.first().and_then(|child| child.first_read_char()),
       Node::InlineLink(node) => node.children.first().and_then(|child| child.first_read_char()),
       Node::ReferenceLink(node) => node.children.first().and_then(|child| child.first_read_char()),
       Node::ShortcutLink(node) => node.children.first().and_then(|child| child.first_read_char()),
@@ -63,6 +63,7 @@ impl<'a> Node<'a> {
     match self {
       Node::Text(node) => node.text.chars().last(),
       Node::Code(node) => node.code.chars().last(),
+      Node::TextDecoration(node) => node.children.last().and_then(|child| child.last_read_char()),
       Node::InlineLink(node) => node.children.last().and_then(|child| child.last_read_char()),
       Node::ReferenceLink(node) => node.children.last().and_then(|child| child.last_read_char()),
       Node::ShortcutLink(node) => node.children.last().and_then(|child| child.last_read_char()),

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -7,11 +7,25 @@ use regex::Regex;
 
 use super::utils::*;
 use crate::configuration::Configuration;
+use crate::configuration::TextWrap;
 use crate::format_text;
 use crate::format_text::FormatError;
 use crate::parser::Span;
 
 type FormatResult = Result<Option<String>, FormatError>;
+
+/// The line breaks that aren't written out, and the characters that end up
+/// written against each other in their place.
+///
+/// Both are held by where the node beside the break begins or ends, in order,
+/// so that one can be looked up by that.
+#[derive(Default)]
+pub struct DroppedBreaks {
+  /// The last character written before the node beginning at each position.
+  pub before: Vec<(usize, char)>,
+  /// The first character written after the node ending at each position.
+  pub after: Vec<(usize, char)>,
+}
 
 /// Where a node sits among the ones around it, which decides how some of them
 /// have to be written.
@@ -67,6 +81,8 @@ pub struct Context<'a> {
   /// when it has to be escaped so that it isn't read as the start of a block
   /// of its own.
   escaped_block_starts: Vec<(usize, usize)>,
+  /// The line breaks between the nodes being written that aren't written out.
+  dropped_breaks: DroppedBreaks,
   /// The delimiter each text decoration is written with, by where it starts.
   decoration_delimiters: std::cell::RefCell<HashMap<usize, &'static str>>,
   /// The character the list item being generated is marked with.
@@ -116,6 +132,7 @@ impl<'a> Context<'a> {
       enclosing_decoration: None,
       escaped_closing_hashes: None,
       escaped_block_starts: Vec::new(),
+      dropped_breaks: Default::default(),
       decoration_delimiters: std::cell::RefCell::new(HashMap::new()),
       list_marker_char: None,
       list_marker_lines_up: true,
@@ -331,6 +348,47 @@ impl<'a> Context<'a> {
     let result = func(self);
     self.escaped_block_starts = previous;
     result
+  }
+
+  /// Generates a run of nodes, `dropped` holding the line breaks within it and
+  /// everything nested in it that aren't written out.
+  pub fn with_dropped_breaks<T>(&mut self, dropped: DroppedBreaks, func: impl FnOnce(&mut Context) -> T) -> T {
+    let previous = std::mem::replace(&mut self.dropped_breaks, dropped);
+    let result = func(self);
+    self.dropped_breaks = previous;
+    result
+  }
+
+  /// Whether the line break written before the node starting here is dropped
+  /// rather than written out.
+  pub fn drops_break_before(&self, start: usize) -> bool {
+    self
+      .dropped_breaks
+      .before
+      .binary_search_by_key(&start, |(at, _)| *at)
+      .is_ok()
+  }
+
+  /// The character written directly before the node starting here, where the
+  /// line break between them is dropped.
+  pub fn char_written_before(&self, start: usize) -> Option<char> {
+    self.written_char(&self.dropped_breaks.before, start)
+  }
+
+  /// The character written directly after the node ending here, where the line
+  /// break between them is dropped.
+  pub fn char_written_after(&self, end: usize) -> Option<char> {
+    self.written_char(&self.dropped_breaks.after, end)
+  }
+
+  fn written_char(&self, at: &[(usize, char)], position: usize) -> Option<char> {
+    // a break that is kept is still written out, so nothing moves against it
+    if self.configuration.text_wrap == TextWrap::Maintain {
+      return None;
+    }
+    at.binary_search_by_key(&position, |(at, _)| *at)
+      .ok()
+      .map(|index| at[index].1)
   }
 
   /// Where a backslash goes in the text starting here, when it is written

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -68,10 +68,78 @@ fn gen_source_file(source_file: &SourceFile, context: &mut Context) -> PrintItem
 }
 
 fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
   if nodes.is_empty() {
-    return items;
+    return PrintItems::new();
   }
+  let dropped = dropped_breaks(nodes, context);
+  context.with_dropped_breaks(dropped, |context| gen_nodes_within_breaks(nodes, context))
+}
+
+/// The line breaks within the nodes, and everything nested in them, that
+/// aren't written out -- which is where a break between two characters of a
+/// script written without spaces reads as nothing at all.
+///
+/// These are worked out once for the whole tree before any of it is written,
+/// so that everything written from it agrees about what ends up beside what.
+/// The delimiters a text decoration is written with are chosen by the
+/// characters on either side of it, and a decoration nested within another is
+/// asked for its delimiters while the run it belongs to is still being
+/// measured -- so nothing below here may be left out.
+fn dropped_breaks(nodes: &[Node], context: &Context) -> DroppedBreaks {
+  let mut dropped = DroppedBreaks::default();
+  // a reference is matched by the text of its label, so a break written within
+  // one is part of what it's matched by and has to stay
+  if context.is_preserving_decorations() {
+    return dropped;
+  }
+  push_dropped_breaks(nodes, context, &mut dropped);
+  dropped.before.sort_by_key(|(at, _)| *at);
+  dropped.after.sort_by_key(|(at, _)| *at);
+  dropped
+}
+
+fn push_dropped_breaks(nodes: &[Node], context: &Context, dropped: &mut DroppedBreaks) {
+  let mut last_node: Option<&Node> = None;
+  for node in nodes.iter().filter(|node| !matches!(node, Node::SoftBreak(_))) {
+    if let Some(last_node) = last_node {
+      let between = (last_node.span().end, node.span().start);
+      if context.get_new_lines_in_range(between.0, between.1) == 1 && drops_break_between(last_node, node, context) {
+        let before = last_node.span().text(context.file_text).chars().last();
+        let after = node.span().text(context.file_text).chars().next();
+        if let (Some(before), Some(after)) = (before, after) {
+          dropped.before.push((node.span().start, before));
+          dropped.after.push((last_node.span().end, after));
+        }
+      }
+    }
+    last_node = Some(node);
+    if let Some(children) = written_children(node) {
+      push_dropped_breaks(children, context, dropped);
+    }
+  }
+}
+
+/// The nodes written within this one, which hold breaks of their own.
+fn written_children<'a>(node: &'a Node<'a>) -> Option<&'a [Node<'a>]> {
+  match node {
+    Node::TextDecoration(node) => Some(&node.children),
+    Node::InlineLink(node) => Some(&node.children),
+    // a reference link is matched by the text of its label, so a break written
+    // within one is part of what it's matched by and has to stay
+    _ => None,
+  }
+}
+
+/// Whether the line break between the two nodes reads as nothing, and so is
+/// dropped rather than written out as the space it would otherwise read as.
+fn drops_break_between(last_node: &Node, node: &Node, context: &Context) -> bool {
+  last_node.ends_with_unspaced_script()
+    && node.starts_with_unspaced_script()
+    && can_be_written_beside(last_node, node, context.file_text)
+}
+
+fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems {
+  let mut items = PrintItems::new();
 
   let mut last_node: Option<&Node> = None;
   let mut node_iterator = nodes.iter().filter(|n| !matches!(n, Node::SoftBreak(_)));
@@ -152,10 +220,7 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
                 items.push_space();
               } else if matches!(node, Node::Html(_)) {
                 items.push_signal(Signal::NewLine);
-              } else if last_node.ends_with_unspaced_script()
-                && node.starts_with_unspaced_script()
-                && can_be_written_beside(last_node, node, context.file_text)
-              {
+              } else if context.drops_break_before(node.span().start) {
                 items.extend(get_unspaced_script_newline_wrapping(context));
               } else {
                 items.extend(get_newline_wrapping_based_on_config(context));
@@ -180,7 +245,14 @@ fn gen_nodes(nodes: &[Node], context: &mut Context) -> PrintItems {
               };
 
               if needs_space {
-                if node.starts_block_at_line_start(text_can_be_wrapped_away(context)) || node.starts_with_list_word() {
+                if drops_break_between(last_node, node, context) {
+                  // a space between two characters of a script written without
+                  // spaces is rendered, so it's kept as one rather than being
+                  // written as the line break that would read as nothing
+                  items.push_space();
+                } else if node.starts_block_at_line_start(text_can_be_wrapped_away(context))
+                  || node.starts_with_list_word()
+                {
                   // the node would start a block of its own at the start of a
                   // line, so it has to be kept off one
                   items.push_space();
@@ -1002,7 +1074,7 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
     // the delimiter of a decoration written directly against this one is read by
     // what sits beside it, so changing this one's character would change theirs.
     // What the file already had parsed as this decoration, so it is safe.
-    if within_word || is_delimiter(before) || is_delimiter(after) {
+    if is_delimiter(before) || is_delimiter(after) {
       return written_delimiter(decoration, context);
     }
 
@@ -1020,6 +1092,10 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
   /// delimiters of the decoration it is nested directly within -- those are
   /// written out here too, so they are chosen to sit beside this one rather
   /// than being something this one has to avoid.
+  ///
+  /// Where the line break beside the decoration isn't written out, the
+  /// character past it is what ends up against the delimiter, so that's what's
+  /// read here.
   fn surrounding_chars(
     decoration: &TextDecoration,
     parent_content: Option<Span>,
@@ -1028,11 +1104,15 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
     let span = decoration.span;
     let before = match parent_content {
       Some(content) if content.start == span.start => None,
-      _ => context.file_text[..span.start].chars().next_back(),
+      _ => context
+        .char_written_before(span.start)
+        .or_else(|| context.file_text[..span.start].chars().next_back()),
     };
     let after = match parent_content {
       Some(content) if content.end == span.end => None,
-      _ => context.file_text[span.end..].chars().next(),
+      _ => context
+        .char_written_after(span.end)
+        .or_else(|| context.file_text[span.end..].chars().next()),
     };
     (before, after)
   }
@@ -2212,7 +2292,54 @@ fn space() -> PrintItems {
 fn can_be_written_beside(last_node: &Node, node: &Node, file_text: &str) -> bool {
   let last = last_node.span().text(file_text).chars().last();
   let next = node.span().text(file_text).chars().next();
-  !matches!((last, next), (Some(last), Some(next)) if last.is_ascii_punctuation() && next.is_ascii_punctuation())
+  if matches!((last, next), (Some(last), Some(next)) if last.is_ascii_punctuation() && next.is_ascii_punctuation()) {
+    return false;
+  }
+  keeps_its_delimiters(last_node, file_text) && keeps_its_delimiters(node, file_text)
+}
+
+/// Whether the node's delimiters would still read as delimiters with the
+/// whitespace beside it taken away.
+fn keeps_its_delimiters(node: &Node, file_text: &str) -> bool {
+  match node {
+    Node::TextDecoration(decoration) => decoration_keeps_its_delimiters(decoration, file_text),
+    _ => true,
+  }
+}
+
+/// Whether the decoration's delimiters would still read as delimiters with the
+/// whitespace beside it taken away.
+///
+/// Which characters sit on either side of a delimiter is what decides whether
+/// it reads as one, so the text it holds has to begin and end with a word
+/// character, and nothing written against it from outside may be read as part
+/// of its delimiters.
+fn decoration_keeps_its_delimiters(decoration: &TextDecoration, file_text: &str) -> bool {
+  // it has to be text that's written against the delimiter: anything with
+  // delimiters of its own there (ex. a code span's backticks, or a decoration
+  // nested at the edge) is read together with it rather than beside it
+  let holds_a_word = |node: Option<&Node>, character: fn(&str) -> Option<char>| match node {
+    Some(Node::Text(text)) => character(text.text).is_some_and(char::is_alphanumeric),
+    _ => false,
+  };
+  // a delimiter character written against the run lengthens it, and how long
+  // the runs on either side of the text are is what pairs them up
+  let is_delimiter = |character: Option<char>| matches!(character, Some('*') | Some('_') | Some('~'));
+  holds_a_word(decoration.children.first(), |text| text.chars().next())
+    && holds_a_word(decoration.children.last(), last_unescaped_char)
+    && !is_delimiter(file_text[..decoration.span.start].chars().next_back())
+    && !is_delimiter(file_text[decoration.span.end..].chars().next())
+    && !holds_the_same_kind(&decoration.children, decoration.kind)
+}
+
+/// Whether a decoration of the same kind is written within these nodes, whose
+/// delimiter would be the same character as the one around them and so would
+/// be paired up with it rather than read on its own.
+fn holds_the_same_kind(nodes: &[Node], kind: TextDecorationKind) -> bool {
+  nodes.iter().any(|node| match node {
+    Node::TextDecoration(decoration) => decoration.kind == kind || holds_the_same_kind(&decoration.children, kind),
+    _ => false,
+  })
 }
 
 /// What takes the place of a line break that falls between two characters of

--- a/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
@@ -30,7 +30,7 @@
 [expect]
 ![日](https://dprint.dev/a.png) 日本語
 
-!! should keep the line break beside a text decoration, whose delimiter is chosen from the whitespace around it !!
+!! should drop a line break beside a text decoration !!
 日本語
 *テスト*
 
@@ -38,9 +38,21 @@
 そして次へ
 
 [expect]
-日本語 _テスト_
+日本語*テスト*
 
-実行**します** そして次へ
+実行**します**そして次へ
+
+!! should keep it where the decoration's delimiter would stop reading as one !!
+**日本、**
+そして次へ
+
+日本語
+*テスト、*
+
+[expect]
+**日本、** そして次へ
+
+日本語 _テスト、_
 
 !! should keep the line break where the delimiters would run together !!
 **日本語**
@@ -77,3 +89,40 @@
 
 [expect]
 日本語 <https://例え.jp>
+
+!! should keep the line break where the delimiter isn't written against the text it holds !!
+日本語
+*`コード`*
+
+日本語
+**_テスト_**
+
+[expect]
+日本語 _`コード`_
+
+日本語 **_テスト_**
+
+!! should keep it where a delimiter written beside the decoration lengthens its run !!
+日本語
+*テスト**
+
+[expect]
+日本語 *テスト**
+
+!! should keep it where the same kind of decoration is written within !!
+日本語
+_テ*ス*ト_
+
+[expect]
+日本語 _テ*ス*ト_
+
+!! should keep it within a reference's label, which the reference is matched by !!
+[_日本_
+語です]
+
+[_日本_ 語です]: https://dprint.dev
+
+[expect]
+[_日本_ 語です]
+
+[_日本_ 語です]: https://dprint.dev


### PR DESCRIPTION
#238 looks through a link's and a code span's delimiters when applying [line-break-transform](https://drafts.csswg.org/css-text-4/#line-break-transform), but deliberately not through a text decoration, because doing so destroyed emphasis:

```md
日本語        →  日本語_テスト_        the underscores are intraword and
*テスト*                                aren't read as delimiters at all
```

The cause wasn't the rule — it was that the decision was made **twice, from different views**. `gen_nodes` decided which breaks to drop from the node list; `decoration_delimiter` decided which character to delimit with by reading the raw file text, where the break was still there. They disagreed, and every attempt to reconcile them (blank lines, block quote markers, cross-node spaces) just moved the disagreement.

### The redesign

The dropped breaks are worked out **once**, for the whole tree, before anything is written, and recorded on the `Context`. Both the wrapping code and the delimiter choice read that one record. The disagreement can't exist any more.

That alone took format-twice instability from 42/7/0/2/5 per 500 documents to **0 across all five configs**, and let me delete the patches rather than add another.

The record covers what's nested inside the nodes, not just the top run: a decoration written inside another is asked for its delimiters while the outer run is still being measured, so anything below has to already be in the record.

### What the rule is now allowed to do

A decoration is looked through only where its delimiters go on reading as delimiters whatever ends up beside them:

- the text it holds begins and ends with a **word character written against the delimiter** — a code span's backtick, a link's `[`, or a nested decoration's own delimiter is read *together* with it rather than beside it;
- nothing written beside it lengthens the delimiter run (`*テスト**` — the run maths is what pairs delimiters up);
- it doesn't hold a decoration of its own kind, whose delimiter would be paired with it instead;
- and a break inside a **reference's label** is left alone, since the label is what the reference is matched by.

Which character delimits a decoration written within a word is now left to the flanking rules rather than keeping whatever the file had. They already say an underscore isn't a delimiter there, so they pick the asterisks that are — and unlike the shortcut they also check the delimiter doesn't run into the content.

A space between two such characters is now kept as a space *between* nodes as well as within one, which it always should have been.

### Verification

All through the `commonmark` reference implementation, formatting to convergence. Strikethrough is excluded from the verified sets because commonmark.js doesn't implement it.

| | main | branch | branch-only |
| --- | --- | --- | --- |
| decoration pairs — structure (2500) | 3 | 3 | **0** |
| decoration pairs — text (2500) | 781 | 601 | **0** |
| inline pairs — structure (2352) | 0 | 0 | **0** |
| inline pairs — text (2352) | 218 | 182 | **0** |
| random docs — structure, 3 seeds (5250) | 15 / 5 / 5 | 15 / 5 / 5 | **0** |
| idempotency, 5 configs × 600 docs | 0 | **0** | — |

`maintain` is byte-identical to main.