### PR TITLE
feat: add `table.cellPadding` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -174,6 +174,21 @@
         "description": "Aligns the cells of a table into columns."
       }]
     },
+    "table.cellPadding": {
+      "description": "The padding to write around the text of a table's cells. Has no effect on a table left as it was written by `table.skipFormat`.",
+      "type": "string",
+      "default": "align",
+      "oneOf": [{
+        "const": "align",
+        "description": "Pads a cell out to the width of its column, which aligns the cells of a column with each other."
+      }, {
+        "const": "space",
+        "description": "Writes a single space on either side of a cell's text."
+      }, {
+        "const": "none",
+        "description": "Writes no space around a cell's text."
+      }]
+    },
     "deno": {
       "description": "Top level configuration that sets the configuration to what is used in Deno.",
       "type": "boolean",
@@ -244,6 +259,9 @@
     },
     "table.skipFormat": {
       "$ref": "#/definitions/table.skipFormat"
+    },
+    "table.cellPadding": {
+      "$ref": "#/definitions/table.cellPadding"
     },
     "deno": {
       "$ref": "#/definitions/deno"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -146,6 +146,12 @@ impl ConfigurationBuilder {
     self.insert("table.skipFormat", value.into())
   }
 
+  /// The padding to write around the text of a table's cells.
+  /// Default: `TableCellPadding::Align`
+  pub fn table_cell_padding(&mut self, value: TableCellPadding) -> &mut Self {
+    self.insert("table.cellPadding", value.to_string().into())
+  }
+
   /// The directive used to ignore a line.
   /// Default: `dprint-ignore`
   pub fn ignore_directive(&mut self, value: &str) -> &mut Self {
@@ -217,13 +223,14 @@ mod tests {
       .code_block_use_tabs(true)
       .code_block_indent_width(2)
       .table_skip_format(true)
+      .table_cell_padding(TableCellPadding::Space)
       .ignore_directive("test")
       .ignore_file_directive("test")
       .ignore_start_directive("test")
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 20);
+    assert_eq!(inner_config.len(), 21);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -79,6 +79,12 @@ pub fn resolve_config(
     code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),
     code_block_indent_width: get_nullable_value(&mut config, "codeBlock.indentWidth", &mut diagnostics),
     table_skip_format: get_value(&mut config, "table.skipFormat", false, &mut diagnostics),
+    table_cell_padding: get_value(
+      &mut config,
+      "table.cellPadding",
+      TableCellPadding::Align,
+      &mut diagnostics,
+    ),
     ignore_directive: get_value(
       &mut config,
       "ignoreDirective",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -38,6 +38,10 @@ pub struct Configuration {
   /// aligning their cells into columns.
   #[serde(rename = "table.skipFormat")]
   pub table_skip_format: bool,
+  /// The padding to write around the text of a table's cells. Has no effect on
+  /// a table left as it was written by `table.skipFormat`.
+  #[serde(rename = "table.cellPadding")]
+  pub table_cell_padding: TableCellPadding,
   pub ignore_directive: String,
   pub ignore_file_directive: String,
   pub ignore_start_directive: String,
@@ -166,6 +170,24 @@ pub enum HardBreakKind {
 }
 
 generate_str_to_from![HardBreakKind, [Backslash, "backslash"], [DoubleSpace, "doubleSpace"]];
+
+/// The padding to write around the text of a table's cells.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TableCellPadding {
+  /// Pads a cell out to the width of its column, which aligns the cells of a
+  /// column with each other (default).
+  ///
+  /// The width of one cell then decides how every row of the table is written,
+  /// so editing a single cell can rewrite all of them.
+  Align,
+  /// Writes a single space on either side of a cell's text.
+  Space,
+  /// Writes no space around a cell's text.
+  None,
+}
+
+generate_str_to_from![TableCellPadding, [Align, "align"], [Space, "space"], [None, "none"]];
 
 /// The style of indentation to use for list items.
 ///

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2204,11 +2204,12 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
     return gen_table_rows_as_written(table, context);
   }
 
+  let padding = context.configuration.table_cell_padding;
   let header = table
     .header
     .cells
     .iter()
-    .map(|cell| get_cell_items_and_width(cell, context))
+    .map(|cell| get_generated_cell(cell, context))
     .collect::<Vec<_>>();
   let rows = table
     .rows
@@ -2217,36 +2218,45 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
       row
         .cells
         .iter()
-        .map(|cell| get_cell_items_and_width(cell, context))
+        .map(|cell| get_generated_cell(cell, context))
         .collect::<Vec<_>>()
     })
     .collect::<Vec<_>>();
