### PR TITLE
refactor: gather ambiguous arguments into named types

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -59,10 +59,7 @@ fn format_text_inner(
   Ok(Some(dprint_core::formatting::format(
     || {
       let mut context = Context::new(markdown_text, config, format_code_block_text);
-      #[allow(clippy::let_and_return)]
-      let print_items = generate(&source_file.into(), &mut context);
-      // eprintln!("{}", print_items.get_as_text());
-      print_items
+      generate(&source_file.into(), &mut context)
     },
     config_to_print_options(file_text, config),
   )))
@@ -81,10 +78,7 @@ pub fn trace_file(
   dprint_core::formatting::trace_printing(
     || {
       let mut context = Context::new(markdown_text, config, format_code_block_text);
-      #[allow(clippy::let_and_return)]
-      let print_items = generate(&source_file.into(), &mut context);
-      // eprintln!("{}", print_items.get_as_text());
-      print_items
+      generate(&source_file.into(), &mut context)
     },
     config_to_print_options(file_text, config),
   )

--- a/src/generation/common/mod.rs
+++ b/src/generation/common/mod.rs
@@ -131,7 +131,7 @@ impl<'a> Node<'a> {
   /// Whether the node would start a block of its own, or turn the line above
   /// it into one, if it were moved to the start of a line by wrapping.
   ///
-  /// Unlike [`Self::starts_block_in_paragraph`] this counts what the node's
+  /// Unlike [`Self::starts_block_at_block_start`] this counts what the node's
   /// first word would start on its own, since the text after it can wrap onto
   /// the line below and leave it there alone.
   pub fn starts_block_at_line_start(&self, following_text: &str, word_can_be_left_alone: bool) -> bool {

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -27,27 +27,55 @@ pub struct DroppedBreaks {
   pub after: Vec<(usize, char)>,
 }
 
+/// What the paragraph being written has to be written with in order to be read
+/// back as the paragraph it is.
+pub struct ParagraphEscapes {
+  /// The text the paragraph writes at the start of a line that would be read
+  /// as the start of a block of its own.
+  pub block_starts: Vec<BlockStartEscape>,
+  /// Where each bit of text the paragraph writes at the start of a line
+  /// starts.
+  pub line_starts: Vec<usize>,
+  /// Where the paragraph ends, which bounds how far the text of one of its
+  /// lines can run.
+  pub end: usize,
+}
+
+/// Where a backslash goes so that a bit of a paragraph's text isn't read as the
+/// start of a block of its own.
+pub struct BlockStartEscape {
+  /// Where the text that would be read that way starts.
+  pub text_start: usize,
+  /// Where within that text the backslash goes.
+  pub position: usize,
+}
+
 /// Where a node sits among the ones around it, which decides how some of them
 /// have to be written.
 #[derive(Default, Clone, Copy)]
 pub struct NodePosition {
-  /// Whether the node is written directly after a list item's marker, which
+  /// The marker of the list item the node is written directly after, which
   /// takes the place of the indentation its first line would have.
-  pub beside_marker: bool,
-  /// The character marking the list item the node is written within, where it
-  /// is written within one.
-  pub marker_char: Option<char>,
-  /// Whether the indentation the list item's content is written at lines up
-  /// with the column its marker leaves the first line at. Where it doesn't,
-  /// nothing that has to keep its own indentation can be written beside the
-  /// marker.
-  pub marker_lines_up: bool,
+  pub marker: Option<ListItemMarker>,
   /// Whether a list is written directly above the node, which would take the
   /// indentation of anything indented into its last item.
   pub after_list: bool,
   /// Whether a paragraph is written directly above the node with no blank line
   /// between, which a line of dashes below would turn into a heading.
   pub after_paragraph: bool,
+}
+
+/// The marker of a list item, which decides how what is written beside it may
+/// be written.
+#[derive(Clone, Copy)]
+pub struct ListItemMarker {
+  /// The character the item is marked with, where it is marked with one rather
+  /// than numbered.
+  pub char: Option<char>,
+  /// Whether the indentation the item's content is written at lines up with
+  /// the column its marker leaves the first line at. Where it doesn't, nothing
+  /// that has to keep its own indentation can be written beside the marker.
+  pub lines_up: bool,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -61,9 +89,9 @@ pub enum MemoizedRcPathKind {
 pub struct Context<'a> {
   pub file_text: &'a str,
   pub configuration: &'a Configuration,
-  /** The current indentation level of what's being printed out. */
+  /// The current indentation level of what's being printed out.
   pub indent_level: u32,
-  /** The current indentation level within the file being formatted. */
+  /// The current indentation level within the file being formatted.
   pub raw_indent_level: u32,
   is_in_list_count: u32,
   /// The indentation level each surrounding block quote started at, from outermost to innermost.
@@ -80,7 +108,7 @@ pub struct Context<'a> {
   /// Where each bit of text a paragraph writes at the start of a line starts,
   /// when it has to be escaped so that it isn't read as the start of a block
   /// of its own.
-  escaped_block_starts: Vec<(usize, usize)>,
+  escaped_block_starts: Vec<BlockStartEscape>,
   /// Where each bit of text written at the start of a line starts.
   line_start_texts: Vec<usize>,
   /// Where the block being written ends, which bounds how far the text of one
@@ -90,11 +118,8 @@ pub struct Context<'a> {
   dropped_breaks: DroppedBreaks,
   /// The delimiter each text decoration is written with, by where it starts.
   decoration_delimiters: std::cell::RefCell<HashMap<usize, &'static str>>,
-  /// The character the list item being generated is marked with.
-  list_marker_char: Option<char>,
-  /// Whether the indentation of the list item being generated lines up with
-  /// the column its marker leaves the first line at.
-  list_marker_lines_up: bool,
+  /// The marker of the list item being generated.
+  list_marker: ListItemMarker,
   /// Where the node generated next sits.
   next_position: NodePosition,
   pub format_code_block_text: Box<dyn for<'b> FnMut(&str, &'b str, u32) -> FormatResult + 'a>,
@@ -141,8 +166,10 @@ impl<'a> Context<'a> {
       block_end: None,
       dropped_breaks: Default::default(),
       decoration_delimiters: std::cell::RefCell::new(HashMap::new()),
-      list_marker_char: None,
-      list_marker_lines_up: true,
+      list_marker: ListItemMarker {
+        char: None,
+        lines_up: true,
+      },
       next_position: NodePosition::default(),
       format_code_block_text: Box::new(format_code_block_text),
       ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
@@ -263,29 +290,18 @@ impl<'a> Context<'a> {
     items
   }
 
-  /// Generates the content of a list item marked with the given character,
-  /// which is indented to line up with the column after its marker where
-  /// `lines_up` holds.
-  pub fn mark_in_list_item<T>(
-    &mut self,
-    marker: Option<char>,
-    lines_up: bool,
-    func: impl FnOnce(&mut Context) -> T,
-  ) -> T {
-    let previous_marker = std::mem::replace(&mut self.list_marker_char, marker);
-    let previous_lines_up = std::mem::replace(&mut self.list_marker_lines_up, lines_up);
+  /// Generates the content of the list item the marker belongs to.
+  pub fn mark_in_list_item<T>(&mut self, marker: ListItemMarker, func: impl FnOnce(&mut Context) -> T) -> T {
+    let previous = std::mem::replace(&mut self.list_marker, marker);
     let result = func(self);
-    self.list_marker_char = previous_marker;
-    self.list_marker_lines_up = previous_lines_up;
+    self.list_marker = previous;
     result
   }
 
   /// Marks that a list item's marker was just written out, so that what comes
   /// directly after it can tell it will be sitting beside it.
   pub fn mark_marker_beside(&mut self) {
-    self.next_position.beside_marker = true;
-    self.next_position.marker_char = self.list_marker_char;
-    self.next_position.marker_lines_up = self.list_marker_lines_up;
+    self.next_position.marker = Some(self.list_marker);
   }
 
   /// Marks that a paragraph was just written out with nothing between it and
@@ -344,20 +360,14 @@ impl<'a> Context<'a> {
     self.escaped_closing_hashes == Some(start)
   }
 
-  /// Generates the content of a paragraph, whose text at each of `starts` would
-  /// be read as the start of a block of its own.
-  pub fn with_escaped_block_starts<T>(
-    &mut self,
-    starts: Vec<(usize, usize)>,
-    line_starts: Vec<usize>,
-    block_end: usize,
-    func: impl FnOnce(&mut Context) -> T,
-  ) -> T {
-    let previous = std::mem::replace(&mut self.escaped_block_starts, starts);
-    let previous_line_starts = std::mem::replace(&mut self.line_start_texts, line_starts);
-    let previous_end = self.block_end.replace(block_end);
+  /// Generates the content of a paragraph, which `escapes` says has to be
+  /// written with backslashes in order to be read back as one.
+  pub fn with_paragraph_escapes<T>(&mut self, escapes: ParagraphEscapes, func: impl FnOnce(&mut Context) -> T) -> T {
+    let previous_starts = std::mem::replace(&mut self.escaped_block_starts, escapes.block_starts);
+    let previous_line_starts = std::mem::replace(&mut self.line_start_texts, escapes.line_starts);
+    let previous_end = self.block_end.replace(escapes.end);
     let result = func(self);
-    self.escaped_block_starts = previous;
+    self.escaped_block_starts = previous_starts;
     self.line_start_texts = previous_line_starts;
     self.block_end = previous_end;
     result
@@ -423,8 +433,8 @@ impl<'a> Context<'a> {
     self
       .escaped_block_starts
       .iter()
-      .find(|(text_start, _)| *text_start == start)
-      .map(|(_, position)| *position)
+      .find(|escape| escape.text_start == start)
+      .map(|escape| escape.position)
   }
 
   pub fn enclosing_decoration(&self) -> Option<Span> {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -214,9 +214,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
               // > Some note.
               if is_callout_node(last_node, context) && !context.is_text_wrap_disabled() {
                 items.push_signal(Signal::NewLine); // force a newline
-              } else if node
-                .starts_block_at_line_start(following_text(node, context), text_can_be_wrapped_away(context))
-              {
+              } else if starts_block_at_line_start(node, context) {
                 // text that would start a block can't be moved to the start of
                 // a line without changing what it means
                 items.push_space();
@@ -258,10 +256,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
                   // spaces is rendered, so it's kept as one rather than being
                   // written as the line break that would read as nothing
                   items.push_space();
-                } else if node
-                  .starts_block_at_line_start(following_text(node, context), text_can_be_wrapped_away(context))
-                  || node.starts_with_list_word()
-                {
+                } else if starts_block_at_line_start(node, context) || node.starts_with_list_word() {
                   // the node would start a block of its own at the start of a
                   // line, so it has to be kept off one
                   items.push_space();
@@ -469,29 +464,29 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
   // a paragraph begins where a block does, and a hard break puts what follows
   // it at the start of a line too, so neither can be left to read as the start
   // of a block of its own
-  let (escaped, line_starts) = escaped_block_starts(&paragraph.children);
-  items.extend(
-    context.with_escaped_block_starts(escaped, line_starts, paragraph.span.end, |context| {
-      gen_task_list_marker_children(&paragraph.children, paragraph.marker.as_ref(), context)
-    }),
-  );
+  items.extend(context.with_paragraph_escapes(paragraph_escapes(paragraph), |context| {
+    gen_task_list_marker_children(&paragraph.children, paragraph.marker.as_ref(), context)
+  }));
   return items;
 
-  /// Where each bit of the paragraph's text that is written at the start of a
-  /// line starts, when it would be read as the start of a block.
-  fn escaped_block_starts(children: &[Node]) -> (Vec<(usize, usize)>, Vec<usize>) {
-    let mut starts = Vec::new();
+  /// What the paragraph has to be written with so that the text it writes at
+  /// the start of a line isn't read as the start of a block.
+  fn paragraph_escapes(paragraph: &Paragraph) -> ParagraphEscapes {
+    let mut block_starts = Vec::new();
     let mut line_starts = Vec::new();
     // the first line of a paragraph has nothing above it to be read together
     // with, so less of what it holds is markup than on the lines after it
     let mut escape: fn(&str) -> Option<usize> = block_start_escape;
     let mut at_line_start = true;
-    for child in children {
+    for child in &paragraph.children {
       if at_line_start {
         line_starts.push(child.span().start);
         if let Node::Text(text) = child {
           if let Some(position) = escape(text.text) {
-            starts.push((text.span.start, position));
+            block_starts.push(BlockStartEscape {
+              text_start: text.span.start,
+              position,
+            });
           }
         }
       }
@@ -500,7 +495,11 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
         escape = line_start_escape;
       }
     }
-    (starts, line_starts)
+    ParagraphEscapes {
+      block_starts,
+      line_starts,
+      end: paragraph.span.end,
+    }
   }
 }
 
@@ -692,7 +691,7 @@ fn gen_code_block(code_block: &CodeBlock, position: NodePosition, context: &mut 
   // an indented code block can only be written with indentation where nothing
   // above it would take that indentation for its own content, and where the
   // indentation of the lines after the first can match the first line's
-  let lines_up = !position.beside_marker || position.marker_lines_up;
+  let lines_up = position.marker.is_none_or(|marker| marker.lines_up);
   let is_fenced = code_block.is_fenced() || position.after_list || !lines_up;
   let indent_level = if is_fenced { 0 } else { 4 };
 
@@ -716,7 +715,7 @@ fn gen_code_block(code_block: &CodeBlock, position: NodePosition, context: &mut 
   }
 
   // body
-  if !is_fenced && position.beside_marker {
+  if !is_fenced && position.marker.is_some() {
     // the item's marker took the place of the first line's indentation, which
     // the printer only writes out for the lines after it
     items.push_sc(sc!("    "));
@@ -850,18 +849,12 @@ fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
 /// single space or line ending is a place the text may be wrapped, but any
 /// longer run of whitespace has to be kept at its original width.
 fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
-  let mut items = PrintItems::new();
-  let mut current_word = String::new();
-  let mut word_start = 0;
-  let mut was_last_newline = false;
+  let mut builder = CodeTextBuilder::new(text, context);
   let mut chars = text.char_indices().peekable();
 
   while let Some((index, c)) = chars.next() {
     if c != ' ' && c != '\n' {
-      if current_word.is_empty() {
-        word_start = index;
-      }
-      current_word.push(c);
+      builder.add_char(index, c);
       continue;
     }
 
@@ -873,60 +866,100 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
 
     // whitespace is only somewhere the span can be broken when there is a word
     // on either side of it -- the space a span opens with is text of its own
-    let is_leading = current_word.is_empty() && items.is_empty();
-    if whitespace_count == 1 && chars.peek().is_some() && !is_leading {
-      push_word(
-        &mut items,
-        &mut current_word,
-        word_start,
-        text,
-        was_last_newline,
-        context,
-      );
-      was_last_newline = c == '\n' && context.configuration.text_wrap == TextWrap::Maintain;
+    if whitespace_count == 1 && chars.peek().is_some() && !builder.is_leading() {
+      builder.end_word(c == '\n');
     } else {
-      if current_word.is_empty() {
-        word_start = index;
-      }
-      // keep the width the same because a line ending renders as a space
-      current_word.push_str(&" ".repeat(whitespace_count));
+      builder.add_spaces(index, whitespace_count);
     }
   }
 
-  push_word(
-    &mut items,
-    &mut current_word,
-    word_start,
-    text,
-    was_last_newline,
-    context,
-  );
+  return builder.build();
 
-  return items;
-
-  fn push_word(
-    items: &mut PrintItems,
-    word: &mut String,
+  struct CodeTextBuilder<'a> {
+    items: PrintItems,
+    /// The span's text, which the word being written is read together with the
+    /// rest of in order to work out what a line would begin with.
+    text: &'a str,
+    /// The word being gathered, and where in `text` it begins.
+    word: String,
     word_start: usize,
-    text: &str,
-    was_last_newline: bool,
-    context: &Context,
-  ) {
-    if word.is_empty() {
-      return;
-    }
-    if !items.is_empty() {
-      // the words the span goes on with count as well as this one, since a
-      // block can be written as several of them (ex. a table's delimiter row)
-      if utils::wrapping_word_starts_block(word, &text[word_start..], text_can_be_wrapped_away(context)) {
-        items.push_space();
-      } else if was_last_newline {
-        items.push_signal(Signal::NewLine);
-      } else {
-        items.extend(get_space_or_newline_based_on_config(context, false));
+    /// Whether the whitespace that ran up to the word being gathered was a line
+    /// ending that the configuration keeps where it was written.
+    after_maintained_newline: bool,
+    context: &'a Context<'a>,
+  }
+
+  impl<'a> CodeTextBuilder<'a> {
+    pub fn new(text: &'a str, context: &'a Context) -> CodeTextBuilder<'a> {
+      CodeTextBuilder {
+        items: PrintItems::new(),
+        text,
+        word: String::new(),
+        word_start: 0,
+        after_maintained_newline: false,
+        context,
       }
     }
-    items.push_string(std::mem::take(word));
+
+    pub fn build(mut self) -> PrintItems {
+      self.flush_word();
+      self.items
+    }
+
+    pub fn add_char(&mut self, index: usize, character: char) {
+      self.start_word_at(index);
+      self.word.push(character);
+    }
+
+    /// Adds whitespace the span can't be broken at, keeping its width because a
+    /// line ending renders as a space.
+    pub fn add_spaces(&mut self, index: usize, count: usize) {
+      self.start_word_at(index);
+      self.word.push_str(&" ".repeat(count));
+    }
+
+    /// Ends the word at whitespace the span can be broken at, which
+    /// `is_newline` says was written as a line ending.
+    pub fn end_word(&mut self, is_newline: bool) {
+      self.flush_word();
+      self.after_maintained_newline = is_newline && self.context.configuration.text_wrap == TextWrap::Maintain;
+    }
+
+    /// Whether nothing has been written yet, where the whitespace that follows
+    /// is text the span opens with rather than somewhere it can be broken.
+    pub fn is_leading(&self) -> bool {
+      self.word.is_empty() && self.items.is_empty()
+    }
+
+    fn start_word_at(&mut self, index: usize) {
+      if self.word.is_empty() {
+        self.word_start = index;
+      }
+    }
+
+    fn flush_word(&mut self) {
+      if self.word.is_empty() {
+        return;
+      }
+      if !self.items.is_empty() {
+        self.items.extend(self.space_items());
+      }
+      self.items.push_string(std::mem::take(&mut self.word));
+    }
+
+    /// What to write in place of the whitespace that ran up to the word.
+    fn space_items(&self) -> PrintItems {
+      // the words the span goes on with count as well as this one, since a
+      // block can be written as several of them (ex. a table's delimiter row)
+      let following_text = &self.text[self.word_start..];
+      if utils::wrapping_word_starts_block(&self.word, following_text, text_can_be_wrapped_away(self.context)) {
+        return space();
+      }
+      if self.after_maintained_newline {
+        return Signal::NewLine.into();
+      }
+      get_space_or_newline_based_on_config(self.context, false)
+    }
   }
 }
 
@@ -1154,8 +1187,8 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
     };
     // an underscore isn't read as a delimiter at all within a word, so only
     // asterisks will do there
-    let (before, after) = surrounding_chars(decoration, parent_content, context);
-    let within_word = is_word(before) || is_word(after);
+    let outside = surroundings(decoration, parent_content, context);
+    let within_word = is_word(outside.before) || is_word(outside.after);
     let prefers_underscores = prefers_underscores && !within_word;
     let (preferred, other) = if prefers_underscores {
       (underscores, asterisks)
@@ -1166,12 +1199,12 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
     // the delimiter of a decoration written directly against this one is read by
     // what sits beside it, so changing this one's character would change theirs.
     // What the file already had parsed as this decoration, so it is safe.
-    if is_delimiter(before) || is_delimiter(after) {
+    if is_delimiter(outside.before) || is_delimiter(outside.after) {
       return written_delimiter(decoration, context);
     }
 
     for candidate in [preferred, other] {
-      if delimits(decoration, candidate, before, after, context) && !collides(decoration, candidate, context) {
+      if delimits(decoration, candidate, outside, context) && !collides(decoration, candidate, context) {
         return candidate;
       }
     }
@@ -1188,11 +1221,7 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
   /// Where the line break beside the decoration isn't written out, the
   /// character past it is what ends up against the delimiter, so that's what's
   /// read here.
-  fn surrounding_chars(
-    decoration: &TextDecoration,
-    parent_content: Option<Span>,
-    context: &Context,
-  ) -> (Option<char>, Option<char>) {
+  fn surroundings(decoration: &TextDecoration, parent_content: Option<Span>, context: &Context) -> Surroundings {
     let span = decoration.span;
     let before = match parent_content {
       Some(content) if content.start == span.start => None,
@@ -1206,7 +1235,7 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
         .char_written_after(span.end)
         .or_else(|| context.file_text[span.end..].chars().next()),
     };
-    (before, after)
+    Surroundings { before, after }
   }
 
   fn is_word(c: Option<char>) -> bool {
@@ -1220,18 +1249,23 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
   /// Whether the character reads as a delimiter at all where the decoration is
   /// written, which the text on either side of it decides -- an underscore
   /// between two letters is one of them rather than a delimiter.
-  fn delimits(
-    decoration: &TextDecoration,
-    delimiter: &str,
-    before: Option<char>,
-    after: Option<char>,
-    context: &Context,
-  ) -> bool {
+  fn delimits(decoration: &TextDecoration, delimiter: &str, outside: Surroundings, context: &Context) -> bool {
     let character = delimiter.chars().next().unwrap();
     let content = content_span(&decoration.children);
     let first = written_first_char(decoration.children.first(), content, context);
     let last = written_last_char(decoration.children.last(), content, context);
-    run_can_open(before, first, character) && run_can_close(last, after, character)
+    // the opening run is written between what precedes the decoration and the
+    // content it wraps, and the closing run between that content and what
+    // follows the decoration
+    let opening = Surroundings {
+      before: outside.before,
+      after: first,
+    };
+    let closing = Surroundings {
+      before: last,
+      after: outside.after,
+    };
+    run_can_open(opening, character) && run_can_close(closing, character)
   }
 
   /// Whether the delimiter would run into the content it is written around,
@@ -1318,22 +1352,36 @@ fn can_pair_with_delimiter(text: &str, delimiter: char) -> bool {
     // another node's punctuation -- either way, not whitespace
     let before = text[..start].chars().next_back().unwrap_or(delimiter);
     let after = text[end..].chars().next().unwrap_or(delimiter);
-    if run_can_pair(Some(before), Some(after), delimiter) {
+    let surroundings = Surroundings {
+      before: Some(before),
+      after: Some(after),
+    };
+    if run_can_pair(surroundings, delimiter) {
       return true;
     }
   }
   false
 }
 
-/// Whether a run of the character surrounded by those two can open or close
-/// emphasis, which is the "flanking" rule of the CommonMark spec.
-fn run_can_pair(before: Option<char>, after: Option<char>, delimiter: char) -> bool {
-  run_can_open(before, after, delimiter) || run_can_close(before, after, delimiter)
+/// The characters written on either side of a run of delimiters, which is what
+/// decides whether the run reads as a delimiter at all. `None` stands for the
+/// edge of the text, which reads the same as whitespace.
+#[derive(Clone, Copy)]
+struct Surroundings {
+  before: Option<char>,
+  after: Option<char>,
 }
 
-/// Whether a run of the character surrounded by those two opens emphasis.
-fn run_can_open(before: Option<char>, after: Option<char>, delimiter: char) -> bool {
-  let flanking = Flanking::new(before, after);
+/// Whether a run of the character written within those surroundings can open or
+/// close emphasis, which is the "flanking" rule of the CommonMark spec.
+fn run_can_pair(surroundings: Surroundings, delimiter: char) -> bool {
+  run_can_open(surroundings, delimiter) || run_can_close(surroundings, delimiter)
+}
+
+/// Whether a run of the character written within those surroundings opens
+/// emphasis.
+fn run_can_open(surroundings: Surroundings, delimiter: char) -> bool {
+  let flanking = Flanking::new(surroundings);
   if delimiter == '_' {
     // `_` can't be used within a word
     flanking.left && (!flanking.right || flanking.before_punctuation)
@@ -1342,9 +1390,10 @@ fn run_can_open(before: Option<char>, after: Option<char>, delimiter: char) -> b
   }
 }
 
-/// Whether a run of the character surrounded by those two closes emphasis.
-fn run_can_close(before: Option<char>, after: Option<char>, delimiter: char) -> bool {
-  let flanking = Flanking::new(before, after);
+/// Whether a run of the character written within those surroundings closes
+/// emphasis.
+fn run_can_close(surroundings: Surroundings, delimiter: char) -> bool {
+  let flanking = Flanking::new(surroundings);
   if delimiter == '_' {
     flanking.right && (!flanking.left || flanking.after_punctuation)
   } else {
@@ -1362,7 +1411,7 @@ struct Flanking {
 }
 
 impl Flanking {
-  fn new(before: Option<char>, after: Option<char>) -> Flanking {
+  fn new(Surroundings { before, after }: Surroundings) -> Flanking {
     let before_whitespace = before.is_none_or(char::is_whitespace);
     let after_whitespace = after.is_none_or(char::is_whitespace);
     let before_punctuation = before.is_some_and(|c| c.is_ascii_punctuation());
@@ -1907,7 +1956,6 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
   context.mark_in_list(|context| {
     let mut items = PrintItems::new();
 
-    // generate items
     for (index, child) in list.children.iter().enumerate() {
       if index > 0 {
         items.extend(get_blank_lines(context.get_leading_blank_lines(child.span().start)));
@@ -1928,9 +1976,11 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         crate::configuration::ListIndentKind::CommonMark => marker_width,
         crate::configuration::ListIndentKind::PythonMarkdown => std::cmp::max(marker_width, 4),
       };
-      // only a bullet marker shares its character with a thematic break
-      let marker_char = list.start_index.is_none().then(|| prefix_text.chars().next()).flatten();
-      let marker_lines_up = indent_increment == marker_width;
+      let marker = ListItemMarker {
+        // only a bullet marker shares its character with a thematic break
+        char: list.start_index.is_none().then(|| prefix_text.chars().next()).flatten(),
+        lines_up: indent_increment == marker_width,
+      };
       context.indent_level += indent_increment;
       items.push_string(prefix_text);
       // the space is dropped where nothing follows it on the line, so an item
@@ -1938,7 +1988,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
       // does follow is the item's to say, not something to measure: content of
       // no width is content all the same
       items.push_signal(Signal::SpaceIfNotTrailing);
-      let child_items = context.mark_in_list_item(marker_char, marker_lines_up, |context| generate(child, context));
+      let child_items = context.mark_in_list_item(marker, |context| generate(child, context));
       items.extend(with_indent_times(child_items, indent_increment));
       context.indent_level -= indent_increment;
     }
@@ -2098,10 +2148,11 @@ fn gen_horizontal_rule(_: &HorizontalRule, position: NodePosition) -> PrintItems
   // a break made of the same character as the marker beside it would read as
   // one long break instead (ex. `- ---`), and one made of dashes below a
   // paragraph would underline it into a heading
-  let runs_together = position.beside_marker && position.marker_char == Some('-');
-  match runs_together || position.after_paragraph {
-    true => "***".into(),
-    false => "---".into(),
+  let runs_together = position.marker.is_some_and(|marker| marker.char == Some('-'));
+  if runs_together || position.after_paragraph {
+    "***".into()
+  } else {
+    "---".into()
   }
 }
 
@@ -2268,12 +2319,10 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
       // + 1 in order to have at least one dash
       let mut max_width = get_column_alignment_properties(*column_alignment).count() + 1;
 
-      // get header width
       if let Some((_, width)) = header.get(i) {
         max_width = std::cmp::max(max_width, *width);
       }
 
-      // check each row width
       for row in rows.iter() {
         if let Some((_, width)) = row.get(i) {
           max_width = std::cmp::max(max_width, *width);
@@ -2420,11 +2469,14 @@ fn sentence_ends_between(last_node: &Node, node: &Node, context: &Context) -> bo
     && !node.starts_with_list_word()
 }
 
-/// The node's text through to the end of the block it's written in, which is
-/// how far the line it begins can run on.
-fn following_text<'a>(node: &Node, context: &'a Context) -> &'a str {
+/// Whether the node would start a block of its own, or turn the line above it
+/// into one, if it were moved to the start of a line by wrapping.
+fn starts_block_at_line_start(node: &Node, context: &Context) -> bool {
+  // the line the node begins can run on past the end of it, since a line break
+  // within a block is written as a break of its own
   let span = node.span();
-  context.text_from(span.start, span.end)
+  let following_text = context.text_from(span.start, span.end);
+  node.starts_block_at_line_start(following_text, text_can_be_wrapped_away(context))
 }
 
 /// Whether the text after a word can be written on the line below it, which is

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -327,11 +327,6 @@ pub fn is_list_word(word: &str) -> bool {
 
 /// The number of blank lines that precede the position at `index`, counting no
 /// further than `max` of them.
-///
-/// When `in_block_quote` is `true`, the block quote markers (`>`) that prefix an
-/// otherwise blank line are skipped while scanning backwards. Without this a blank
-/// line inside a block quote (which is written as `>`) would not be recognized as
-/// blank because of the leading `>` character.
 pub fn get_leading_blank_lines(index: usize, text: &str, in_block_quote: bool, max: u32) -> u32 {
   let mut newline_count = 0;
   // whether the character to the right of this one was a newline, which makes

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -509,10 +509,10 @@ impl<'a, 'c> BlockParser<'a, 'c> {
         // leaving the rest of the paragraph above the table
         if let Some(alignment) = table_delimiter_row(rest, content.last().unwrap().rest()) {
           self.push_paragraph(&content[..content.len() - 1], nodes);
-          return self.parse_table(lines, end - 1, end, alignment, nodes);
+          return self.parse_table(lines, end, alignment, nodes);
         }
         if is_definition_marker(rest) {
-          return self.parse_definition_list(lines, index, end, content, nodes);
+          return self.parse_definition_list(lines, end, content, nodes);
         }
       }
       if !line.is_lazy && line.indent_columns() < CODE_INDENT && self.interrupts_paragraph(lines, end) {
@@ -530,7 +530,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       && lines[after_blanks].indent_columns() < CODE_INDENT
       && is_definition_marker(lines[after_blanks].rest())
     {
-      return self.parse_definition_list(lines, index, after_blanks, content, nodes);
+      return self.parse_definition_list(lines, after_blanks, content, nodes);
     }
 
     self.push_paragraph(&content, nodes);
@@ -590,17 +590,19 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     index + found.min(content.len())
   }
 
+  /// Parses the table whose delimiter row is at `delimiter_index`, its header
+  /// being the line directly above that row.
   fn parse_table(
     &self,
     lines: &[ContentLine<'a>],
-    index: usize,
     delimiter_index: usize,
     column_alignment: Vec<ColumnAlignment>,
     nodes: &mut Vec<Node<'a>>,
   ) -> usize {
+    let header_line = lines[delimiter_index - 1];
     let header = TableHead {
-      span: lines[index].trim_end().span(),
-      cells: self.parse_table_cells(lines[index]),
+      span: header_line.trim_end().span(),
+      cells: self.parse_table_cells(header_line),
     };
 
     let mut rows = Vec::new();
@@ -633,7 +635,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
 
     nodes.push(
       Table {
-        span: Span::new(lines[index].rest_start(), lines[end - 1].trim_end().end()),
+        span: Span::new(header_line.rest_start(), lines[end - 1].trim_end().end()),
         header,
         column_alignment,
         rows,
@@ -658,16 +660,18 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     cells
   }
 
-  /// Parses the definition list whose terms are the lines gathered so far and
+  /// Parses the definition list whose first group of terms is `titles` and
   /// whose first definition marker is at `marker_index`.
   fn parse_definition_list(
     &self,
     lines: &[ContentLine<'a>],
-    index: usize,
     marker_index: usize,
     titles: Vec<ContentLine<'a>>,
     nodes: &mut Vec<Node<'a>>,
   ) -> usize {
+    // the list begins where its first term does, which has to be read before
+    // the loop below replaces `titles` with the next group of them
+    let list_start = titles.first().unwrap_or(&lines[marker_index]).rest_start();
     let mut children: Vec<Node<'a>> = Vec::new();
     let mut end = marker_index;
     let mut titles = titles;
@@ -704,7 +708,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
 
     nodes.push(
       DefinitionList {
-        span: Span::new(lines[index].rest_start(), children.last().unwrap().span().end),
+        span: Span::new(list_start, children.last().unwrap().span().end),
         children,
       }
       .into(),

--- a/src/parser/inline.rs
+++ b/src/parser/inline.rs
@@ -652,8 +652,8 @@ impl<'a, 'b> InlineParser<'a, 'b> {
   fn flanking(&self, start: usize, end: usize, byte: u8) -> (bool, bool) {
     let before = self.text.char_before(start);
     let after = self.text.char_at(end);
-    let before_whitespace = before.is_none_or(is_markdown_whitespace);
-    let after_whitespace = after.is_none_or(is_markdown_whitespace);
+    let before_whitespace = before.is_none_or(char::is_whitespace);
+    let after_whitespace = after.is_none_or(char::is_whitespace);
     let before_punctuation = before.is_some_and(is_markdown_punctuation);
     let after_punctuation = after.is_some_and(is_markdown_punctuation);
 
@@ -869,8 +869,6 @@ fn is_mergeable_text(previous: &Text<'_>, node: &Node<'_>, source: &str) -> bool
       .all(|b| matches!(b, b' ' | b'\t'))
 }
 
-/// A code span's content has a space stripped off each end when it has one on
-/// both and isn't all spaces.
 /// Strips the space a code span pads its text with.
 ///
 /// A reader takes one space off each end of a span that has one at both, which
@@ -907,10 +905,6 @@ fn trailing_space_len(code: &str) -> Option<usize> {
     _ if code.ends_with([' ', '\n', '\r']) => Some(1),
     _ => None,
   }
-}
-
-fn is_markdown_whitespace(c: char) -> bool {
-  c.is_whitespace()
 }
 
 fn is_markdown_punctuation(c: char) -> bool {

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -110,12 +110,11 @@ impl SyncPluginHandler<Configuration> for MarkdownPluginHandler {
     fn tag_to_extension<'a>(tag: &str, config: &'a Configuration) -> Option<&'a str> {
       let tag_lower = tag.trim().to_lowercase();
 
-      // First check custom tags from configuration
+      // a tag the configuration maps takes precedence over the built-in ones
       if let Some(ext) = config.tags.get(&tag_lower) {
         return Some(ext);
       }
 
-      // Fall back to built-in mappings
       match tag_lower.as_str() {
         "typescript" | "ts" => Some("ts"),
         "tsx" => Some("tsx"),


### PR DESCRIPTION
Several functions took long runs of positional arguments the type system couldn't tell apart, and a few comments had outlived what they described. No behavior change.

## Arguments

- **`gen_code_str`** threaded its loop state through a six argument `push_word(&mut items, &mut word, word_start, text, was_last_newline, context)`. It now uses a `CodeTextBuilder`, the way the `gen_str` beside it already uses a `TextBuilder`.
- **`Context::with_escaped_block_starts(starts, line_starts, block_end, func)`** took the three pieces of what a paragraph has to escape separately, and one was a `Vec<(usize, usize)>` destructured as `|(text_start, _)|` in one place and `|(_, position)|` in another. Now `with_paragraph_escapes(escapes, func)` taking a `ParagraphEscapes` of `BlockStartEscape`s.
- **The `(Option<char>, Option<char>)` pair of the emphasis rules** went positionally through `run_can_pair`, `run_can_open`, `run_can_close` and `Flanking::new` — four places where swapping the two still compiles and quietly changes which delimiter gets written. It's a `Surroundings` now, which also makes plain something that was invisible before: the opening and closing runs of a decoration are read against *different* pairs.

  ```rust
  let opening = Surroundings { before: outside.before, after: first };
  let closing = Surroundings { before: last, after: outside.after };
  run_can_open(opening, character) && run_can_close(closing, character)
  ```
- **`mark_in_list_item(marker, lines_up, func)`** took a bare bool; it takes a `ListItemMarker` now. That collapses the three fields `NodePosition` kept for one marker (`beside_marker`, `marker_char`, `marker_lines_up`) into one `Option<ListItemMarker>`, so `!position.beside_marker || position.marker_lines_up` reads as `position.marker.is_none_or(|m| m.lines_up)`.
- **`parse_table`** was called as `(lines, end - 1, end, ..)` and **`parse_definition_list`** took an `index` that `titles` already held and that only fed the list's span start. Both drop the argument they could derive, so the two can no longer drift apart.
- Two identical calls of `node.starts_block_at_line_start(following_text(node, context), text_can_be_wrapped_away(context))` collapsed into one helper.

## Comments

Removed the ones that no longer said anything true:

- `strip_code_span_padding` carried **two stacked summary lines**, one describing behavior an earlier edit had replaced.
- Two commented out `eprintln!("{}", print_items.get_as_text())` calls, plus the `#[allow(clippy::let_and_return)]` that existed only to accommodate them.
- A rustdoc link to `Self::starts_block_in_paragraph`, a method `Node` doesn't have. `cargo doc --document-private-items` now reports 0 warnings, down from 1.
- `is_markdown_whitespace`, a passthrough to `char::is_whitespace` whose name implied a markdown specific definition it didn't have.
- `/** … */` doc comments in `gen_types.rs`, which the rest of the codebase writes as `///`.
- A few that restated the line below them, and a doc paragraph on `get_leading_blank_lines` that duplicated the inline comment at the exact line it described.

The `// todo:` notes and `// Note: This is extremely hacky` are left alone — those are genuine long lived signals.

## Verification

`cargo build`, `cargo clippy --all-targets` and `cargo doc` are warning free, and `cargo check --target wasm32-unknown-unknown --features wasm` passes. All 202 tests pass.

Since the `parse_table` and `parse_definition_list` changes alter how spans are derived, the parser spec tests carry the weight there — they assert the full AST json including exact byte spans, and `tests/parser_specs/` has dedicated `tables.txt`, `tables_edge_cases.txt`, `table_rows.txt`, `definition_lists.txt` and `definitions_then_blocks.txt`. The fuzzer also ran at `FUZZ_CASES=2000000`, re-checking the span and text coverage invariants on generated markdown (confirmed it actually scaled: 0.9s at 200k, 11.5s at 2M).
