### PR TITLE
feat: add `codeBlock.raiseSyntaxErrors` config option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -126,6 +126,18 @@
         "description": "Formats the code within a code block."
       }]
     },
+    "codeBlock.raiseSyntaxErrors": {
+      "description": "Whether to fail the file when the plugin that formats the code within a code block reports an error, which is what it does when the code doesn't parse, rather than leaving that code as it was written.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Fails the file when the code within a code block can't be formatted."
+      }, {
+        "const": false,
+        "description": "Leaves the code within a code block as it was written when it can't be formatted."
+      }]
+    },
     "codeBlock.preserveIndentation": {
       "description": "Whether to keep the indentation the code within a code block was written with, rather than unindenting it.",
       "type": "boolean",
@@ -252,6 +264,9 @@
     },
     "codeBlock.skipFormat": {
       "$ref": "#/definitions/codeBlock.skipFormat"
+    },
+    "codeBlock.raiseSyntaxErrors": {
+      "$ref": "#/definitions/codeBlock.raiseSyntaxErrors"
     },
     "codeBlock.preserveIndentation": {
       "$ref": "#/definitions/codeBlock.preserveIndentation"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -118,6 +118,14 @@ impl ConfigurationBuilder {
     self.insert("codeBlock.skipFormat", value.into())
   }
 
+  /// Whether to fail the file when the plugin that formats the code within a
+  /// code block reports an error, which is what it does when the code doesn't
+  /// parse, rather than leaving that code as it was written.
+  /// Default: `false`
+  pub fn code_block_raise_syntax_errors(&mut self, value: bool) -> &mut Self {
+    self.insert("codeBlock.raiseSyntaxErrors", value.into())
+  }
+
   /// Whether to keep the indentation the code within a code block was
   /// written with, rather than unindenting it.
   /// Default: `false`
@@ -227,6 +235,7 @@ mod tests {
       .list_unordered_marker(ListUnorderedMarker::Asterisks)
       .list_indent_kind(ListIndentKind::PythonMarkdown)
       .code_block_skip_format(true)
+      .code_block_raise_syntax_errors(true)
       .code_block_preserve_indentation(true)
       .code_block_preserve_blank_lines(true)
       .code_block_use_tabs(true)
@@ -239,7 +248,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 22);
+    assert_eq!(inner_config.len(), 23);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -83,6 +83,7 @@ pub fn resolve_config(
       &mut diagnostics,
     ),
     code_block_skip_format: get_value(&mut config, "codeBlock.skipFormat", false, &mut diagnostics),
+    code_block_raise_syntax_errors: get_value(&mut config, "codeBlock.raiseSyntaxErrors", false, &mut diagnostics),
     code_block_preserve_indentation: get_value(&mut config, "codeBlock.preserveIndentation", false, &mut diagnostics),
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
     code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -33,6 +33,11 @@ pub struct Configuration {
   pub list_indent_kind: ListIndentKind,
   #[serde(rename = "codeBlock.skipFormat")]
   pub code_block_skip_format: bool,
+  /// Whether to fail the file when the plugin that formats the code within a
+  /// code block reports an error, which is what it does when the code doesn't
+  /// parse, rather than leaving that code as it was written.
+  #[serde(rename = "codeBlock.raiseSyntaxErrors")]
+  pub code_block_raise_syntax_errors: bool,
   #[serde(rename = "codeBlock.preserveIndentation")]
   pub code_block_preserve_indentation: bool,
   #[serde(rename = "codeBlock.preserveBlankLines")]

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -1,7 +1,11 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use dprint_core::configuration::resolve_new_line_kind;
 use dprint_core::formatting::*;
 
 use super::configuration::Configuration;
+use super::generation::count_new_lines;
 use super::generation::file_has_ignore_file_directive;
 use super::generation::generate;
 use super::generation::strip_metadata_header;
@@ -20,6 +24,14 @@ pub enum FormatError {
   /// An error occurred while formatting the text of a code block.
   #[error("{0}")]
   CodeBlock(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl FormatError {
+  /// Says which line of the file the code block that failed to format was
+  /// written on.
+  fn in_code_block_on_line(self, line: u32) -> FormatError {
+    FormatError::CodeBlock(Box::new(CodeBlockErrorOnLine { line, error: self }))
+  }
 }
 
 impl From<std::string::FromUtf8Error> for FormatError {
@@ -50,19 +62,35 @@ fn format_text_inner(
   config: &Configuration,
   format_code_block_text: impl for<'a> FnMut(&str, &'a str, u32) -> Result<Option<String>, FormatError>,
 ) -> Result<Option<String>, FormatError> {
+  let full_text = file_text;
   let file_text = strip_bom(file_text);
+  // the lines taken off the front of the file, which the lines the rest of it
+  // is reported on are still counted from
+  let stripped_lines = count_new_lines(&full_text[..full_text.len() - file_text.len()]);
   let (source_file, markdown_text) = match parse_source_file(file_text, config)? {
     ParseFileResult::IgnoreFile => return Ok(None),
     ParseFileResult::SourceFile(file) => file,
   };
 
-  Ok(Some(dprint_core::formatting::format(
+  // a code block whose plugin errors can't fail the file from where it's
+  // generated, so the error is carried out of the generation and raised here
+  let code_block_error = Rc::new(RefCell::new(None));
+  let text = dprint_core::formatting::format(
     || {
-      let mut context = Context::new(markdown_text, config, format_code_block_text);
+      let mut context = Context::new(markdown_text, config, format_code_block_text, code_block_error.clone());
       generate(&source_file.into(), &mut context)
     },
     config_to_print_options(file_text, config),
-  )))
+  );
+
+  let code_block_error = code_block_error.borrow_mut().take();
+  match code_block_error {
+    Some(code_block_error) => {
+      let line = stripped_lines + count_new_lines(&markdown_text[..code_block_error.pos]) + 1;
+      Err(code_block_error.error.in_code_block_on_line(line))
+    }
+    None => Ok(Some(text)),
+  }
 }
 
 #[cfg(feature = "tracing")]
@@ -77,7 +105,7 @@ pub fn trace_file(
   };
   dprint_core::formatting::trace_printing(
     || {
-      let mut context = Context::new(markdown_text, config, format_code_block_text);
+      let mut context = Context::new(markdown_text, config, format_code_block_text, Default::default());
       generate(&source_file.into(), &mut context)
     },
     config_to_print_options(file_text, config),
@@ -117,6 +145,16 @@ fn parse_source_file<'a>(file_text: &'a str, config: &Configuration) -> Result<P
   Ok(ParseFileResult::SourceFile((file, file_text)))
 }
 
+/// An error a code block's plugin ran into, along with where in the file the
+/// code block was written.
+#[derive(Debug, thiserror::Error)]
+#[error("the code block on line {line} failed to format\n\n{error}")]
+struct CodeBlockErrorOnLine {
+  /// The line the code block starts on, counting from one.
+  line: u32,
+  error: FormatError,
+}
+
 fn config_to_print_options(file_text: &str, config: &Configuration) -> PrintOptions {
   PrintOptions {
     indent_width: 1, // force
@@ -144,5 +182,90 @@ mod test {
       let result = format_text(input_text, &config, |_, _, _| Ok(None)).unwrap();
       assert_eq!(result, Some("# Title\n".to_string()));
     }
+  }
+
+  #[test]
+  fn reports_the_line_the_code_block_starts_on() {
+    for (file_text, line) in [
+      ("# Title\n\n```error\nnot  code\n```\n", 3),
+      ("# Title\r\n\r\n```error\r\nnot  code\r\n```\r\n", 3),
+      ("---\na: b\n---\n\n# Title\n\n```error\nnot  code\n```\n", 7),
+      // the lines taken off with the byte order marks still count
+      ("\n\n\u{FEFF}# Title\n\n```error\nnot  code\n```\n", 5),
+    ] {
+      let error = format_failing_code_block(file_text, &raise_errors_config())
+        .err()
+        .unwrap();
+      assert_eq!(
+        error.to_string(),
+        format!("the code block on line {} failed to format\n\nsyntax error", line)
+      );
+    }
+  }
+
+  #[test]
+  fn leaves_code_block_as_written_when_not_enabled() {
+    let config = ConfigurationBuilder::new().build();
+    let result = format_failing_code_block("#  Title\n\n```error\nnot  code\n```\n", &config).unwrap();
+    assert_eq!(result, Some("# Title\n\n```error\nnot  code\n```\n".to_string()));
+  }
+
+  #[test]
+  fn does_not_error_when_code_blocks_are_not_formatted() {
+    let config = ConfigurationBuilder::new()
+      .code_block_raise_syntax_errors(true)
+      .code_block_skip_format(true)
+      .build();
+    let result = format_failing_code_block("# Title\n\n```error\nnot  code\n```\n", &config).unwrap();
+    assert_eq!(result, None);
+  }
+
+  #[test]
+  fn does_not_error_on_ignored_code_block() {
+    let file_text = "<!-- dprint-ignore -->\n\n```error\nnot  code\n```\n";
+    let result = format_failing_code_block(file_text, &raise_errors_config()).unwrap();
+    assert_eq!(result, None);
+  }
+
+  #[test]
+  fn errors_on_code_block_within_a_markdown_code_block() {
+    let file_text = r#"````md
+# Title
+
+```error
+not  code
+```
+````
+"#;
+    let error = format_failing_code_block(file_text, &raise_errors_config())
+      .err()
+      .unwrap();
+    // the line the inner error reports is the line of the markdown the code
+    // block holds, rather than a line of the file it's written in
+    assert_eq!(
+      error.to_string(),
+      concat!(
+        "the code block on line 1 failed to format\n\n",
+        "the code block on line 3 failed to format\n\nsyntax error"
+      )
+    );
+  }
+
+  /// A configuration that fails a file for an error a code block's plugin runs
+  /// into.
+  fn raise_errors_config() -> Configuration {
+    ConfigurationBuilder::new().code_block_raise_syntax_errors(true).build()
+  }
+
+  /// Formats a file, with the plugin of any code block tagged `error` failing
+  /// to format the code it holds.
+  fn format_failing_code_block(file_text: &str, config: &Configuration) -> Result<Option<String>, FormatError> {
+    format_text(file_text, config, |tag, _, _| {
+      if tag == "error" {
+        Err(FormatError::CodeBlock("syntax error".into()))
+      } else {
+        Ok(None)
+      }
+    })
   }
 }

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use dprint_core::formatting::PrintItemPath;
 use dprint_core::formatting::PrintItems;
@@ -12,6 +14,17 @@ use crate::format_text::FormatError;
 use crate::parser::Span;
 
 type FormatResult = Result<Option<String>, FormatError>;
+
+/// The error the plugin that formats the code within a code block ran into,
+/// along with where the code block was written.
+///
+/// The line it's reported on is worked out once the file has been generated,
+/// where the text the file began with is known.
+pub struct CodeBlockError {
+  /// Where the code block starts within the text being generated.
+  pub pos: usize,
+  pub error: FormatError,
+}
 
 /// The line breaks that aren't written out, and the characters that end up
 /// written against each other in their place.
@@ -122,6 +135,12 @@ pub struct Context<'a> {
   /// Where the node generated next sits.
   next_position: NodePosition,
   pub format_code_block_text: Box<dyn for<'b> FnMut(&str, &'b str, u32) -> FormatResult + 'a>,
+  /// The first error a code block's plugin ran into, which fails the file once
+  /// it's been generated when `codeBlock.raiseSyntaxErrors` is on.
+  ///
+  /// It's held outside the context so that it's still there to be read once
+  /// the context has been dropped.
+  code_block_error: Rc<RefCell<Option<CodeBlockError>>>,
   pub ignore_regex: Regex,
   pub ignore_start_regex: Regex,
   pub ignore_end_regex: Regex,
@@ -147,6 +166,7 @@ impl<'a> Context<'a> {
     file_text: &'a str,
     configuration: &'a Configuration,
     format_code_block_text: impl for<'b> FnMut(&str, &'b str, u32) -> FormatResult + 'a,
+    code_block_error: Rc<RefCell<Option<CodeBlockError>>>,
   ) -> Context<'a> {
     Context {
       file_text,
@@ -171,6 +191,7 @@ impl<'a> Context<'a> {
       },
       next_position: NodePosition::default(),
       format_code_block_text: Box::new(format_code_block_text),
+      code_block_error,
       ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
       ignore_start_regex: get_ignore_comment_regex(&configuration.ignore_start_directive),
       ignore_end_regex: get_ignore_comment_regex(&configuration.ignore_end_directive),
@@ -463,6 +484,15 @@ impl<'a> Context<'a> {
     self.text_wrap_disabled_count > 0
   }
 
+  /// Keeps the error a code block's plugin ran into, when it's the first, so
+  /// that it can fail the file once it's been generated.
+  pub fn mark_code_block_error(&mut self, pos: usize, error: FormatError) {
+    let mut code_block_error = self.code_block_error.borrow_mut();
+    if code_block_error.is_none() {
+      *code_block_error = Some(CodeBlockError { pos, error });
+    }
+  }
+
   pub fn format_text<'b>(&mut self, tag: &str, text: &'b str) -> FormatResult {
     let line_width = std::cmp::max(10, self.configuration.line_width as i32 - self.indent_level as i32) as u32;
 
@@ -479,18 +509,6 @@ impl<'a> Context<'a> {
       return 0;
     } // ignore
 
-    // a line ends at a newline, at a carriage return written on its own, and
-    // at a carriage return and the newline that follows it, which is one line
-    // ending rather than two
-    let file_bytes = self.file_text.as_bytes();
-    let mut count = 0;
-    for (index, byte) in file_bytes[start..end].iter().enumerate() {
-      match byte {
-        b'\n' => count += 1,
-        b'\r' if file_bytes.get(start + index + 1) != Some(&b'\n') => count += 1,
-        _ => {}
-      }
-    }
-    count
+    count_new_lines(&self.file_text[start..end])
   }
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -749,10 +749,20 @@ fn gen_code_block(code_block: &CodeBlock, position: NodePosition, context: &mut 
       if let Some(tag) = code_block.tag() {
         // allow situations like ```rust,ignore
         let tag = tag.chars().take_while(|&c| c != ' ' && c != ',').collect::<String>();
-        if let Ok(Some(text)) = context.format_text(&tag, code) {
-          // Formatters produce a string with a trailing newline, which must be removed.
-          let text = text.strip_suffix("\n").unwrap_or(&text);
-          return Cow::Owned(text.strip_suffix("\r").unwrap_or(text).to_owned());
+        match context.format_text(&tag, code) {
+          Ok(Some(text)) => {
+            // Formatters produce a string with a trailing newline, which must be removed.
+            let text = text.strip_suffix("\n").unwrap_or(&text);
+            return Cow::Owned(text.strip_suffix("\r").unwrap_or(text).to_owned());
+          }
+          Ok(None) => {}
+          // code the plugin can't format is left as it was written, unless the
+          // configuration says an error it runs into should fail the file
+          Err(err) => {
+            if context.configuration.code_block_raise_syntax_errors {
+              context.mark_code_block_error(code_block.span.start, err);
+            }
+          }
         }
       }
     }

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -3,6 +3,24 @@ use std::borrow::Cow;
 
 use regex::Regex;
 
+/// How many lines the text has beyond its first.
+///
+/// A line ends at a newline, at a carriage return written on its own, and at a
+/// carriage return and the newline that follows it, which is one line ending
+/// rather than two.
+pub fn count_new_lines(text: &str) -> u32 {
+  let bytes = text.as_bytes();
+  let mut count = 0;
+  for (index, byte) in bytes.iter().enumerate() {
+    match byte {
+      b'\n' => count += 1,
+      b'\r' if bytes.get(index + 1) != Some(&b'\n') => count += 1,
+      _ => {}
+    }
+  }
+  count
+}
+
 /// Whether the character belongs to a script written without spaces between
 /// its words, where a line break carries no meaning of its own.
 ///


### PR DESCRIPTION
Closes #64

Adds `codeBlock.raiseSyntaxErrors` (default `false`). When on, an error the plugin formatting a code block reports — which is what it does when the code doesn't parse — fails the whole file instead of silently leaving that code block as it was written.

```json
{
  "markdown": {
    "codeBlock.raiseSyntaxErrors": true
  }
}
```

The error names the line the code block starts on, with the plugin's own message below it:

```
the code block on line 3 failed to format

Line 1, column 5: Expected a semi-colon
```

Only the first failing code block is reported. A code block within a markdown code block chains the messages, with the inner line being a line of the markdown that block holds.

As suggested in the issue, the existing escape hatches cover the cases where a block shouldn't be checked: `<!-- dprint-ignore -->` (and the start/end pair) writes the block out raw so no plugin runs, and `codeBlock.skipFormat` turns the formatting off entirely. Both are covered by tests.

## Implementation

Generation can't fail from where a code block is written, so `Context` records the first error along with where the block starts, and `format_text` raises it once the file has been generated. The error is held in an `Rc<RefCell<..>>` handed to the context so that it's read after `dprint_core::formatting::format` returns rather than from inside the closure that generates.

The line is worked out at that point, from the text the file began with, so that the newlines `strip_bom` takes off the front of a file are still counted. `count_new_lines` moved out of `Context::get_new_lines_in_range` for that, which both now share.