### PR TITLE
fix: write a list beside the marker of the item that holds only it

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1909,10 +1909,16 @@ fn gen_item(item: &Item, context: &mut Context) -> PrintItems {
     context,
   ));
 
-  if !item.sub_lists.is_empty() {
-    items.extend(get_blank_lines(
-      context.get_leading_blank_lines(item.sub_lists.first().unwrap().span().start),
-    ));
+  if let Some(first_sub_list) = item.sub_lists.first() {
+    // an item with nothing of its own has its lists written beside its marker.
+    // On a line of their own the marker would be left alone on one, where it
+    // underlines a paragraph above it into a heading and can't be read as a
+    // marker at all, since an item with nothing in it doesn't interrupt one
+    if !item.children.is_empty() {
+      items.extend(get_blank_lines(
+        context.get_leading_blank_lines(first_sub_list.span().start),
+      ));
+    }
     items.extend(gen_nodes(&item.sub_lists, context));
   }
 

--- a/tests/specs/Issues/Issue0192.txt
+++ b/tests/specs/Issues/Issue0192.txt
@@ -24,8 +24,7 @@
 - - [a]: b
 
 [expect]
--
-  - [a]: b
+- - [a]: b
 
 !! should keep a link reference definition in a block quote's list item !!
 > - [a]: b

--- a/tests/specs/Lists/Lists_All.txt
+++ b/tests/specs/Lists/Lists_All.txt
@@ -122,8 +122,7 @@ Here is a paragraph
    - test
 
 [expect]
-1.
-   - test
+1. - test
 
 !! should handle sub list between paragraphs !!
 1. Testing

--- a/tests/specs/Lists/Lists_ItemHoldingOnlyAList.txt
+++ b/tests/specs/Lists/Lists_ItemHoldingOnlyAList.txt
@@ -1,0 +1,25 @@
+!! should write an item's list beside its marker where the item holds nothing else !!
+- a
+  * - b
+
+[expect]
+- a
+  - - b
+
+!! should do so for each such item !!
+- a
+  * - b
+  * - c
+
+[expect]
+- a
+  - - b
+  - - c
+
+!! should do so within an ordered item !!
+1. a
+   * - b
+
+[expect]
+1. a
+   - - b


### PR DESCRIPTION
An item holding nothing but a list of its own has its marker written on a line by itself, with the list below it. Directly under a paragraph, that line of dashes underlines the paragraph into a heading:

```md
- a
  * - b
```

formats to `- a` / `  -` / `    - b`, and formatting **that** gives:

```md
- ## a
  - b
```

The item's text has become a heading. Confirmed against the `commonmark` reference implementation — the source renders `<li>a<ul><li><ul><li>b`, the output renders `<li><h2>a</h2><ul><li>b`.

It's width-independent: it reproduces under `maintain` and `never` as well as while wrapping.

### Why the marker character isn't the fix

My first attempt was to use the other bullet character there, mirroring what `gen_horizontal_rule` already does for `---` under a paragraph. That trades one corruption for another — an item with nothing in it **can't interrupt a paragraph**, so a marker alone below one is read as part of the paragraph's text whatever it's written with. The `*` became literal text and a level of nesting was lost.

Writing the list beside the marker leaves nothing on a line of its own, and renders identically to the source:

```md
- a
  - - b
```

### Two specs change, both style not meaning

`1.` / `   - test` becomes `1. - test`, and `-` / `  - [a]: b` becomes `- - [a]: b`. Both render identically to the form they replace — checked through the reference implementation before updating them.

### Verification

Every ordered pair of 10 item shapes under 5 container prefixes at 3 configs — 1500 runs, formatted to convergence, rendered structure and text compared against the source:

| | main | branch | branch-only |
| --- | --- | --- | --- |
| rendering changed | 78 | **30** | **0** |

48 fixed, none introduced. On general documents at 400 per config, format-twice instability goes 3 → 1 at width 60 and 80, and 2 → 0 under `maintain` and `never`.

Not addressed: under `listIndentKind: pythonMarkdown` instability is unchanged at 9/400 — a separate residual.