### PR TITLE
feat: add `heading.blankLinesAbove` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -243,7 +243,7 @@
       "type": "number"
     },
     "heading.blankLinesAbove": {
-      "description": "The number of blank lines to write above a heading, which is written even where `maxBlankLines` is lower. When not specified, the blank lines that were written above a heading are kept, up to `maxBlankLines`.",
+      "description": "The number of blank lines to write above a heading. That many are written even where `maxBlankLines` is lower, though a heading drawn up against the block above it within a list is left there, which keeps the list tight. When not specified, the blank lines that were written above a heading are kept, up to `maxBlankLines`.",
       "minimum": 1,
       "type": "number"
     },

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -242,6 +242,11 @@
       "minimum": 1,
       "type": "number"
     },
+    "heading.blankLinesAbove": {
+      "description": "The number of blank lines to write above a heading, which is written even where `maxBlankLines` is lower. When not specified, the blank lines that were written above a heading are kept, up to `maxBlankLines`.",
+      "minimum": 1,
+      "type": "number"
+    },
     "codeBlock.skipFormat": {
       "$ref": "#/definitions/codeBlock.skipFormat"
     },

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -103,8 +103,9 @@ impl ConfigurationBuilder {
     self.insert("maxBlankLines", (value as i32).into())
   }
 
-  /// The number of blank lines to write above a heading, which is written even
-  /// where `maxBlankLines` is lower.
+  /// The number of blank lines to write above a heading. That many are written
+  /// even where `maxBlankLines` is lower, though a heading drawn up against the
+  /// block above it within a list is left there, which keeps the list tight.
   /// Default: the blank lines that were written are kept, up to `maxBlankLines`
   pub fn heading_blank_lines_above(&mut self, value: u32) -> &mut Self {
     self.insert("heading.blankLinesAbove", (value as i32).into())

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -103,6 +103,13 @@ impl ConfigurationBuilder {
     self.insert("maxBlankLines", (value as i32).into())
   }
 
+  /// The number of blank lines to write above a heading, which is written even
+  /// where `maxBlankLines` is lower.
+  /// Default: the blank lines that were written are kept, up to `maxBlankLines`
+  pub fn heading_blank_lines_above(&mut self, value: u32) -> &mut Self {
+    self.insert("heading.blankLinesAbove", (value as i32).into())
+  }
+
   /// Whether to leave the code within a code block as it was written rather
   /// than formatting it with the plugin that handles the code's language.
   /// Default: `false`
@@ -217,6 +224,7 @@ mod tests {
       .hard_break_kind(HardBreakKind::DoubleSpace)
       .list_indent_kind(ListIndentKind::PythonMarkdown)
       .max_blank_lines(2)
+      .heading_blank_lines_above(2)
       .code_block_skip_format(true)
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
@@ -230,7 +238,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 21);
+    assert_eq!(inner_config.len(), 22);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }
@@ -288,6 +296,27 @@ mod tests {
     assert_eq!(result.diagnostics[0].property_name, "maxBlankLines");
     assert!(result.diagnostics[0].message.contains("at least 1"));
     assert_eq!(result.config.max_blank_lines, 1);
+  }
+
+  #[test]
+  fn heading_blank_lines_above_only_set_when_specified() {
+    let config = ConfigurationBuilder::new().build();
+    assert_eq!(config.heading_blank_lines_above, None);
+
+    let config = ConfigurationBuilder::new().heading_blank_lines_above(2).build();
+    assert_eq!(config.heading_blank_lines_above, Some(2));
+  }
+
+  #[test]
+  fn heading_blank_lines_above_below_one() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("heading.blankLinesAbove".into(), 0.into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].property_name, "heading.blankLinesAbove");
+    assert!(result.diagnostics[0].message.contains("at least 1"));
+    assert_eq!(result.config.heading_blank_lines_above, Some(1));
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -133,9 +133,9 @@ fn get_max_blank_lines(config: &mut ConfigKeyMap, diagnostics: &mut Vec<Configur
   ensure_at_least_one_blank_line("maxBlankLines", value, diagnostics)
 }
 