-  let column_widths = get_column_widths(&header, &rows, &table.column_alignment);
+  // only a cell that's aligned is written out to the width of its column, so
+  // any other padding leaves the cells of a column no width to be written to
+  let column_widths = match padding {
+    TableCellPadding::Align => Some(get_column_widths(&header, &rows, &table.column_alignment)),
+    TableCellPadding::Space | TableCellPadding::None => None,
+  };
+  let column_widths = column_widths.as_deref();
   let mut items = PrintItems::new();
 
-  items.extend(get_row_items(header, &column_widths, &table.column_alignment));
+  items.extend(get_row_items(header, column_widths, &table.column_alignment, padding));
   items.push_signal(Signal::NewLine);
-  items.extend(get_divider_row(&column_widths, &table.column_alignment));
+  items.extend(get_divider_row(column_widths, &table.column_alignment, padding));
 
   for row in rows {
     items.push_signal(Signal::NewLine);
-    items.extend(get_row_items(row, &column_widths, &table.column_alignment));
+    items.extend(get_row_items(row, column_widths, &table.column_alignment, padding));
   }
 
   return items;
 
-  fn get_divider_row(column_widths: &[usize], column_alignments: &[ColumnAlignment]) -> PrintItems {
+  fn get_divider_row(
+    column_widths: Option<&[usize]>,
+    column_alignments: &[ColumnAlignment],
+    padding: TableCellPadding,
+  ) -> PrintItems {
     let mut items = PrintItems::new();
-    for (i, column_width) in column_widths.iter().enumerate() {
-      let column_alignment = column_alignments.get(i).copied().unwrap_or(ColumnAlignment::None);
-      if i == 0 {
-        items.push_sc(sc!("| "));
-      } else {
-        items.push_space();
-      }
+    for (i, column_alignment) in column_alignments.iter().enumerate() {
+      items.extend(get_cell_start(i == 0, padding));
 
-      let column_alignment_props = get_column_alignment_properties(column_alignment);
-      let dashes_count = column_width - column_alignment_props.count();
+      let column_alignment_props = get_column_alignment_properties(*column_alignment);
+      // a column that isn't written out to a width gets the one dash a
+      // delimiter row needs to be read as one
+      let dashes_count = get_column_width(column_widths, i)
+        .map(|column_width| column_width - column_alignment_props.count())
+        .unwrap_or(1);
 
       if column_alignment_props.has_left_colon {
         items.push_sc(sc!(":"));
@@ -2256,28 +2266,25 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
         items.push_sc(sc!(":"));
       }
 
-      items.push_sc(sc!(" |"));
+      items.extend(get_cell_end(padding, false));
     }
 
     ir_helpers::with_no_new_lines(items)
   }
 
   fn get_row_items(
-    row_cells: Vec<(PrintItems, usize)>,
-    column_widths: &[usize],
+    row_cells: Vec<GeneratedCell>,
+    column_widths: Option<&[usize]>,
     column_alignments: &[ColumnAlignment],
+    padding: TableCellPadding,
   ) -> PrintItems {
     let mut items = PrintItems::new();
-    for (i, (cell_items, cell_width)) in row_cells.into_iter().enumerate() {
+    for (i, cell) in row_cells.into_iter().enumerate() {
       let column_alignment = column_alignments.get(i).copied().unwrap_or(ColumnAlignment::None);
-      // a cell past the last column has no column to be sized or aligned to,
-      // so it is written out as it is
-      let difference = column_widths.get(i).map(|width| width - cell_width).unwrap_or(0);
-      if i == 0 {
-        items.push_sc(sc!("| "))
-      } else {
-        items.push_space();
-      }
+      let difference = get_column_width(column_widths, i)
+        .map(|width| width - cell.width)
+        .unwrap_or(0);
+      items.extend(get_cell_start(i == 0, padding));
 
       if difference > 0 {
         match column_alignment {
@@ -2293,7 +2300,7 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
         }
       }
 
-      items.extend(cell_items);
+      items.extend(cell.items);
 
       if difference > 0 {
         match column_alignment {
@@ -2305,31 +2312,64 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
         }
       }
 
-      items.push_sc(sc!(" |"));
+      items.extend(get_cell_end(padding, cell.ends_with_escape));
     }
 
     ir_helpers::with_no_new_lines(items)
   }
 
+  /// The width the cell of the column is written out to, which a column has
+  /// only where the cells are aligned, and only for as many columns as the
+  /// delimiter row gave the table -- a cell written past the last of them is
+  /// no part of any column.
+  fn get_column_width(column_widths: Option<&[usize]>, index: usize) -> Option<usize> {
+    column_widths?.get(index).copied()
+  }
+
+  /// Writes the pipe a cell begins with, which for any cell but the first of a
+  /// row is the one the cell before it ended with.
+  fn get_cell_start(is_first: bool, padding: TableCellPadding) -> PrintItems {
+    let mut items = PrintItems::new();
+    if is_first {
+      items.push_sc(sc!("|"));
+    }
+    if padding != TableCellPadding::None {
+      items.push_space();
+    }
+    items
+  }
+
+  /// Writes the pipe a cell ends with.
+  ///
+  /// Text that ends with a backslash keeps a space after it however the cells
+  /// are padded, since the backslash would otherwise escape that pipe and read
+  /// the cell into the one beside it.
+  fn get_cell_end(padding: TableCellPadding, ends_with_escape: bool) -> PrintItems {
+    let mut items = PrintItems::new();
+    if padding != TableCellPadding::None || ends_with_escape {
+      items.push_space();
+    }
+    items.push_sc(sc!("|"));
+    items
+  }
+
   fn get_column_widths(
-    header: &[(PrintItems, usize)],
-    rows: &[Vec<(PrintItems, usize)>],
+    header: &[GeneratedCell],
+    rows: &[Vec<GeneratedCell>],
     column_alignments: &[ColumnAlignment],
   ) -> Vec<usize> {
-    // the delimiter row is what says how many columns the table has, and a
-    // cell written past the last of them is no part of any column
     let mut column_widths = Vec::with_capacity(column_alignments.len());
     for (i, column_alignment) in column_alignments.iter().enumerate() {
       // + 1 in order to have at least one dash
       let mut max_width = get_column_alignment_properties(*column_alignment).count() + 1;
 
-      if let Some((_, width)) = header.get(i) {
-        max_width = std::cmp::max(max_width, *width);
+      if let Some(cell) = header.get(i) {
+        max_width = std::cmp::max(max_width, cell.width);
       }
 
       for row in rows.iter() {
-        if let Some((_, width)) = row.get(i) {
-          max_width = std::cmp::max(max_width, *width);
+        if let Some(cell) = row.get(i) {
+          max_width = std::cmp::max(max_width, cell.width);
         }
       }
 
@@ -2358,10 +2398,30 @@ fn gen_table(table: &Table, context: &mut Context) -> PrintItems {
     }
   }
 
-  fn get_cell_items_and_width(cell: &TableCell, context: &mut Context) -> (PrintItems, usize) {
-    let items = gen_table_cell(cell, context);
-    get_items_single_line_width(items)
+  fn get_generated_cell(cell: &TableCell, context: &mut Context) -> GeneratedCell {
+    let (items, cloned_items) = clone_items(gen_table_cell(cell, context));
+    let text = get_items_text(cloned_items);
+    GeneratedCell {
+      items,
+      width: UnicodeWidthStr::width(text.as_str()),
+      ends_with_escape: ends_with_escape(&text),
+    }
   }
+
+  /// Whether the text ends with a backslash that escapes whatever is written
+  /// after it, which is when the backslashes it ends with are odd in number --
+  /// an even number of them is a run of escaped backslashes.
+  fn ends_with_escape(text: &str) -> bool {
+    (text.len() - text.trim_end_matches('\\').len()) % 2 == 1
+  }
+}
+
+/// The text of a table's cell, ready to be written out beside the others.
+struct GeneratedCell {
+  items: PrintItems,
+  /// The columns the text takes up on a line.
+  width: usize,
+  ends_with_escape: bool,
 }
 
 /// Writes out the rows of a table as they were written in the file, leaving
@@ -2429,12 +2489,6 @@ fn gen_metadata_block(node: &MetadataBlock, context: &mut Context) -> PrintItems
   items
 }
 
-fn get_items_single_line_width(items: PrintItems) -> (PrintItems, usize) {
-  let (items, cloned_items) = clone_items(items);
-  let width = measure_single_line_width(cloned_items);
-  (items, width)
-}
-
 fn clone_items(items: PrintItems) -> (PrintItems, PrintItems) {
   // todo: something in the core library? This is weird
   let rc_path = items.into_rc_path();
@@ -2443,10 +2497,6 @@ fn clone_items(items: PrintItems) -> (PrintItems, PrintItems) {
   items1.push_optional_path(rc_path);
   items2.push_optional_path(rc_path);
   (items1, items2)
-}
-
-fn measure_single_line_width(items: PrintItems) -> usize {
-  UnicodeWidthStr::width(get_items_text(items).as_str())
 }
 
 fn get_items_text(items: PrintItems) -> String {

--- a/tests/specs/Tables/Tables_CellPadding_None.txt
+++ b/tests/specs/Tables/Tables_CellPadding_None.txt
@@ -1,0 +1,82 @@
+~~ table.cellPadding: none ~~
+!! should write no space around a cell's text !!
+| Testing|test |Outtt   | final |
+|--|:--:|:--|--:|
+| Some Data | Otherrrr|asdfffff | testingthis |
+
+[expect]
+|Testing|test|Outtt|final|
+|-|:-:|:-|-:|
+|Some Data|Otherrrr|asdfffff|testingthis|
+
+!! should still write the text of a cell as the configuration says !!
+|a|b|
+|-|-|
+|*c*|__d__|
+
+[expect]
+|a|b|
+|-|-|
+|_c_|**d**|
+
+!! should fill out a row that is short of cells !!
+|a|b|c|
+|-|-|-|
+|d|
+
+[expect]
+|a|b|c|
+|-|-|-|
+|d|||
+
+!! should write a cell past the last column as it is !!
+|a|b|
+|-|-|
+|c|d|e|
+
+[expect]
+|a|b|
+|-|-|
+|c|d|e|
+
+!! should write an empty cell as the pipes it is written between !!
+| a |  | c |
+| - | - | - |
+|  |  |  |
+| d |  |  |
+
+[expect]
+|a||c|
+|-|-|-|
+||||
+|d|||
+
+!! should keep a space after text that ends with a backslash !!
+| a\ | b |
+| - | - |
+| c\\ | d\ |
+
+[expect]
+|a\ |b|
+|-|-|
+|c\\|d\ |
+
+!! should keep a table in a list and a block quote !!
+- > | a | b |
+  > | - | - |
+  > | c | d |
+
+[expect]
+- > |a|b|
+  > |-|-|
+  > |c|d|
+
+!! should keep a table whose cells read as a delimiter row !!
+| - | :- |
+| - | - |
+| - | - |
+
+[expect]
+|-|:-|
+|-|-|
+|-|-|

--- a/tests/specs/Tables/Tables_CellPadding_Space.txt
+++ b/tests/specs/Tables/Tables_CellPadding_Space.txt
@@ -1,0 +1,60 @@
+~~ table.cellPadding: space ~~
+!! should write a single space around a cell's text rather than aligning it !!
+| Testing|test |Outtt   | final |
+|--|:--:|:--|--:|
+| Some Data | Otherrrr|asdfffff | testingthis |
+
+[expect]
+| Testing | test | Outtt | final |
+| - | :-: | :- | -: |
+| Some Data | Otherrrr | asdfffff | testingthis |
+
+!! should still write the text of a cell as the configuration says !!
+|a|b|
+|-|-|
+|*c*|__d__|
+
+[expect]
+| a | b |
+| - | - |
+| _c_ | **d** |
+
+!! should fill out a row that is short of cells !!
+|a|b|c|
+|-|-|-|
+|d|
+
+[expect]
+| a | b | c |
+| - | - | - |
+| d |  |  |
+
+!! should write a cell past the last column as it is !!
+|a|b|
+|-|-|
+|c|d|e|
+
+[expect]
+| a | b |
+| - | - |
+| c | d | e |
+
+!! should keep a table in a list and a block quote !!
+- > |a|b|
+  > |-|-|
+  > |c|d|
+
+[expect]
+- > | a | b |
+  > | - | - |
+  > | c | d |
+
+!! should keep the space after text that ends with a backslash !!
+|a|b|
+|-|-|
+| c\ | d |
+
+[expect]
+| a | b |
+| - | - |
+| c\ | d |

--- a/tests/specs/Tables/Tables_SkipFormat_CellPadding.txt
+++ b/tests/specs/Tables/Tables_SkipFormat_CellPadding.txt
@@ -1,0 +1,10 @@
+~~ table.skipFormat: true, table.cellPadding: none ~~
+!! should leave a table as it was written whatever the cells are padded with !!
+| a | b |
+| - | - |
+| c | d |
+
+[expect]
+| a | b |
+| - | - |
+| c | d |


### PR DESCRIPTION
Follows #247. `table.skipFormat` is all or nothing -- it leaves a table exactly as it was written -- and the churn in #180 comes from one part of that: padding each cell out to the width of its column makes the width of a single cell decide how every row is written. `table.cellPadding` says how much padding to write instead, leaving the rest of the table formatted:

| `table.cellPadding` | output |
| --- | --- |
| `"align"` (default) | `\| a   \| bbb \|` |
| `"space"` | `\| a \| bbb \|` |
| `"none"` | `\|a\|bbb\|` |

`"space"` and `"none"` still write the cells out from what was parsed, so the text within them is written as the rest of the configuration says, a row short of cells is filled out to the last column, and the delimiter row keeps its alignment colons. Only `table.skipFormat` leaves the rows alone, and it takes precedence.

The one thing the padding can't drop: a cell whose text ends with a backslash keeps a space before its pipe, since `|c\|d|` reads the two cells as one.

`gen_table` was refactored a little to carry this: a cell is now a named `GeneratedCell` rather than a `(PrintItems, usize)` tuple, the pipes are written by `get_cell_start`/`get_cell_end`, and the column widths are an `Option` -- a table whose cells aren't aligned has no widths to write them out to.

The default is untouched, byte for byte. Along with the specs here, that was checked by formatting ~200k generated documents -- tables of random cells, in block quotes and lists, across each `textWrap` and several line widths -- with each padding, asserting `"align"` matched the output from `main`, that each padding settles in one pass, and that reformatting the result back to `"align"` gives what the input formats to, so no output reads back as anything else.
