### PR TITLE
feat: add `table.skipFormat` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -162,6 +162,18 @@
       "description": "The indentation width the plugin that formats the code within a code block should use, overriding that plugin's own `indentWidth` configuration. When not specified, that plugin's configuration is left alone.",
       "type": "number"
     },
+    "table.skipFormat": {
+      "description": "Whether to leave a table's rows as they were written rather than aligning their cells into columns.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Leaves a table's rows as they were written."
+      }, {
+        "const": false,
+        "description": "Aligns the cells of a table into columns."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -229,6 +241,9 @@
     },
     "codeBlock.indentWidth": {
       "$ref": "#/definitions/codeBlock.indentWidth"
+    },
+    "table.skipFormat": {
+      "$ref": "#/definitions/table.skipFormat"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -139,6 +139,13 @@ impl ConfigurationBuilder {
     self.insert("codeBlock.indentWidth", (value as i32).into())
   }
 
+  /// Whether to leave a table's rows as they were written rather than
+  /// aligning their cells into columns.
+  /// Default: `false`
+  pub fn table_skip_format(&mut self, value: bool) -> &mut Self {
+    self.insert("table.skipFormat", value.into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -209,13 +216,14 @@ mod tests {
       .code_block_preserve_blank_lines(true)
       .code_block_use_tabs(true)
       .code_block_indent_width(2)
+      .table_skip_format(true)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 19);
+    assert_eq!(inner_config.len(), 20);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -78,6 +78,7 @@ pub fn resolve_config(
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
     code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),
     code_block_indent_width: get_nullable_value(&mut config, "codeBlock.indentWidth", &mut diagnostics),
+    table_skip_format: get_value(&mut config, "table.skipFormat", false, &mut diagnostics),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -34,6 +34,10 @@ pub struct Configuration {
   /// formats the code within a code block. `None` leaves it to that plugin.
   #[serde(rename = "codeBlock.indentWidth")]
   pub code_block_indent_width: Option<u8>,
+  /// Whether to leave a table's rows as they were written rather than
+  /// aligning their cells into columns.
+  #[serde(rename = "table.skipFormat")]
+  pub table_skip_format: bool,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2200,6 +2200,10 @@ fn gen_hard_break(hard_break: &HardBreak, context: &mut Context) -> PrintItems {
 }
 
 fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
+  if context.configuration.table_skip_format {
+    return gen_table_rows_as_written(table, context);
+  }
+
   let header = table
     .header
     .cells
@@ -2358,6 +2362,33 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
     let items = gen_table_cell(cell, context);
     get_items_single_line_width(items)
   }
+}
+
+/// Writes out the rows of a table as they were written in the file, leaving
+/// the cells unaligned.
+///
+/// A row is always a single line, so what the printer writes at the start of
+/// one itself -- the indentation and the block quote markers -- is dropped
+/// from the text of the file, as is the whitespace at the end of a line, which
+/// says nothing within a table.
+fn gen_table_rows_as_written(table: &Table, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  // a line ending may be in either of its forms, so split on both characters
+  // and skip the empty text a carriage return and line feed pair leaves behind
+  let mut lines = table
+    .span
+    .text(context.file_text)
+    .split(['\r', '\n'])
+    .filter(|line| !line.is_empty());
+  if let Some(line) = lines.next() {
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+  }
+  for line in lines {
+    items.push_signal(Signal::NewLine);
+    let line = strip_block_quote_markers(line, context);
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+  }
+  items
 }
 
 fn gen_table_cell(table_cell: &TableCell, context: &mut Context) -> PrintItems {

--- a/tests/newline_test.rs
+++ b/tests/newline_test.rs
@@ -109,3 +109,15 @@ fn test_keeps_the_whitespace_that_is_text_of_the_line() {
     assert_eq!(kept(&once), kept(input), "for {:?}, which became {:?}", input, once);
   }
 }
+
+#[test]
+fn test_carriage_return_ends_a_row_of_a_table_left_as_written() {
+  let config = ConfigurationBuilder::new().table_skip_format(true).build();
+  for (input, expected) in [
+    ("|a|b|\r|-|-|\r|c|d|\r", "|a|b|\n|-|-|\n|c|d|\n"),
+    ("> |a|b|\r> |-|-|\r> |c|d|\r", "> |a|b|\n> |-|-|\n> |c|d|\n"),
+  ] {
+    let result = format_text(input, &config, |_, _, _| Ok(None)).unwrap();
+    assert_eq!(result.unwrap(), expected, "for {:?}", input);
+  }
+}

--- a/tests/specs/Tables/Tables_SkipFormat.txt
+++ b/tests/specs/Tables/Tables_SkipFormat.txt
@@ -1,0 +1,104 @@
+~~ table.skipFormat: true ~~
+!! should leave a table's rows as they were written !!
+| Testing|test |Outtt   | final |
+|--|:--:|:--|--:|
+| Some Data | Otherrrr|asdfffff | testingthis |
+
+[expect]
+| Testing|test |Outtt   | final |
+|--|:--:|:--|--:|
+| Some Data | Otherrrr|asdfffff | testingthis |
+
+!! should still format the text around a table !!
+# heading   #
+
+|a|b|
+|-|-|
+|c|d|
+
+*  item
+*  other
+
+[expect]
+# heading
+
+|a|b|
+|-|-|
+|c|d|
+
+- item
+- other
+
+!! should indent a table written in a list !!
+1. Testing
+
+     |a|b|
+     |-|-|
+     |c|d|
+
+[expect]
+1. Testing
+
+   |a|b|
+   |-|-|
+   |c|d|
+
+!! should write the block quote markers of a table in a block quote !!
+> |a|b|
+>|-|-|
+>   |c|d|
+
+[expect]
+> |a|b|
+> |-|-|
+> |c|d|
+
+!! should write the block quote markers of a table in a nested block quote !!
+> > |a|b|
+>>|-|-|
+> >    |c|d|
+
+[expect]
+>> |a|b|
+>> |-|-|
+>> |c|d|
+
+!! should leave the text of a cell as it was written !!
+|a|b|
+|-|-|
+|*c*|`d`|
+
+[expect]
+|a|b|
+|-|-|
+|*c*|`d`|
+
+!! should unindent a table indented up to three spaces !!
+   |a|b|
+   |-|-|
+   |c|d|
+
+[expect]
+|a|b|
+|-|-|
+|c|d|
+
+!! should leave a row's cells past the last column as they were written !!
+|a|b|
+|-|-|
+|c|d|e|
+
+[expect]
+|a|b|
+|-|-|
+|c|d|e|
+
+!! should keep a tab written within a row !!
+|a	x|b|
+|-|-|
+|c|d|
+
+[expect]
+|a	x|b|
+|-|-|
+|c|d|


### PR DESCRIPTION
Closes #180

Adds `table.skipFormat` (default `false`), which leaves a table's rows as they were written rather than aligning their cells into columns. Aligning means a change to the width of one cell rewrites every row of the table, which is churn some sources -- the issue's is markdown generated by an LLM -- aren't worth it.

The rows are written back a line at a time through the printer rather than dumped raw, since a table row is always a single line: the indentation and block quote markers the printer writes at the start of a line itself are dropped from the file's text, along with the whitespace at the end of a line, which says nothing within a table. So a skipped table still indents within a list, keeps its markers within a block quote, and settles in one pass.

```md
| a | b |
|-|-|
|c|d|
```

...is left alone rather than becoming:

```md
| a | b |
| - | - |
| c | d |
```