-/// A heading drawn up against the block above it reads as part of that block --
-/// a setext heading would underline the paragraph rather than follow it -- so a
-/// count below one isn't something the formatter could write.
+/// With `headingKind: setext` a heading written against the paragraph above it
+/// would underline that paragraph rather than follow it, so a count below one
+/// isn't one that could be written wherever the option applies.
 fn get_heading_blank_lines_above(
   config: &mut ConfigKeyMap,
   diagnostics: &mut Vec<ConfigurationDiagnostic>,

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -73,6 +73,7 @@ pub fn resolve_config(
       &mut diagnostics,
     ),
     max_blank_lines: get_max_blank_lines(&mut config, &mut diagnostics),
+    heading_blank_lines_above: get_heading_blank_lines_above(&mut config, &mut diagnostics),
     code_block_skip_format: get_value(&mut config, "codeBlock.skipFormat", false, &mut diagnostics),
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
@@ -129,9 +130,32 @@ pub fn resolve_config(
 /// maximum below one isn't something the formatter could ever stay under.
 fn get_max_blank_lines(config: &mut ConfigKeyMap, diagnostics: &mut Vec<ConfigurationDiagnostic>) -> u32 {
   let value = get_value(config, "maxBlankLines", 1, diagnostics);
+  ensure_at_least_one_blank_line("maxBlankLines", value, diagnostics)
+}
+
+/// A heading drawn up against the block above it reads as part of that block --
+/// a setext heading would underline the paragraph rather than follow it -- so a
+/// count below one isn't something the formatter could write.
+fn get_heading_blank_lines_above(
+  config: &mut ConfigKeyMap,
+  diagnostics: &mut Vec<ConfigurationDiagnostic>,
+) -> Option<u32> {
+  let value = get_nullable_value(config, "heading.blankLinesAbove", diagnostics)?;
+  Some(ensure_at_least_one_blank_line(
+    "heading.blankLinesAbove",
+    value,
+    diagnostics,
+  ))
+}
+
+fn ensure_at_least_one_blank_line(
+  property_name: &str,
+  value: u32,
+  diagnostics: &mut Vec<ConfigurationDiagnostic>,
+) -> u32 {
   if value < 1 {
     diagnostics.push(ConfigurationDiagnostic {
-      property_name: "maxBlankLines".to_string(),
+      property_name: property_name.to_string(),
       message: "Expected a value of at least 1.".to_string(),
     });
     return 1;

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -20,6 +20,11 @@ pub struct Configuration {
   pub list_indent_kind: ListIndentKind,
   /// The maximum number of consecutive blank lines to keep between blocks.
   pub max_blank_lines: u32,
+  /// The number of blank lines to write above a heading, which is written even
+  /// where `max_blank_lines` is lower. `None` keeps the blank lines that were
+  /// written, the same as any other block.
+  #[serde(rename = "heading.blankLinesAbove")]
+  pub heading_blank_lines_above: Option<u32>,
   #[serde(rename = "codeBlock.skipFormat")]
   pub code_block_skip_format: bool,
   #[serde(rename = "codeBlock.preserveIndentation")]

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -20,9 +20,11 @@ pub struct Configuration {
   pub list_indent_kind: ListIndentKind,
   /// The maximum number of consecutive blank lines to keep between blocks.
   pub max_blank_lines: u32,
-  /// The number of blank lines to write above a heading, which is written even
-  /// where `max_blank_lines` is lower. `None` keeps the blank lines that were
-  /// written, the same as any other block.
+  /// The number of blank lines to write above a heading. That many are written
+  /// even where `max_blank_lines` is lower, though a heading drawn up against
+  /// the block above it within a list is left there, which keeps the list
+  /// tight. `None` keeps the blank lines that were written, the same as any
+  /// other block.
   #[serde(rename = "heading.blankLinesAbove")]
   pub heading_blank_lines_above: Option<u32>,
   #[serde(rename = "codeBlock.skipFormat")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -149,7 +149,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
     if let Some(Node::List(last_list)) = &last_node {
       if let Node::List(list) = &node {
         if last_list.start_index.is_some() == list.start_index.is_some() {
-          items.extend(get_conditional_blank_line(node.span(), context));
+          items.extend(get_conditional_blank_line(node, context));
           items.extend(gen_list(list, true, context));
           if let Some(current_node) = node_iterator.next() {
             last_node = Some(node);
@@ -175,7 +175,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
           | Node::Table(_)
           | Node::BlockQuote(_)
       ) {
-        items.extend(get_conditional_blank_line(node.span(), context));
+        items.extend(get_conditional_blank_line(node, context));
       } else if !matches!(node, Node::HardBreak(_)) {
         match last_node {
           Node::Heading(_)
@@ -189,7 +189,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
           | Node::MetadataBlock(_)
           | Node::BlockQuote(_)
           | Node::DisplayMath(_) => {
-            items.extend(get_conditional_blank_line(node.span(), context));
+            items.extend(get_conditional_blank_line(node, context));
           }
           Node::Code(_)
           | Node::SoftBreak(_)
@@ -277,7 +277,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
               let blank_lines = std::cmp::min(new_line_count.saturating_sub(1), context.configuration.max_blank_lines);
               items.extend(get_blank_lines(blank_lines));
             } else {
-              items.extend(get_conditional_blank_line(node.span(), context));
+              items.extend(get_conditional_blank_line(node, context));
             }
           }
           Node::SourceFile(_)
@@ -373,12 +373,11 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
 
   return items;
 
-  fn get_conditional_blank_line(span: Span, context: &mut Context) -> PrintItems {
+  fn get_conditional_blank_line(node: &Node, context: &mut Context) -> PrintItems {
     // within a list two blocks may sit on consecutive lines, which is what
     // keeps the list tight. Everywhere else a blank line is what separates them
     let minimum = if context.is_in_list() { 0 } else { 1 };
-    let blank_lines = std::cmp::max(context.get_leading_blank_lines(span.start), minimum);
-    get_blank_lines(blank_lines)
+    get_blank_lines(get_blank_lines_above(node, minimum, context))
   }
 }
 
@@ -2125,9 +2124,11 @@ fn gen_task_list_marker_children(
 
   // insert the remaining children without indent
   if indent_child_index_end > 0 && indent_child_index_end != children.len() {
-    items.extend(get_blank_lines(
-      context.get_leading_blank_lines(children[indent_child_index_end].span().start),
-    ));
+    items.extend(get_blank_lines(get_blank_lines_above(
+      &children[indent_child_index_end],
+      0,
+      context,
+    )));
   }
   items.extend(gen_nodes(&children[indent_child_index_end..], context));
   items
@@ -2528,6 +2529,19 @@ fn measure_longest_line_width(items: PrintItems, max_width: u32) -> usize {
     .map(|line| UnicodeWidthStr::width(line.trim_end_matches(WHITESPACE)))
     .max()
     .unwrap_or(0)
+}
+
+/// The number of blank lines to write above `node`, which is at least
+/// `minimum` and otherwise however many were written above it.
+///
+/// A heading takes the configured number instead, unless it's drawn up against
+/// the block above it, which is what keeps a list tight.
+fn get_blank_lines_above(node: &Node, minimum: u32, context: &Context) -> u32 {
+  let written = std::cmp::max(context.get_leading_blank_lines(node.span().start), minimum);
+  match (node, context.configuration.heading_blank_lines_above) {
+    (Node::Heading(_), Some(count)) if written > 0 => count,
+    _ => written,
+  }
 }
 
 /// Ends the current line and writes `count` blank lines below it.

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2534,13 +2534,15 @@ fn measure_longest_line_width(items: PrintItems, max_width: u32) -> usize {
 /// The number of blank lines to write above `node`, which is at least
 /// `minimum` and otherwise however many were written above it.
 ///
-/// A heading takes the configured number instead, unless it's drawn up against
-/// the block above it, which is what keeps a list tight.
+/// A heading takes the configured number instead, except within a list, where
+/// one drawn up against the block above it is left there to keep the list tight.
 fn get_blank_lines_above(node: &Node, minimum: u32, context: &Context) -> u32 {
-  let written = std::cmp::max(context.get_leading_blank_lines(node.span().start), minimum);
+  let written_or_minimum = std::cmp::max(context.get_leading_blank_lines(node.span().start), minimum);
   match (node, context.configuration.heading_blank_lines_above) {
-    (Node::Heading(_), Some(count)) if written > 0 => count,
-    _ => written,
+    // everywhere but within a list the minimum is one, so the only heading this
+    // leaves out is one drawn up against the block above it in a tight list
+    (Node::Heading(_), Some(count)) if written_or_minimum > 0 => count,
+    _ => written_or_minimum,
   }
 }
 

--- a/tests/specs/headers/Headers_BlankLinesAbove.txt
+++ b/tests/specs/headers/Headers_BlankLinesAbove.txt
@@ -1,0 +1,160 @@
+~~ heading.blankLinesAbove: 2 ~~
+!! should write the configured number of blank lines above a heading !!
+# Project
+
+This is a cool project.
+
+## Installation
+
+Some installation instructions.
+
+[expect]
+# Project
+
+This is a cool project.
+
+
+## Installation
+
+Some installation instructions.
+
+!! should not write blank lines above a heading that starts the file !!
+
+
+# Project
+
+Text.
+
+[expect]
+# Project
+
+Text.
+
+!! should write the blank lines above a heading of any kind !!
+Text.
+
+Setext Heading
+==============
+
+Text.
+
+### Atx Heading
+
+Text.
+
+[expect]
+Text.
+
+
+# Setext Heading
+
+Text.
+
+
+### Atx Heading
+
+Text.
+
+!! should write them between two headings !!
+# One
+
+## Two
+
+[expect]
+# One
+
+
+## Two
+
+!! should write them below the front matter !!
+---
+title: Test
+---
+
+# Heading
+
+[expect]
+---
+title: Test
+---
+
+
+# Heading
+
+!! should write them above a heading within a block quote !!
+> Text.
+>
+> # Heading
+>
+> Text.
+
+[expect]
+> Text.
+>
+>
+> # Heading
+>
+> Text.
+
+!! should write them above a heading within a nested block quote !!
+> > Text.
+> >
+> > # Heading
+
+[expect]
+>> Text.
+>>
+>>
+>> # Heading
+
+!! should write them above a heading within a footnote definition !!
+[^1]: Text.
+
+    # Heading
+
+    Text.
+
+[expect]
+[^1]: Text.
+
+
+    # Heading
+
+    Text.
+
+!! should leave a heading drawn up against the block above it in a list !!
+- Text.
+  # Heading
+  Text.
+
+[expect]
+- Text.
+  # Heading
+  Text.
+
+!! should write them above a heading in a list whose blocks are separated !!
+- Text.
+
+  # Heading
+
+  Text.
+
+[expect]
+- Text.
+
+
+  # Heading
+
+  Text.
+
+!! should leave a heading that follows an ignore comment as it was written !!
+Text.
+
+<!-- dprint-ignore -->
+# Heading
+
+[expect]
+Text.
+
+<!-- dprint-ignore -->
+# Heading

--- a/tests/specs/headers/Headers_BlankLinesAbove_MaxBlankLines.txt
+++ b/tests/specs/headers/Headers_BlankLinesAbove_MaxBlankLines.txt
@@ -1,0 +1,51 @@
+~~ heading.blankLinesAbove: 2, maxBlankLines: 3 ~~
+!! should write the configured number above a heading rather than the ones written !!
+Text.
+
+
+
+# Heading
+
+Text.
+
+[expect]
+Text.
+
+
+# Heading
+
+Text.
+
+!! should write it when fewer were written !!
+Text.
+
+# Heading
+
+[expect]
+Text.
+
+
+# Heading
+
+!! should keep the blank lines above other blocks up to the maximum !!
+Text.
+
+
+
+Text.
+
+
+
+
+Text.
+
+[expect]
+Text.
+
+
+
+Text.
+
+
+
+Text.

--- a/tests/specs/headers/Headers_BlankLinesAbove_One.txt
+++ b/tests/specs/headers/Headers_BlankLinesAbove_One.txt
@@ -1,0 +1,30 @@
+~~ heading.blankLinesAbove: 1, maxBlankLines: 3 ~~
+!! should collapse the blank lines above a heading to the configured number !!
+Text.
+
+
+
+# Heading
+
+Text.
+
+[expect]
+Text.
+
+# Heading
+
+Text.
+
+!! should keep the blank lines above the blocks that are not headings !!
+Text.
+
+
+
+Text.
+
+[expect]
+Text.
+
+
+
+Text.

--- a/tests/specs/headers/Headers_BlankLinesAbove_Setext.txt
+++ b/tests/specs/headers/Headers_BlankLinesAbove_Setext.txt
@@ -1,0 +1,39 @@
+~~ heading.blankLinesAbove: 2, headingKind: setext ~~
+!! should write the configured number above a setext heading !!
+Text.
+
+Heading
+=======
+
+Text.
+
+Other Heading
+-------------
+
+[expect]
+Text.
+
+
+Heading
+=======
+
+Text.
+
+
+Other Heading
+-------------
+
+!! should write it above a heading that stays atx !!
+Text.
+
+### Three
+
+Text.
+
+[expect]
+Text.
+
+
+### Three
+
+Text.


### PR DESCRIPTION
Closes #181

Sets the number of blank lines written above a heading.

When it isn't set, nothing changes: the blank lines above a heading are kept as they were written, up to `maxBlankLines`.

When it is set, that many are written above every heading. This is an exact count rather than a minimum, so more blank lines than that are collapsed as well:

```json
{ "markdown": { "heading.blankLinesAbove": 2 } }
```

```md
# Project

This is a cool project.


## Installation

Some installation instructions.
```

Two things worth a look:

- **It overrides `maxBlankLines`.** The request in #181 is two blank lines above a heading and one below, which the default maximum of one would otherwise rule out. Clamping to `maxBlankLines` would defeat the option, and raising `maxBlankLines` to compensate would loosen every other block, so the configured count wins. Documented in the schema, the builder method and `Configuration`.
- **A heading drawn up against the block above it within a list is left there**, since that's what keeps a list tight. A loose list, where the blocks are already blank-separated, gets the configured count like anywhere else.

Values below 1 are rejected with a diagnostic — with `headingKind: setext` a heading written against the paragraph above it would underline that paragraph rather than follow it.

Specs cover front matter, block quotes (including nested), footnote definitions, tight and loose lists, setext headings, `dprint-ignore`, the collapsing direction, and the interaction with a raised `maxBlankLines`.
