### PR TITLE
feat(BREAKING): move heading and list options under namespaces

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -63,19 +63,7 @@
         "description": "Uses underscores (__) for strong emphasis."
       }]
     },
-    "unorderedListKind": {
-      "description": "The character to use for unordered lists.",
-      "type": "string",
-      "default": "dashes",
-      "oneOf": [{
-        "const": "dashes",
-        "description": "Uses dashes (-) as primary character for lists."
-      }, {
-        "const": "asterisks",
-        "description": "Uses asterisks (*) as primary character for lists."
-      }]
-    },
-    "headingKind": {
+    "heading.kind": {
       "description": "The style of heading to use for level 1 and level 2 headings. Level 3 and higher always use ATX headings.",
       "type": "string",
       "default": "atx",
@@ -99,7 +87,19 @@
         "description": "Uses two trailing spaces for hard line breaks. Note that some tools strip trailing whitespace, which would silently remove these hard line breaks."
       }]
     },
-    "listIndentKind": {
+    "list.unorderedMarker": {
+      "description": "The character to write the marker of an unordered list's items with.",
+      "type": "string",
+      "default": "dashes",
+      "oneOf": [{
+        "const": "dashes",
+        "description": "Uses dashes (-) as primary character for lists."
+      }, {
+        "const": "asterisks",
+        "description": "Uses asterisks (*) as primary character for lists."
+      }]
+    },
+    "list.indentKind": {
       "description": "The style of indentation to use for list items. CommonMark aligns to the content column after the marker. PythonMarkdown uses a fixed 4-space indent, required by tools like mkdocs-material.",
       "type": "string",
       "default": "commonMark",
@@ -224,17 +224,8 @@
     "strongKind": {
       "$ref": "#/definitions/strongKind"
     },
-    "unorderedListKind": {
-      "$ref": "#/definitions/unorderedListKind"
-    },
-    "headingKind": {
-      "$ref": "#/definitions/headingKind"
-    },
     "hardBreakKind": {
       "$ref": "#/definitions/hardBreakKind"
-    },
-    "listIndentKind": {
-      "$ref": "#/definitions/listIndentKind"
     },
     "maxBlankLines": {
       "description": "The maximum number of consecutive blank lines to keep between blocks.",
@@ -242,10 +233,19 @@
       "minimum": 1,
       "type": "number"
     },
+    "heading.kind": {
+      "$ref": "#/definitions/heading.kind"
+    },
     "heading.blankLinesAbove": {
       "description": "The number of blank lines to write above a heading. That many are written even where `maxBlankLines` is lower, though a heading drawn up against the block above it within a list is left there, which keeps the list tight. When not specified, the blank lines that were written above a heading are kept, up to `maxBlankLines`.",
       "minimum": 1,
       "type": "number"
+    },
+    "list.unorderedMarker": {
+      "$ref": "#/definitions/list.unorderedMarker"
+    },
+    "list.indentKind": {
+      "$ref": "#/definitions/list.indentKind"
     },
     "codeBlock.skipFormat": {
       "$ref": "#/definitions/codeBlock.skipFormat"
@@ -290,6 +290,24 @@
       "description": "The text to use for an ignore end directive (ex. `<!-- dprint-ignore-end -->`).",
       "default": "dprint-ignore-end",
       "type": "string"
+    },
+    "headingKind": {
+      "description": "Deprecated: renamed to `heading.kind`.",
+      "deprecated": true,
+      "deprecationMessage": "Renamed to `heading.kind`.",
+      "allOf": [{ "$ref": "#/definitions/heading.kind" }]
+    },
+    "unorderedListKind": {
+      "description": "Deprecated: renamed to `list.unorderedMarker`.",
+      "deprecated": true,
+      "deprecationMessage": "Renamed to `list.unorderedMarker`.",
+      "allOf": [{ "$ref": "#/definitions/list.unorderedMarker" }]
+    },
+    "listIndentKind": {
+      "description": "Deprecated: renamed to `list.indentKind`.",
+      "deprecated": true,
+      "deprecationMessage": "Renamed to `list.indentKind`.",
+      "allOf": [{ "$ref": "#/definitions/list.indentKind" }]
     },
     "tags": {
       "description": "Custom tag to file extension mappings for formatting code blocks. For example: { \"markdown\": \"md\" }",

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -73,28 +73,10 @@ impl ConfigurationBuilder {
     self.insert("strongKind", value.to_string().into())
   }
 
-  /// The character to use for lists.
-  /// Default: `UnorderedListKind::Dashes`
-  pub fn unordered_list_kind(&mut self, value: UnorderedListKind) -> &mut Self {
-    self.insert("unorderedListKind", value.to_string().into())
-  }
-
-  /// The type of heading to use.
-  /// Default: `HeadingKind::Atx`
-  pub fn heading_kind(&mut self, value: HeadingKind) -> &mut Self {
-    self.insert("headingKind", value.to_string().into())
-  }
-
   /// The style of hard line break to use.
   /// Default: `HardBreakKind::Backslash`
   pub fn hard_break_kind(&mut self, value: HardBreakKind) -> &mut Self {
     self.insert("hardBreakKind", value.to_string().into())
-  }
-
-  /// The style of list indentation to use.
-  /// Default: `ListIndentKind::CommonMark`
-  pub fn list_indent_kind(&mut self, value: ListIndentKind) -> &mut Self {
-    self.insert("listIndentKind", value.to_string().into())
   }
 
   /// The maximum number of consecutive blank lines to keep between blocks.
@@ -103,12 +85,30 @@ impl ConfigurationBuilder {
     self.insert("maxBlankLines", (value as i32).into())
   }
 
+  /// The type of heading to use.
+  /// Default: `HeadingKind::Atx`
+  pub fn heading_kind(&mut self, value: HeadingKind) -> &mut Self {
+    self.insert("heading.kind", value.to_string().into())
+  }
+
   /// The number of blank lines to write above a heading. That many are written
   /// even where `maxBlankLines` is lower, though a heading drawn up against the
   /// block above it within a list is left there, which keeps the list tight.
   /// Default: the blank lines that were written are kept, up to `maxBlankLines`
   pub fn heading_blank_lines_above(&mut self, value: u32) -> &mut Self {
     self.insert("heading.blankLinesAbove", (value as i32).into())
+  }
+
+  /// The character to write the marker of an unordered list's items with.
+  /// Default: `ListUnorderedMarker::Dashes`
+  pub fn list_unordered_marker(&mut self, value: ListUnorderedMarker) -> &mut Self {
+    self.insert("list.unorderedMarker", value.to_string().into())
+  }
+
+  /// The style of list indentation to use.
+  /// Default: `ListIndentKind::CommonMark`
+  pub fn list_indent_kind(&mut self, value: ListIndentKind) -> &mut Self {
+    self.insert("list.indentKind", value.to_string().into())
   }
 
   /// Whether to leave the code within a code block as it was written rather
@@ -220,12 +220,12 @@ mod tests {
       .text_wrap(TextWrap::Always)
       .emphasis_kind(EmphasisKind::Asterisks)
       .strong_kind(StrongKind::Underscores)
-      .unordered_list_kind(UnorderedListKind::Asterisks)
-      .heading_kind(HeadingKind::Atx)
       .hard_break_kind(HardBreakKind::DoubleSpace)
-      .list_indent_kind(ListIndentKind::PythonMarkdown)
       .max_blank_lines(2)
+      .heading_kind(HeadingKind::Atx)
       .heading_blank_lines_above(2)
+      .list_unordered_marker(ListUnorderedMarker::Asterisks)
+      .list_indent_kind(ListIndentKind::PythonMarkdown)
       .code_block_skip_format(true)
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
@@ -318,6 +318,31 @@ mod tests {
     assert_eq!(result.diagnostics[0].property_name, "heading.blankLinesAbove");
     assert!(result.diagnostics[0].message.contains("at least 1"));
     assert_eq!(result.config.heading_blank_lines_above, Some(1));
+  }
+
+  #[test]
+  fn deprecated_names_still_resolve() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "setext".into());
+    config.insert("unorderedListKind".into(), "asterisks".into());
+    config.insert("listIndentKind".into(), "pythonMarkdown".into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert!(result.config.heading_kind == HeadingKind::Setext);
+    assert!(result.config.list_unordered_marker == ListUnorderedMarker::Asterisks);
+    assert!(result.config.list_indent_kind == ListIndentKind::PythonMarkdown);
+  }
+
+  #[test]
+  fn deprecated_names_lose_to_current_names() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "atx".into());
+    config.insert("heading.kind".into(), "setext".into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert!(result.config.heading_kind == HeadingKind::Setext);
   }
 
   #[test]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -58,22 +58,30 @@ pub fn resolve_config(
     text_wrap: get_value(&mut config, "textWrap", TextWrap::Maintain, &mut diagnostics),
     emphasis_kind: get_value(&mut config, "emphasisKind", EmphasisKind::Underscores, &mut diagnostics),
     strong_kind: get_value(&mut config, "strongKind", StrongKind::Asterisks, &mut diagnostics),
-    unordered_list_kind: get_value(
+    hard_break_kind: get_value(&mut config, "hardBreakKind", HardBreakKind::Backslash, &mut diagnostics),
+    max_blank_lines: get_max_blank_lines(&mut config, &mut diagnostics),
+    heading_kind: get_renamed_value(
       &mut config,
-      "unorderedListKind",
-      UnorderedListKind::Dashes,
+      "heading.kind",
+      "headingKind",
+      HeadingKind::Atx,
       &mut diagnostics,
     ),
-    heading_kind: get_value(&mut config, "headingKind", HeadingKind::Atx, &mut diagnostics),
-    hard_break_kind: get_value(&mut config, "hardBreakKind", HardBreakKind::Backslash, &mut diagnostics),
-    list_indent_kind: get_value(
+    heading_blank_lines_above: get_heading_blank_lines_above(&mut config, &mut diagnostics),
+    list_unordered_marker: get_renamed_value(
       &mut config,
+      "list.unorderedMarker",
+      "unorderedListKind",
+      ListUnorderedMarker::Dashes,
+      &mut diagnostics,
+    ),
+    list_indent_kind: get_renamed_value(
+      &mut config,
+      "list.indentKind",
       "listIndentKind",
       ListIndentKind::CommonMark,
       &mut diagnostics,
     ),
-    max_blank_lines: get_max_blank_lines(&mut config, &mut diagnostics),
-    heading_blank_lines_above: get_heading_blank_lines_above(&mut config, &mut diagnostics),
     code_block_skip_format: get_value(&mut config, "codeBlock.skipFormat", false, &mut diagnostics),
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
@@ -126,6 +134,26 @@ pub fn resolve_config(
   }
 }
 
+/// Reads a property, falling back to the deprecated name the property used to
+/// go by. Both names are taken from the map so that a deprecated one isn't
+/// reported as unknown.
+fn get_renamed_value<T>(
+  config: &mut ConfigKeyMap,
+  key: &str,
+  deprecated_key: &str,
+  default_value: T,
+  diagnostics: &mut Vec<ConfigurationDiagnostic>,
+) -> T
+where
+  T: std::str::FromStr,
+  <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+  let deprecated_value = get_nullable_value(config, deprecated_key, diagnostics);
+  get_nullable_value(config, key, diagnostics)
+    .or(deprecated_value)
+    .unwrap_or(default_value)
+}
+
 /// A block is always separated from the one above it by a blank line, so a
 /// maximum below one isn't something the formatter could ever stay under.
 fn get_max_blank_lines(config: &mut ConfigKeyMap, diagnostics: &mut Vec<ConfigurationDiagnostic>) -> u32 {
@@ -133,7 +161,7 @@ fn get_max_blank_lines(config: &mut ConfigKeyMap, diagnostics: &mut Vec<Configur
   ensure_at_least_one_blank_line("maxBlankLines", value, diagnostics)
 }
 
-/// With `headingKind: setext` a heading written against the paragraph above it
+/// With `heading.kind: setext` a heading written against the paragraph above it
 /// would underline that paragraph rather than follow it, so a count below one
 /// isn't one that could be written wherever the option applies.
 fn get_heading_blank_lines_above(

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -14,12 +14,11 @@ pub struct Configuration {
   pub text_wrap: TextWrap,
   pub emphasis_kind: EmphasisKind,
   pub strong_kind: StrongKind,
-  pub unordered_list_kind: UnorderedListKind,
-  pub heading_kind: HeadingKind,
   pub hard_break_kind: HardBreakKind,
-  pub list_indent_kind: ListIndentKind,
   /// The maximum number of consecutive blank lines to keep between blocks.
   pub max_blank_lines: u32,
+  #[serde(rename = "heading.kind")]
+  pub heading_kind: HeadingKind,
   /// The number of blank lines to write above a heading. That many are written
   /// even where `max_blank_lines` is lower, though a heading drawn up against
   /// the block above it within a list is left there, which keeps the list
@@ -27,6 +26,11 @@ pub struct Configuration {
   /// other block.
   #[serde(rename = "heading.blankLinesAbove")]
   pub heading_blank_lines_above: Option<u32>,
+  /// The character to write the marker of an unordered list's items with.
+  #[serde(rename = "list.unorderedMarker")]
+  pub list_unordered_marker: ListUnorderedMarker,
+  #[serde(rename = "list.indentKind")]
+  pub list_indent_kind: ListIndentKind,
   #[serde(rename = "codeBlock.skipFormat")]
   pub code_block_skip_format: bool,
   #[serde(rename = "codeBlock.preserveIndentation")]
@@ -110,41 +114,6 @@ pub enum StrongKind {
 
 generate_str_to_from![StrongKind, [Asterisks, "asterisks"], [Underscores, "underscores"]];
 
-/// The character to use primarily for lists.
-///
-/// Unnumbered lists will be formatted to use a common list character, i.e., the primary list
-/// character. Additionally, an alternate list character is used to separate lists which are not
-/// separated by other paragraphs. This parameter defines which character should be used as primary
-/// list character, i.e., either '-' (default) or '*'. The alternate list character will be the one
-/// which is _not_ primary.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum UnorderedListKind {
-  /// Uses dashes (-) as primary character for lists (default).
-  ///
-  /// In this case, asterisks are used as alternate list characters.
-  Dashes,
-  /// Uses asterisks (*) as primary character for lists.
-  ///
-  /// In this case, dashes are used as alternate list characters.
-  Asterisks,
-}
-
-impl UnorderedListKind {
-  /// Determine the character to use for a list, i.e., '-' or '*'.
-  ///
-  /// The result depends on the configuration and whether the primary or alternate character is
-  /// requested. See [`Self`].
-  pub fn list_char(&self, is_alternate: bool) -> char {
-    match (self, is_alternate) {
-      (Self::Dashes, true) | (Self::Asterisks, false) => '*',
-      _ => '-',
-    }
-  }
-}
-
-generate_str_to_from![UnorderedListKind, [Dashes, "dashes"], [Asterisks, "asterisks"]];
-
 /// The style of heading to use for level 1 and level 2 headings:
 /// [setext](https://spec.commonmark.org/0.31.2/#setext-headings) or
 /// [ATX](https://spec.commonmark.org/0.31.2/#atx-headings). Level 3 and
@@ -195,6 +164,41 @@ pub enum TableCellPadding {
 }
 
 generate_str_to_from![TableCellPadding, [Align, "align"], [Space, "space"], [None, "none"]];
+
+/// The character to use primarily for lists.
+///
+/// Unnumbered lists will be formatted to use a common list character, i.e., the primary list
+/// character. Additionally, an alternate list character is used to separate lists which are not
+/// separated by other paragraphs. This parameter defines which character should be used as primary
+/// list character, i.e., either '-' (default) or '*'. The alternate list character will be the one
+/// which is _not_ primary.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ListUnorderedMarker {
+  /// Uses dashes (-) as primary character for lists (default).
+  ///
+  /// In this case, asterisks are used as alternate list characters.
+  Dashes,
+  /// Uses asterisks (*) as primary character for lists.
+  ///
+  /// In this case, dashes are used as alternate list characters.
+  Asterisks,
+}
+
+impl ListUnorderedMarker {
+  /// Determine the character to use for a list, i.e., '-' or '*'.
+  ///
+  /// The result depends on the configuration and whether the primary or alternate character is
+  /// requested. See [`Self`].
+  pub fn list_char(&self, is_alternate: bool) -> char {
+    match (self, is_alternate) {
+      (Self::Dashes, true) | (Self::Asterisks, false) => '*',
+      _ => '-',
+    }
+  }
+}
+
+generate_str_to_from![ListUnorderedMarker, [Dashes, "dashes"], [Asterisks, "asterisks"]];
 
 /// The style of indentation to use for list items.
 ///

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1968,7 +1968,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         };
         format!("{}{}", display_index, end_char)
       } else {
-        String::from(context.configuration.unordered_list_kind.list_char(is_alternate))
+        String::from(context.configuration.list_unordered_marker.list_char(is_alternate))
       };
       let marker_width = prefix_text.chars().count() as u32 + 1;
       let indent_increment = match context.configuration.list_indent_kind {

--- a/tests/specs/BlockQuotes/BlockQuotes_HeadingKind_Setext.txt
+++ b/tests/specs/BlockQuotes/BlockQuotes_HeadingKind_Setext.txt
@@ -1,4 +1,4 @@
-~~ headingKind: setext ~~
+~~ heading.kind: setext ~~
 !! should keep the markers of a setext heading !!
 > some words here that are quite long and more text again that keeps going on and on
 > ===

--- a/tests/specs/DefinitionLists/DefinitionLists_ListIndentKind_PythonMarkdown.txt
+++ b/tests/specs/DefinitionLists/DefinitionLists_ListIndentKind_PythonMarkdown.txt
@@ -1,4 +1,4 @@
-~~ listIndentKind: pythonMarkdown ~~
+~~ list.indentKind: pythonMarkdown ~~
 !! should indent a definition by 4 spaces !!
 Term
 : Definition

--- a/tests/specs/Lists/Lists_ListIndentKind_PythonMarkdown.txt
+++ b/tests/specs/Lists/Lists_ListIndentKind_PythonMarkdown.txt
@@ -1,4 +1,4 @@
-~~ listIndentKind: pythonMarkdown ~~
+~~ list.indentKind: pythonMarkdown ~~
 !! should indent nested ordered list by 4 spaces !!
 1. first
    1. nested first

--- a/tests/specs/Lists/Lists_ListKind_Asterisks.txt
+++ b/tests/specs/Lists/Lists_ListKind_Asterisks.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, unorderedListKind: asterisks ~~
+~~ lineWidth: 40, list.unorderedMarker: asterisks ~~
 !! should format an unordered list with asterisks !!
 - A
 - B

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, headingKind: setext ~~
+~~ lineWidth: 40, heading.kind: setext ~~
 !! should format the headers !!
 # H1
 

--- a/tests/specs/headers/Headers_BlankLinesAbove_Setext.txt
+++ b/tests/specs/headers/Headers_BlankLinesAbove_Setext.txt
@@ -1,4 +1,4 @@
-~~ heading.blankLinesAbove: 2, headingKind: setext ~~
+~~ heading.blankLinesAbove: 2, heading.kind: setext ~~
 !! should write the configured number above a setext heading !!
 Text.
 

--- a/tests/specs/headers/Headers_Setext_BlockStarts.txt
+++ b/tests/specs/headers/Headers_Setext_BlockStarts.txt
@@ -1,4 +1,4 @@
-~~ headingKind: setext ~~
+~~ heading.kind: setext ~~
 !! should not underline html, which begins a block of its own !!
 # <a>
 

--- a/tests/specs/headers/Headers_Setext_HardBreaks_DoubleSpace.txt
+++ b/tests/specs/headers/Headers_Setext_HardBreaks_DoubleSpace.txt
@@ -1,4 +1,4 @@
-~~ headingKind: setext, hardBreakKind: doubleSpace ~~
+~~ heading.kind: setext, hardBreakKind: doubleSpace ~~
 !! should not count a hard break's trailing spaces in the underline width !!
 head\
 ing

--- a/tests/specs/headers/Headers_Setext_TextWrap_Always.txt
+++ b/tests/specs/headers/Headers_Setext_TextWrap_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, headingKind: setext, textWrap: always ~~
+~~ lineWidth: 40, heading.kind: setext, textWrap: always ~~
 !! should wrap long level 1 heading and size underline to longest line !!
 # This heading is long enough that it should wrap onto multiple lines
 


### PR DESCRIPTION
Renames three options so they read as `<item>.<setting>`, the way `heading.blankLinesAbove`, `codeBlock.*`, and `table.*` already do:

| old | new |
| --- | --- |
| `headingKind` | `heading.kind` |
| `unorderedListKind` | `list.unorderedMarker` |
| `listIndentKind` | `list.indentKind` |

`list.unorderedMarker` rather than `list.unorderedKind` because the values are `dashes`/`asterisks` — the marker character, not a kind of list.

The old names keep working, so this isn't breaking for a config. A deprecated name is read only where the name that replaced it isn't written, and neither one is reported as an unknown property. No diagnostic is pushed for one, since a config diagnostic fails the run rather than warning.

In the schema the old names are kept as properties marked `"deprecated"`, with a description pointing at the name that replaced them. They wrap their `$ref` in an `allOf` because this is draft-07, where a sibling of a `$ref` is ignored.

The Rust API does break: `UnorderedListKind` is now `ListUnorderedMarker` and `Configuration::unordered_list_kind` is now `list_unordered_marker`, which lines up with how `table.cellPadding` and `TableCellPadding` are already named. `heading_kind` and `list_indent_kind` already matched the names they were moved to.

The fields of `Configuration`, the builder's methods, and the schema's properties are also reordered so that each namespace reads together.
