### PR TITLE
feat: add `textWrap: "maintainAndWrap"` config value

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -32,6 +32,9 @@
         "const": "maintain",
         "description": "Maintains line breaks."
       }, {
+        "const": "maintainAndWrap",
+        "description": "Maintains line breaks, but wraps a line that runs past the line width."
+      }, {
         "const": "never",
         "description": "Never wraps text."
       }, {

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -71,6 +71,12 @@ pub enum TextWrap {
   Always,
   /// Maintains line breaks (default).
   Maintain,
+  /// Maintains line breaks, but wraps a line that runs past the line width.
+  ///
+  /// This is `Maintain` with the wrapping of `Always` layered on top: no line
+  /// is ever drawn up into the one above it, so the breaks that were written
+  /// stay where they are, while a line too long to fit is broken up.
+  MaintainAndWrap,
   /// Never wraps text.
   Never,
   /// Writes one sentence per line, ignoring the line width.
@@ -82,10 +88,20 @@ pub enum TextWrap {
   Sentence,
 }
 
+impl TextWrap {
+  /// Whether the line breaks the file was written with are kept where they
+  /// are, rather than the text being written back out over the lines it fits
+  /// on.
+  pub(crate) fn keeps_line_breaks(&self) -> bool {
+    matches!(self, TextWrap::Maintain | TextWrap::MaintainAndWrap)
+  }
+}
+
 generate_str_to_from![
   TextWrap,
   [Always, "always"],
   [Maintain, "maintain"],
+  [MaintainAndWrap, "maintainAndWrap"],
   [Never, "never"],
   [Sentence, "sentence"]
 ];

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -7,7 +7,6 @@ use regex::Regex;
 
 use super::utils::*;
 use crate::configuration::Configuration;
-use crate::configuration::TextWrap;
 use crate::format_text;
 use crate::format_text::FormatError;
 use crate::parser::Span;
@@ -419,7 +418,7 @@ impl<'a> Context<'a> {
 
   fn written_char(&self, at: &[(usize, char)], position: usize) -> Option<char> {
     // a break that is kept is still written out, so nothing moves against it
-    if self.configuration.text_wrap == TextWrap::Maintain {
+    if self.configuration.text_wrap.keeps_line_breaks() {
       return None;
     }
     at.binary_search_by_key(&position, |(at, _)| *at)

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -921,7 +921,7 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
     /// `is_newline` says was written as a line ending.
     pub fn end_word(&mut self, is_newline: bool) {
       self.flush_word();
-      self.after_maintained_newline = is_newline && self.context.configuration.text_wrap == TextWrap::Maintain;
+      self.after_maintained_newline = is_newline && self.context.configuration.text_wrap.keeps_line_breaks();
     }
 
     /// Whether nothing has been written yet, where the whitespace that follows
@@ -1723,7 +1723,7 @@ fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> Prin
   if context.configuration.text_wrap == TextWrap::Sentence && !context.is_text_wrap_disabled() {
     return gen_word_with_sentence_breaks(word);
   }
-  if context.configuration.text_wrap != TextWrap::Always || context.is_text_wrap_disabled() {
+  if !wraps_at_the_line_width(context) {
     return gen_text_with_tabs(word);
   }
 
@@ -2584,7 +2584,17 @@ fn starts_block_at_line_start(node: &Node, context: &Context) -> bool {
 /// checks that keep it off one read the word on its own rather than the line
 /// the file happened to write it on.
 fn text_can_be_wrapped_away(context: &Context) -> bool {
-  matches!(context.configuration.text_wrap, TextWrap::Always | TextWrap::Sentence) && !context.is_text_wrap_disabled()
+  wraps_at_the_line_width(context)
+    || (context.configuration.text_wrap == TextWrap::Sentence && !context.is_text_wrap_disabled())
+}
+
+/// Whether a line that runs past the line width is broken up, which is what
+/// the printer is left to decide the line breaks of.
+fn wraps_at_the_line_width(context: &Context) -> bool {
+  matches!(
+    context.configuration.text_wrap,
+    TextWrap::Always | TextWrap::MaintainAndWrap
+  ) && !context.is_text_wrap_disabled()
 }
 
 fn get_space_or_newline_based_on_config(context: &Context, ends_sentence: bool) -> PrintItems {
@@ -2592,7 +2602,9 @@ fn get_space_or_newline_based_on_config(context: &Context, ends_sentence: bool) 
     return space();
   }
   match context.configuration.text_wrap {
-    TextWrap::Always => Signal::SpaceOrNewLine.into(),
+    // the space was written within a line, so it's somewhere the printer may
+    // break the line even where the breaks that were written are kept
+    TextWrap::Always | TextWrap::MaintainAndWrap => Signal::SpaceOrNewLine.into(),
     TextWrap::Sentence if ends_sentence => new_line_or_space_if_newlines_disabled(),
     TextWrap::Sentence | TextWrap::Never | TextWrap::Maintain => space(),
   }
@@ -2708,7 +2720,7 @@ fn get_unspaced_script_newline_wrapping(context: &Context, ends_sentence: bool) 
     // where newlines are being forced off (ex. within a heading) the printer
     // drops this one, which is what should take the place of a break that read
     // as nothing anyway
-    TextWrap::Maintain => Signal::NewLine.into(),
+    TextWrap::Maintain | TextWrap::MaintainAndWrap => Signal::NewLine.into(),
   }
 }
 
@@ -2718,7 +2730,7 @@ fn get_newline_wrapping_based_on_config(context: &Context, ends_sentence: bool) 
     // being wrapped, but keeps the line breaks it has when text is maintained
     return match context.configuration.text_wrap {
       TextWrap::Always | TextWrap::Never | TextWrap::Sentence => space(),
-      TextWrap::Maintain => new_line_or_space_if_newlines_disabled(),
+      TextWrap::Maintain | TextWrap::MaintainAndWrap => new_line_or_space_if_newlines_disabled(),
     };
   }
   match context.configuration.text_wrap {
@@ -2731,7 +2743,7 @@ fn get_newline_wrapping_based_on_config(context: &Context, ends_sentence: bool) 
     // a line break can't be written where newlines are being forced off
     // (ex. within a heading), where it stands for the space between the words
     // it separated
-    TextWrap::Maintain => new_line_or_space_if_newlines_disabled(),
+    TextWrap::Maintain | TextWrap::MaintainAndWrap => new_line_or_space_if_newlines_disabled(),
   }
 }
 

--- a/tests/specs/Text/Text_TextWrap_MaintainAndWrap.txt
+++ b/tests/specs/Text/Text_TextWrap_MaintainAndWrap.txt
@@ -1,0 +1,146 @@
+~~ lineWidth: 40, textWrap: maintainAndWrap ~~
+!! should keep the line breaks that were written !!
+A new paragraph.
+Here the lines are shorter.
+Like so.
+
+[expect]
+A new paragraph.
+Here the lines are shorter.
+Like so.
+
+!! should wrap a line that runs past the line width !!
+A very long line exceeding the line width. It goes all the way and stops.
+
+[expect]
+A very long line exceeding the line
+width. It goes all the way and stops.
+
+!! should wrap the long lines and leave the short ones where they were !!
+A very long line exceeding the line width. It goes all the way and stops.
+
+A new paragraph.
+Here the lines are shorter.
+Like so.
+
+[expect]
+A very long line exceeding the line
+width. It goes all the way and stops.
+
+A new paragraph.
+Here the lines are shorter.
+Like so.
+
+!! should keep the blank lines between paragraphs !!
+One.
+
+Two.
+
+[expect]
+One.
+
+Two.
+
+!! should keep a heading on one line !!
+# A heading that is quite long indeed and runs past the width
+
+[expect]
+# A heading that is quite long indeed and runs past the width
+
+!! should wrap within a block quote !!
+> A very long line exceeding the line width. It goes all the way and stops.
+> Short line.
+
+[expect]
+> A very long line exceeding the line
+> width. It goes all the way and stops.
+> Short line.
+
+!! should wrap within a list !!
+- A very long list item that exceeds the line width by quite a lot indeed.
+  Short line.
+- Another
+
+[expect]
+- A very long list item that exceeds the
+  line width by quite a lot indeed.
+  Short line.
+- Another
+
+!! should keep a table cell on one line !!
+| a | b |
+| - | - |
+| a very long cell value here that is long | b |
+
+[expect]
+| a                                        | b |
+| ---------------------------------------- | - |
+| a very long cell value here that is long | b |
+
+!! should keep a hard break !!
+A very long line exceeding the line width. It goes all the way.\
+Short line.
+
+[expect]
+A very long line exceeding the line
+width. It goes all the way.\
+Short line.
+
+!! should not move text that would start a block to the start of a line !!
+Some text that is long enough to wrap here - not a list at all
+
+Some text that is long enough to wrap ok 1. not a list at all
+
+[expect]
+Some text that is long enough to wrap
+here - not a list at all
+
+Some text that is long enough to wrap
+ok 1. not a list at all
+
+!! should keep the line breaks within a link's text, and not break within it !!
+[a link whose text is long enough to run past the width](https://example.com/)
+
+[a link whose text
+runs over lines](https://example.com/)
+
+[expect]
+[a link whose text is long enough to run past the width](https://example.com/)
+
+[a link whose text
+runs over lines](https://example.com/)
+
+!! should wrap a code span, and keep the break within it !!
+`a code span with quite a lot of words inside of it` and more text here
+
+`a code span
+over lines` and more text that runs past the line width here
+
+[expect]
+`a code span with quite a lot of words
+inside of it` and more text here
+
+`a code span
+over lines` and more text that runs past
+the line width here
+
+!! should break a run of a script written without spaces, and keep the break within it !!
+一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
+短い行
+
+[expect]
+一二三四五六七八九十一二三四五六七八九十
+一二三四五六七八九十
+短い行
+
+!! should join a line whose first word alone would start a block, which wrapping could leave it as !!
+aaaaaaaaaa
+-- bbbbbbbbbb
+
+aaaaaaaaaa
+|--| bbbbbbbbbb
+
+[expect]
+aaaaaaaaaa -- bbbbbbbbbb
+
+aaaaaaaaaa |--| bbbbbbbbbb


### PR DESCRIPTION
Closes #228.

Keeps the line breaks the file was written with, the way `maintain` does, while breaking up a line that runs past the line width, the way `always` does. No line is ever drawn up into the one above it.

With `lineWidth: 80`, the example from the issue:

```markdown
A very long line exceeding 80 characters. It goes all the way to 80 and stops. Then it goes past it.

A new paragraph.
Here the lines are shorter.
Like so.
```

```markdown
A very long line exceeding 80 characters. It goes all the way to 80 and stops.
Then it goes past it.

A new paragraph.
Here the lines are shorter.
Like so.
```

## The name

The existing values combine two behaviors, and this fills in the pair that was missing:

| value | joins short lines | breaks long lines |
| --- | --- | --- |
| `always` | yes | yes |
| `never` | yes | no |
| `maintain` | no | no |
| `sentence` | no | only at sentence ends |
| `maintainAndWrap` | no | yes |

It names both halves because anything shorter (`wrapOverflow`, `split`) names only the added wrapping and leaves the reader guessing whether the breaks that were written survive. `preserve` was ruled out because Prettier's `proseWrap: "preserve"` means our `maintain`. The pattern also extends, should `sentence` ever want the same treatment.

## How it's done

A space written within a line becomes a `SpaceOrNewLine` (what `always` does), while a line break that was written becomes a `NewLine` (what `maintain` does). The two behaviors were already separate functions, so most of this is adding the value to the arms it belongs in. `wraps_at_the_line_width` gathers the "the printer decides this line's breaks" question that `always` used to be the sole answer to, which is what `text_can_be_wrapped_away` and the unspaced-script breaking are really asking.

`written_char` and `after_maintained_newline` go with `maintain` instead, through a new `TextWrap::keeps_line_breaks`.

## Checking

Beyond the specs, every input in `tests/specs` and `tests/parser_specs` (534 of them) was formatted at five line widths and compared against the same input under `maintain`: no panics, no errors, every result idempotent, no text lost, and no line break dropped -- except the one case below.

## One known limitation

Where a line's *first word alone* would read as block markup, the break above it is joined rather than kept:

```markdown
aaaaaaaaaa
-- bbbbbbbbbb
```

becomes `aaaaaaaaaa -- bbbbbbbbbb`, because wrapping could otherwise leave `--` by itself at the start of a line, where it would be read as a setext heading's underline. This is the protection `always` already relies on, reached here because the text can now be wrapped away. Keeping the break instead would need a way to hold those leading words together across the nodes that follow them, which the text builder only does within a single text node today. The output is always valid markdown, and the case is pinned in the specs.
