### PR TITLE
fix: write a backslash where two spaces can't be read as a hard break

### DIFF
--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -370,9 +370,9 @@ impl<'a> Context<'a> {
     &self.file_text[start..end]
   }
 
-  /// Whether the text starting here is written at the start of a line, which
-  /// is where nothing precedes it that a line break could be written at.
-  pub fn is_line_start_text(&self, start: usize) -> bool {
+  /// Whether what starts here is written at the start of a line, with nothing
+  /// before it on that line.
+  pub fn is_line_start(&self, start: usize) -> bool {
     self.line_start_texts.contains(&start)
   }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -44,7 +44,7 @@ pub fn generate(node: &Node, context: &mut Context) -> PrintItems {
     Node::TaskListMarker(_) => unreachable!("this should be handled by gen_paragraph"),
     Node::HorizontalRule(node) => gen_horizontal_rule(node, position),
     Node::SoftBreak(_) => PrintItems::new(),
-    Node::HardBreak(_) => gen_hard_break(context),
+    Node::HardBreak(node) => gen_hard_break(node, context),
     Node::Table(node) => gen_table(node, context),
     Node::TableHead(_) => unreachable!(),
     Node::TableRow(_) => unreachable!(),
@@ -479,8 +479,8 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
     let mut at_line_start = true;
     for child in children {
       if at_line_start {
+        line_starts.push(child.span().start);
         if let Node::Text(text) = child {
-          line_starts.push(text.span.start);
           if let Some(position) = escape(text.text) {
             starts.push((text.span.start, position));
           }
@@ -1048,7 +1048,7 @@ fn gen_str(text: &str, text_start: Option<usize>, context: &mut Context) -> Prin
     /// Whether the text was written at the start of a line, which is where a
     /// line break can't have been written before the words it begins with.
     fn is_at_line_start(&self) -> bool {
-      matches!(self.text_start, Some(start) if self.context.is_line_start_text(start))
+      matches!(self.text_start, Some(start) if self.context.is_line_start(start))
     }
 
     /// Whether the space sits between two characters of a script written
@@ -2014,7 +2014,7 @@ fn gen_horizontal_rule(_: &HorizontalRule, position: NodePosition) -> PrintItems
 /// becomes a space where newlines are being forced off (ex. within an ATX
 /// heading). Otherwise the marker it leaves behind would either escape the
 /// character that followed it or be collapsed as extra whitespace.
-fn gen_hard_break(context: &mut Context) -> PrintItems {
+fn gen_hard_break(hard_break: &HardBreak, context: &mut Context) -> PrintItems {
   /// The two spaces a double space hard break leaves behind, measured as zero
   /// columns because trailing whitespace isn't visible.
   const DOUBLE_SPACE: StringContainer = StringContainer::proc_macro_new_with_char_count("  ", 0);
@@ -2025,12 +2025,19 @@ fn gen_hard_break(context: &mut Context) -> PrintItems {
 
   let hard_break = {
     let mut items = PrintItems::new();
-    match context.configuration.hard_break_kind {
-      HardBreakKind::Backslash => items.push_sc(sc!("\\")),
+    // two spaces are only read as a break where there's text before them on
+    // the line, so a backslash is written where there isn't -- a line holding
+    // nothing but whitespace ends the paragraph rather than breaking a line
+    // within it
+    let writes_double_space = context.configuration.hard_break_kind == HardBreakKind::DoubleSpace
+      && !context.is_line_start(hard_break.span.start);
+    if writes_double_space {
       // the two spaces sit at the end of the line, where they take no visible
       // width, so they're written as zero columns to keep them out of the
       // decision of where the text before them wraps
-      HardBreakKind::DoubleSpace => items.push_sc(&DOUBLE_SPACE),
+      items.push_sc(&DOUBLE_SPACE);
+    } else {
+      items.push_sc(sc!("\\"));
     }
     items.push_signal(Signal::NewLine);
     items

--- a/tests/specs/General/HardBreaks_DoubleSpace_LineStart.txt
+++ b/tests/specs/General/HardBreaks_DoubleSpace_LineStart.txt
@@ -1,0 +1,40 @@
+~~ hardBreakKind: doubleSpace ~~
+!! should write a backslash where two spaces would have nothing before them !!
+> \
+> bbb
+
+[expect]
+> \
+> bbb
+
+!! should write one within a nested block quote and a list item !!
+>> \
+>> bbb
+
+- > \
+  > bbb
+
+[expect]
+>> \
+>> bbb
+
+- > \
+  > bbb
+
+!! should write one for a break that follows another !!
+> aaa\
+> \
+> bbb
+
+[expect]
+> aaa  
+> \
+> bbb
+
+!! should still write two spaces where there is text before them !!
+aaa\
+bbb
+
+[expect]
+aaa  
+bbb


### PR DESCRIPTION
Two spaces are only read as a hard break where there's **text before them on the line** — a line holding nothing but whitespace ends the paragraph rather than breaking a line within it. So `hardBreakKind: doubleSpace` silently lost every break that had nothing written before it.

```md
> \
> bbb
```

is written as `>` followed by two spaces, which reads back as no break at all, and a second pass settles on:

```md
> bbb
```

Two breaks in a row are worse — `aaa\` / `\` / `bbb` comes out as a blank line, so one paragraph becomes two.

Where the break has nothing before it on its line, the backslash that *can* be read there is written instead. Whether there's text before it is already known: the walk in `gen_paragraph` that decides what has to be escaped at the start of a line tracks exactly that, for the first child and for anything after a hard break.

Through the `commonmark` reference implementation:

| | source | main | this branch |
| --- | --- | --- | --- |
| `> \` / `> bbb` | `<br />` | *break gone* | `<br />` |
| `aaa\` / `\` / `bbb` | one paragraph, two `<br />` | **two paragraphs** | one paragraph, two `<br />` |

### Verification

700 generated documents of breaks in paragraphs, block quotes, nested block quotes and list items, four configs, formatted to convergence and compared against the source's rendering:

| | main | branch |
| --- | --- | --- |
| rendering changed (2800 runs) | 117 | **81** |

— 36 fixed, **0 branch-only**. Across 500 general documents per config, format-twice instability under `doubleSpace` drops from 79 to 8 (and from 76 to 7 while wrapping); under `backslash`, the default, and `never` the output is **byte-identical to main**.

The 8 that remain are the same shapes `main` fails on for other reasons — a list item whose content starts with a mark run, and code-fence backtick counting.