### PR TITLE
perf: format three times faster, with a tenth of the allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ dependencies = [
  "dprint-core-macros",
  "dprint-development",
  "file_test_runner",
- "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ harness = false
 [dependencies]
 dprint-core = { version = "0.69.1", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
-regex = "1"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0"

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -6,8 +6,8 @@ use dprint_core::formatting::*;
 
 use super::configuration::Configuration;
 use super::generation::count_new_lines;
-use super::generation::file_has_ignore_file_directive;
 use super::generation::generate;
+use super::generation::is_ignore_comment;
 use super::generation::strip_metadata_header;
 use super::generation::Context;
 
@@ -137,7 +137,7 @@ enum ParseFileResult<'a> {
 
 fn parse_source_file<'a>(file_text: &'a str, config: &Configuration) -> Result<ParseFileResult<'a>, FormatError> {
   // check for the presence of a dprint-ignore-file comment before parsing
-  if file_has_ignore_file_directive(strip_metadata_header(file_text), &config.ignore_file_directive) {
+  if is_ignore_comment(strip_metadata_header(file_text), &config.ignore_file_directive) {
     return Ok(ParseFileResult::IgnoreFile);
   }
 

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use dprint_core::formatting::PrintItemPath;
 use dprint_core::formatting::PrintItems;
 use dprint_core::formatting::Signal;
-use regex::Regex;
 
 use super::utils::*;
 use crate::configuration::Configuration;
@@ -47,10 +46,35 @@ pub struct ParagraphEscapes {
   pub block_starts: Vec<BlockStartEscape>,
   /// Where each bit of text the paragraph writes at the start of a line
   /// starts.
-  pub line_starts: Vec<usize>,
+  pub line_starts: LineStarts,
   /// Where the paragraph ends, which bounds how far the text of one of its
   /// lines can run.
   pub end: usize,
+}
+
+/// Where each bit of text a paragraph writes at the start of a line starts.
+///
+/// Only a hard break puts anything but a paragraph's first node at the start of
+/// a line, so almost every paragraph has just the one. That one is held beside
+/// the rest rather than in a vector of its own, which most paragraphs then
+/// never need.
+#[derive(Default)]
+pub struct LineStarts {
+  first: Option<usize>,
+  rest: Vec<usize>,
+}
+
+impl LineStarts {
+  pub fn push(&mut self, start: usize) {
+    match self.first {
+      None => self.first = Some(start),
+      Some(_) => self.rest.push(start),
+    }
+  }
+
+  pub fn contains(&self, start: usize) -> bool {
+    self.first == Some(start) || self.rest.contains(&start)
+  }
 }
 
 /// Where a backslash goes so that a bit of a paragraph's text isn't read as the
@@ -122,7 +146,7 @@ pub struct Context<'a> {
   /// of its own.
   escaped_block_starts: Vec<BlockStartEscape>,
   /// Where each bit of text written at the start of a line starts.
-  line_start_texts: Vec<usize>,
+  line_start_texts: LineStarts,
   /// Where the block being written ends, which bounds how far the text of one
   /// of its lines can run.
   block_end: Option<usize>,
@@ -141,9 +165,6 @@ pub struct Context<'a> {
   /// It's held outside the context so that it's still there to be read once
   /// the context has been dropped.
   code_block_error: Rc<RefCell<Option<CodeBlockError>>>,
-  pub ignore_regex: Regex,
-  pub ignore_start_regex: Regex,
-  pub ignore_end_regex: Regex,
   memoized_rc_paths: HashMap<MemoizedRcPathKind, Option<PrintItemPath>>,
   /// How much each of the paths above indents by, keyed by address, so that
   /// they can be told apart from the paths that hold generated content and
@@ -181,7 +202,7 @@ impl<'a> Context<'a> {
       enclosing_decoration: None,
       escaped_closing_hashes: None,
       escaped_block_starts: Vec::new(),
-      line_start_texts: Vec::new(),
+      line_start_texts: LineStarts::default(),
       block_end: None,
       dropped_breaks: Default::default(),
       decoration_delimiters: std::cell::RefCell::new(HashMap::new()),
@@ -192,9 +213,6 @@ impl<'a> Context<'a> {
       next_position: NodePosition::default(),
       format_code_block_text: Box::new(format_code_block_text),
       code_block_error,
-      ignore_regex: get_ignore_comment_regex(&configuration.ignore_directive),
-      ignore_start_regex: get_ignore_comment_regex(&configuration.ignore_start_directive),
-      ignore_end_regex: get_ignore_comment_regex(&configuration.ignore_end_directive),
       memoized_rc_paths: HashMap::new(),
       memoized_rc_path_indents: HashMap::new(),
     }
@@ -403,7 +421,7 @@ impl<'a> Context<'a> {
   /// Whether what starts here is written at the start of a line, with nothing
   /// before it on that line.
   pub fn is_line_start(&self, start: usize) -> bool {
-    self.line_start_texts.contains(&start)
+    self.line_start_texts.contains(start)
   }
 
   /// Generates a run of nodes, `dropped` holding the line breaks within it and
@@ -474,6 +492,23 @@ impl<'a> Context<'a> {
     let delimiter = resolve();
     self.decoration_delimiters.borrow_mut().insert(start, delimiter);
     delimiter
+  }
+
+  /// Whether the html is the comment that turns off formatting for the node
+  /// written after it.
+  pub fn is_ignore_comment(&self, html_text: &str) -> bool {
+    is_ignore_comment(html_text, &self.configuration.ignore_directive)
+  }
+
+  /// Whether the html is the comment that turns off formatting until the
+  /// matching end comment.
+  pub fn is_ignore_start_comment(&self, html_text: &str) -> bool {
+    is_ignore_comment(html_text, &self.configuration.ignore_start_directive)
+  }
+
+  /// Whether the html is the comment that turns formatting back on.
+  pub fn is_ignore_end_comment(&self, html_text: &str) -> bool {
+    is_ignore_comment(html_text, &self.configuration.ignore_end_directive)
   }
 
   pub fn is_preserving_decorations(&self) -> bool {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -324,7 +324,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
     // check for ignore comment
     if let Node::Html(html) = node {
       let html_text = html.span.text(context.file_text);
-      if context.ignore_regex.is_match(html_text) {
+      if context.is_ignore_comment(html_text) {
         items.push_signal(Signal::NewLine);
         if let Some(node) = node_iterator.next() {
           if context.has_leading_blankline(node.span().start) {
@@ -340,7 +340,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
 
           last_node = Some(node);
         }
-      } else if context.ignore_start_regex.is_match(html_text) {
+      } else if context.is_ignore_start_comment(html_text) {
         let mut end_comment = None;
         let start = html.span().end;
         for node in node_iterator.by_ref() {
@@ -348,7 +348,7 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
 
           if let Node::Html(html) = node {
             let html_text = html.span.text(context.file_text);
-            if context.ignore_end_regex.is_match(html_text) {
+            if context.is_ignore_end_comment(html_text) {
               end_comment = Some(html);
               break;
             }
@@ -443,7 +443,14 @@ fn gen_heading(heading: &Heading, context: &mut Context) -> PrintItems {
 
 fn gen_atx_heading(level: u8, children: PrintItems) -> PrintItems {
   let mut items = PrintItems::new();
-  items.push_string("#".repeat(level as usize));
+  items.push_sc(match level {
+    1 => sc!("#"),
+    2 => sc!("##"),
+    3 => sc!("###"),
+    4 => sc!("####"),
+    5 => sc!("#####"),
+    _ => sc!("######"),
+  });
   // an empty heading is just the number signs, so don't leave a trailing space
   items.push_signal(Signal::SpaceIfNotTrailing);
   items.extend(with_no_new_lines(children));
@@ -472,7 +479,7 @@ fn gen_paragraph(paragraph: &Paragraph, context: &mut Context) -> PrintItems {
   /// the start of a line isn't read as the start of a block.
   fn paragraph_escapes(paragraph: &Paragraph) -> ParagraphEscapes {
     let mut block_starts = Vec::new();
-    let mut line_starts = Vec::new();
+    let mut line_starts = LineStarts::default();
     // the first line of a paragraph has nothing above it to be read together
     // with, so less of what it holds is markup than on the lines after it
     let mut escape: fn(&str) -> Option<usize> = block_start_escape;
@@ -705,7 +712,7 @@ fn gen_code_block(code_block: &CodeBlock, position: NodePosition, context: &mut 
       }
       // the info string may hold a tab, which the printer measures itself
       if tag.contains('\t') {
-        items.extend(gen_text_with_tabs(tag.to_string()));
+        items.extend(gen_text_with_tabs(tag));
       } else {
         items.push_str(tag);
       }
@@ -802,7 +809,7 @@ fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   // a code span holds its text as it is, so the only choice here is how to
   // write the delimiters so that the text is read back out of them
   let text = code.code.as_ref();
-  let backtick_text = "`".repeat(get_backtick_count(text));
+  let backticks = get_backtick_count(text);
   // a reader takes one space off each end of a span that has one at both, and
   // a backtick written against the delimiter would make the delimiter longer.
   // A space on each end handles either: the reader takes it straight back off
@@ -818,9 +825,9 @@ fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   // only the text is run through the text builder so that the backticks
   // always stay attached to it when the text is wrapped
   let mut items = PrintItems::new();
-  items.push_string(format!("{}{}", backtick_text, separator));
+  push_code_delimiter(&mut items, backticks, separator, true);
   items.extend(gen_code_str(text, context));
-  items.push_string(format!("{}{}", separator, backtick_text));
+  push_code_delimiter(&mut items, backticks, separator, false);
   return items;
 
   /// A code span ends at the first run of backticks with the same length as
@@ -889,9 +896,10 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
     /// The span's text, which the word being written is read together with the
     /// rest of in order to work out what a line would begin with.
     text: &'a str,
-    /// The word being gathered, and where in `text` it begins.
-    word: String,
-    word_start: usize,
+    /// Where the word being gathered runs from and to. It is a slice of
+    /// `text`, apart from the line endings within it that are written as the
+    /// spaces they render as.
+    word: Option<(usize, usize)>,
     /// Whether the whitespace that ran up to the word being gathered was a line
     /// ending that the configuration keeps where it was written.
     after_maintained_newline: bool,
@@ -903,8 +911,7 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
       CodeTextBuilder {
         items: PrintItems::new(),
         text,
-        word: String::new(),
-        word_start: 0,
+        word: None,
         after_maintained_newline: false,
         context,
       }
@@ -916,15 +923,15 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
     }
 
     pub fn add_char(&mut self, index: usize, character: char) {
-      self.start_word_at(index);
-      self.word.push(character);
+      self.extend_word(index, character.len_utf8());
     }
 
     /// Adds whitespace the span can't be broken at, keeping its width because a
     /// line ending renders as a space.
     pub fn add_spaces(&mut self, index: usize, count: usize) {
-      self.start_word_at(index);
-      self.word.push_str(&" ".repeat(count));
+      // a space and a line ending are one byte each, so the run is as many
+      // bytes long as it has characters
+      self.extend_word(index, count);
     }
 
     /// Ends the word at whitespace the span can be broken at, which
@@ -937,37 +944,74 @@ fn gen_code_str(text: &str, context: &mut Context) -> PrintItems {
     /// Whether nothing has been written yet, where the whitespace that follows
     /// is text the span opens with rather than somewhere it can be broken.
     pub fn is_leading(&self) -> bool {
-      self.word.is_empty() && self.items.is_empty()
+      self.word.is_none() && self.items.is_empty()
     }
 
-    fn start_word_at(&mut self, index: usize) {
-      if self.word.is_empty() {
-        self.word_start = index;
+    fn extend_word(&mut self, index: usize, len: usize) {
+      match self.word.as_mut() {
+        Some((_, end)) => *end = index + len,
+        None => self.word = Some((index, index + len)),
       }
     }
 
     fn flush_word(&mut self) {
-      if self.word.is_empty() {
+      let Some((start, end)) = self.word.take() else {
         return;
-      }
+      };
+      let word = word_text(self.text, start, end);
       if !self.items.is_empty() {
-        self.items.extend(self.space_items());
+        self.items.extend(self.space_items(start, &word));
       }
-      self.items.push_string(std::mem::take(&mut self.word));
+      self.items.push_str(&word);
     }
 
     /// What to write in place of the whitespace that ran up to the word.
-    fn space_items(&self) -> PrintItems {
+    fn space_items(&self, word_start: usize, word: &str) -> PrintItems {
       // the words the span goes on with count as well as this one, since a
       // block can be written as several of them (ex. a table's delimiter row)
-      let following_text = &self.text[self.word_start..];
-      if utils::wrapping_word_starts_block(&self.word, following_text, text_can_be_wrapped_away(self.context)) {
+      let following_text = &self.text[word_start..];
+      if utils::wrapping_word_starts_block(word, following_text, text_can_be_wrapped_away(self.context)) {
         return space();
       }
       if self.after_maintained_newline {
         return Signal::NewLine.into();
       }
       get_space_or_newline_based_on_config(self.context, false)
+    }
+  }
+}
+
+/// The text of a code span's word, which is written as it stands apart from
+/// the line endings within it, each of which renders as the space it becomes.
+fn word_text<'a>(text: &'a str, start: usize, end: usize) -> Cow<'a, str> {
+  let word = &text[start..end];
+  match word.contains('\n') {
+    true => Cow::Owned(word.replace('\n', " ")),
+    false => Cow::Borrowed(word),
+  }
+}
+
+/// Writes the backticks a code span is delimited by, along with the space that
+/// holds them off its text where one is needed.
+fn push_code_delimiter(items: &mut PrintItems, backticks: usize, separator: &str, leading: bool) {
+  // almost every span is written with a single backtick and nothing between it
+  // and the text, which is worth not building a string for
+  let known = match (backticks, separator, leading) {
+    (1, "", _) => Some(sc!("`")),
+    (2, "", _) => Some(sc!("``")),
+    (3, "", _) => Some(sc!("```")),
+    (1, " ", true) => Some(sc!("` ")),
+    (1, " ", false) => Some(sc!(" `")),
+    _ => None,
+  };
+  match known {
+    Some(text) => items.push_sc(text),
+    None => {
+      let backticks = "`".repeat(backticks);
+      items.push_string(match leading {
+        true => format!("{}{}", backticks, separator),
+        false => format!("{}{}", separator, backticks),
+      });
     }
   }
 }
@@ -1042,7 +1086,8 @@ fn gen_str(text: &str, text_start: Option<usize>, context: &mut Context) -> Prin
     /// The last character written, which decides how the space that follows it
     /// reads.
     last_char: Option<char>,
-    current_word: Option<(usize, String)>,
+    /// Where the word being read runs from and to.
+    current_word: Option<(usize, usize)>,
     context: &'a Context<'a>,
   }
 
@@ -1073,23 +1118,22 @@ fn gen_str(text: &str, text_start: Option<usize>, context: &mut Context) -> Prin
         return;
       }
 
-      if let Some((_, current_word)) = self.current_word.as_mut() {
-        current_word.push(character);
-      } else {
-        let mut word = String::new();
-        word.push(character);
-        self.current_word = Some((index, word));
+      let end = index + character.len_utf8();
+      match self.current_word.as_mut() {
+        Some((_, word_end)) => *word_end = end,
+        None => self.current_word = Some((index, end)),
       }
     }
 
     fn flush_current_word(&mut self) {
-      if let Some((start, current_word)) = self.current_word.take() {
+      if let Some((start, end)) = self.current_word.take() {
+        let current_word = &self.text[start..end];
         if !self.items.is_empty() {
-          self.items.extend(self.space_items(start, &current_word));
+          self.items.extend(self.space_items(start, current_word));
         }
 
         self.last_word_start = start;
-        self.last_char = current_word.chars().last();
+        self.last_char = current_word.chars().next_back();
         self
           .items
           .extend(gen_word_with_unspaced_script_breaks(current_word, self.context));
@@ -1591,7 +1635,7 @@ fn gen_link_destination_text(text: Cow<'_, str>) -> PrintItems {
   } else {
     text
   };
-  gen_text_with_tabs(text.into_owned())
+  gen_text_with_tabs(&text)
 }
 
 /// Generates an image's alt text, which is the raw text from the file.
@@ -1658,7 +1702,7 @@ fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
   // and skip the empty text a carriage return and line feed pair leaves behind
   let mut lines = text.split(['\r', '\n']).filter(|line| !line.is_empty());
   if let Some(line) = lines.next() {
-    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES)));
   }
   for line in lines {
     // a label, a title, and an image's alt text are not prose, so a sentence
@@ -1667,7 +1711,7 @@ fn gen_raw_text(text: &str, context: &Context) -> PrintItems {
     // the printer provides the indentation and block quote markers of a
     // continued line, so drop the ones this picked up from the file
     let line = strip_block_quote_markers(line, context);
-    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES)));
   }
   items
 }
@@ -1694,19 +1738,19 @@ fn strip_block_quote_markers<'a>(line: &'a str, context: &Context) -> &'a str {
 /// written, the same as in [`gen_word_with_unspaced_script_breaks`]: anywhere
 /// else the break would be read back as a space that wasn't written, and the
 /// text after it could begin a block of its own at the start of the line.
-fn gen_word_with_sentence_breaks(word: String) -> PrintItems {
+fn gen_word_with_sentence_breaks(word: &str) -> PrintItems {
   let mut items = PrintItems::new();
   let mut segment_start = 0;
   let mut last_char: Option<char> = None;
   for (index, character) in word.char_indices() {
     if matches!(last_char, Some(last) if breaks_between_sentences(last, character)) {
-      items.extend(gen_text_with_tabs(word[segment_start..index].to_string()));
+      items.extend(gen_text_with_tabs(&word[segment_start..index]));
       items.extend(new_line_or_nothing_if_newlines_disabled());
       segment_start = index;
     }
     last_char = Some(character);
   }
-  items.extend(gen_text_with_tabs(word[segment_start..].to_string()));
+  items.extend(gen_text_with_tabs(&word[segment_start..]));
   return items;
 
   /// Only the character beside the terminator decides this. What a longer look
@@ -1729,7 +1773,7 @@ fn gen_word_with_sentence_breaks(word: String) -> PrintItems {
 /// without this it would be written on one line however long it ran. Only a
 /// break with one of its characters on either side can be written: anywhere
 /// else the break would be read back as a space that wasn't written.
-fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> PrintItems {
+fn gen_word_with_unspaced_script_breaks(word: &str, context: &Context) -> PrintItems {
   if context.configuration.text_wrap == TextWrap::Sentence && !context.is_text_wrap_disabled() {
     return gen_word_with_sentence_breaks(word);
   }
@@ -1742,13 +1786,13 @@ fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> Prin
   let mut last_char: Option<char> = None;
   for (index, character) in word.char_indices() {
     if matches!(last_char, Some(last) if breaks_between(last, character)) {
-      items.extend(gen_text_with_tabs(word[segment_start..index].to_string()));
+      items.extend(gen_text_with_tabs(&word[segment_start..index]));
       items.push_signal(Signal::PossibleNewLine);
       segment_start = index;
     }
     last_char = Some(character);
   }
-  items.extend(gen_text_with_tabs(word[segment_start..].to_string()));
+  items.extend(gen_text_with_tabs(&word[segment_start..]));
 
   return items;
 
@@ -1765,10 +1809,10 @@ fn gen_word_with_unspaced_script_breaks(word: String, context: &Context) -> Prin
 
 /// Writes out text, sending any tab it has as a signal, since the printer
 /// can't be handed one as part of a string.
-fn gen_text_with_tabs(text: String) -> PrintItems {
+fn gen_text_with_tabs(text: &str) -> PrintItems {
   let mut items = PrintItems::new();
   if !text.contains('\t') {
-    items.push_string(text);
+    items.push_str(text);
     return items;
   }
 
@@ -1961,6 +2005,37 @@ fn gen_shortcut_image(image: &ShortcutImage, context: &mut Context) -> PrintItem
   })
 }
 
+/// Somewhere to write a list item's marker that costs nothing to have.
+///
+/// The printer copies what it is given into its own memory, so a marker only
+/// has to be spelled out somewhere long enough to hand over -- and every marker
+/// is short enough to spell out on the stack.
+#[derive(Default)]
+struct MarkerBuffer {
+  bytes: [u8; MarkerBuffer::LEN],
+}
+
+impl MarkerBuffer {
+  /// Room for the longest marker, which is a `u64` written out in full
+  /// followed by the character that ends it.
+  const LEN: usize = 24;
+
+  /// Writes a numbered marker (ex. `12.`).
+  fn write(&mut self, index: u64, end_char: &str) -> &str {
+    use std::io::Write;
+    let mut rest = &mut self.bytes[..];
+    // the buffer has room for the longest of these, so writing can't fail
+    let _ = write!(rest, "{}{}", index, end_char);
+    let written = MarkerBuffer::LEN - rest.len();
+    std::str::from_utf8(&self.bytes[..written]).unwrap()
+  }
+
+  /// Writes a bullet marker (ex. `-`).
+  fn write_char(&mut self, marker: char) -> &str {
+    marker.encode_utf8(&mut self.bytes)
+  }
+}
+
 fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItems {
   context.mark_in_list(|context| {
     let mut items = PrintItems::new();
@@ -1969,6 +2044,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
       if index > 0 {
         items.extend(get_blank_lines(context.get_leading_blank_lines(child.span().start)));
       }
+      let mut buffer = MarkerBuffer::default();
       let prefix_text = if let Some(start_index) = list.start_index {
         let end_char = if is_alternate { ")" } else { "." };
         let display_index = if is_all_ones_list(list, context) {
@@ -1976,9 +2052,9 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         } else {
           start_index + index as u64
         };
-        format!("{}{}", display_index, end_char)
+        buffer.write(display_index, end_char)
       } else {
-        String::from(context.configuration.list_unordered_marker.list_char(is_alternate))
+        buffer.write_char(context.configuration.list_unordered_marker.list_char(is_alternate))
       };
       let marker_width = prefix_text.chars().count() as u32 + 1;
       let indent_increment = match context.configuration.list_indent_kind {
@@ -1991,7 +2067,7 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         lines_up: indent_increment == marker_width,
       };
       context.indent_level += indent_increment;
-      items.push_string(prefix_text);
+      items.push_str(prefix_text);
       // the space is dropped where nothing follows it on the line, so an item
       // with nothing in it is written as the marker alone. Whether anything
       // does follow is the item's to say, not something to measure: content of
@@ -2452,12 +2528,12 @@ fn gen_table_rows_as_written(table: &Table, context: &Context) -> PrintItems {
     .split(['\r', '\n'])
     .filter(|line| !line.is_empty());
   if let Some(line) = lines.next() {
-    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES)));
   }
   for line in lines {
     items.push_signal(Signal::NewLine);
     let line = strip_block_quote_markers(line, context);
-    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES).to_string()));
+    items.extend(gen_text_with_tabs(line.trim_end_matches(SPACES)));
   }
   items
 }

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -1,8 +1,6 @@
 use crate::parser::SPACES;
 use std::borrow::Cow;
 
-use regex::Regex;
-
 /// How many lines the text has beyond its first.
 ///
 /// A line ends at a newline, at a carriage return written on its own, and at a
@@ -374,15 +372,16 @@ pub fn get_leading_blank_lines(index: usize, text: &str, in_block_quote: bool, m
   newline_count.saturating_sub(1)
 }
 
-pub fn file_has_ignore_file_directive(file_text: &str, directive_inner_text: &str) -> bool {
-  let ignore_regex = get_ignore_comment_regex(directive_inner_text);
-  ignore_regex.is_match(file_text)
-}
-
-pub fn get_ignore_comment_regex(inner_text: &str) -> Regex {
-  // todo: don't use regex
-  let text = format!(r"^\s*<!\-\-\s*{}\s*\-\->\s*", inner_text);
-  Regex::new(&text).unwrap()
+/// Whether the text begins with a `<!-- directive -->` comment, whatever
+/// whitespace it is written with.
+pub fn is_ignore_comment(text: &str, directive: &str) -> bool {
+  let Some(rest) = text.trim_start().strip_prefix("<!--") else {
+    return false;
+  };
+  let Some(rest) = rest.trim_start().strip_prefix(directive) else {
+    return false;
+  };
+  rest.trim_start().starts_with("-->")
 }
 
 pub fn get_leading_non_space_tab_byte_pos(text: &str, pos: usize) -> usize {
@@ -397,40 +396,30 @@ pub fn get_leading_non_space_tab_byte_pos(text: &str, pos: usize) -> usize {
   0
 }
 
+/// Removes the indentation every line of the text shares.
 pub fn unindent(text: &str) -> Cow<'_, str> {
-  let lines = text.split('\n').collect::<Vec<_>>();
-  let mut lines_with_indent = Vec::with_capacity(lines.len());
-  for line in lines.into_iter() {
-    // a character that only looks like a space, such as a non-breaking one, is
-    // text of the code rather than the indentation written before it
-    let line_indent = line.chars().take_while(|c| SPACES.contains(c)).count();
-    if line_indent == 0 {
-      return Cow::Borrowed(text);
+  // a character that only looks like a space, such as a non-breaking one, is
+  // text of the code rather than the indentation written before it
+  let indent_of = |line: &str| line.chars().take_while(|c| SPACES.contains(c)).count();
+  // a line that begins at the margin leaves nothing to take off any of them,
+  // which is worth finding out before writing any of it out
+  if text.split('\n').any(|line| indent_of(line) == 0) {
+    return Cow::Borrowed(text);
+  }
+
+  let min_indent = text.split('\n').map(indent_of).min().unwrap_or(0);
+  let mut result = String::with_capacity(text.len());
+  for (index, line) in text.split('\n').enumerate() {
+    if index > 0 {
+      result.push('\n');
     }
-    lines_with_indent.push((line, line_indent));
+    let mut characters = line.chars();
+    for _ in 0..min_indent {
+      characters.next();
+    }
+    result.push_str(characters.as_str());
   }
-  let min_indent = lines_with_indent.iter().map(|(_, indent)| indent).min().copied();
-  if let Some(min_indent) = min_indent {
-    Cow::Owned(
-      lines_with_indent
-        .into_iter()
-        .map(|(l, indent)| {
-          if indent >= min_indent {
-            let mut chars = l.chars();
-            for _ in 0..min_indent {
-              chars.next();
-            }
-            chars.as_str()
-          } else {
-            l
-          }
-        })
-        .collect::<Vec<_>>()
-        .join("\n"),
-    )
-  } else {
-    Cow::Borrowed(text)
-  }
+  Cow::Owned(result)
 }
 
 #[cfg(test)]

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -149,11 +149,18 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       content_end = end;
     }
 
-    let content: Vec<ContentLine<'a>> = lines[index + 1..content_end]
-      .iter()
-      .map(|line| line.strip_columns(indent))
-      .collect();
-    let code = join_lines(&content, self.source, !content.is_empty());
+    let stripped: Vec<ContentLine<'a>>;
+    let content: &[ContentLine<'a>] = if indent == 0 {
+      // the fence sits at the margin, so its lines carry nothing to strip
+      &lines[index + 1..content_end]
+    } else {
+      stripped = lines[index + 1..content_end]
+        .iter()
+        .map(|line| line.strip_columns(indent))
+        .collect();
+      &stripped
+    };
+    let code = join_lines(content, self.source, !content.is_empty());
 
     nodes.push(
       CodeBlock {
@@ -238,7 +245,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
   // ==== container blocks ====
 
   fn parse_block_quote(&self, lines: &[ContentLine<'a>], index: usize, nodes: &mut Vec<Node<'a>>) -> usize {
-    let mut content = Vec::new();
+    let mut content = Vec::with_capacity(gathered_line_capacity(lines, index));
     let mut end = index;
     let mut paragraph = OpenParagraph::default();
 
@@ -276,7 +283,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
 
   fn parse_list(&self, lines: &[ContentLine<'a>], index: usize, nodes: &mut Vec<Node<'a>>) -> usize {
     let first = list_marker(lines[index].rest()).unwrap();
-    let mut items = Vec::new();
+    let mut items: Vec<Node<'a>> = Vec::new();
     let mut end = index;
 
     while end < lines.len() {
@@ -299,18 +306,18 @@ impl<'a, 'c> BlockParser<'a, 'c> {
         break;
       }
       let (item, next) = self.parse_item(lines, end, &marker);
-      items.push(item);
+      items.push(item.into());
       end = next;
     }
 
     // any blank lines that followed the last item aren't part of the list
-    let last_line = items.last().map(|item| item.span.end).unwrap_or(lines[index].end());
+    let last_line = items.last().map(|item| item.span().end).unwrap_or(lines[index].end());
     nodes.push(
       List {
         span: Span::new(lines[index].rest_start(), last_line),
         start_index: first.is_ordered.then_some(first.start_index),
         marker_char: first.char,
-        children: items.into_iter().map(Into::into).collect(),
+        children: items,
       }
       .into(),
     );
@@ -334,7 +341,8 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     // its lines have already had stripped off them
     let content_indent = lines[index].indent_columns() + marker.len + spaces;
 
-    let mut content = vec![after_marker.strip_columns(spaces)];
+    let mut content = Vec::with_capacity(gathered_line_capacity(lines, index));
+    content.push(after_marker.strip_columns(spaces));
     // an item may begin with at most one blank line, so a second one before
     // any content ends it
     let begins_blank = content[0].is_blank();
@@ -405,7 +413,8 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     let name = footnote_definition_name(start_line.text).unwrap();
     let marker_len = name.len() + 4; // `[^` + name + `]:`
 
-    let mut content = vec![start_line.strip_bytes(marker_len).strip_columns(usize::MAX)];
+    let mut content = Vec::with_capacity(gathered_line_capacity(lines, index));
+    content.push(start_line.strip_bytes(marker_len).strip_columns(usize::MAX));
     let mut paragraph = OpenParagraph::default();
     paragraph.push(content[0]);
     let mut end = index + 1;
@@ -480,7 +489,9 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       after_definitions
     };
 
-    let mut content = vec![lines[index]];
+    // the lines of a paragraph are taken as they are, so the content is the
+    // run of them that it reaches rather than a gathered up copy
+    let content_start = index;
     let mut end = index + 1;
 
     while end < lines.len() {
@@ -494,12 +505,13 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       // the paragraph, never the start of one of these
       if line.indent_columns() < CODE_INDENT && !line.is_lazy {
         if let Some(level) = setext_heading_level(rest) {
+          let content = &lines[content_start..end];
           nodes.push(
             Heading {
               span: Span::new(content[0].rest_start(), line.trim_end().end()),
               level,
               style: HeadingStyle::Setext,
-              children: self.parse_inlines(&content),
+              children: self.parse_inlines(content),
             }
             .into(),
           );
@@ -507,21 +519,21 @@ impl<'a, 'c> BlockParser<'a, 'c> {
         }
         // a delimiter row turns the line above it into a table's header,
         // leaving the rest of the paragraph above the table
-        if let Some(alignment) = table_delimiter_row(rest, content.last().unwrap().rest()) {
-          self.push_paragraph(&content[..content.len() - 1], nodes);
+        if let Some(alignment) = table_delimiter_row(rest, lines[end - 1].rest()) {
+          self.push_paragraph(&lines[content_start..end - 1], nodes);
           return self.parse_table(lines, end, alignment, nodes);
         }
         if is_definition_marker(rest) {
-          return self.parse_definition_list(lines, end, content, nodes);
+          return self.parse_definition_list(lines, end, &lines[content_start..end], nodes);
         }
       }
       if !line.is_lazy && line.indent_columns() < CODE_INDENT && self.interrupts_paragraph(lines, end) {
         break;
       }
 
-      content.push(line);
       end += 1;
     }
+    let content = &lines[content_start..end];
 
     // a blank line may separate the terms of a definition list from their
     // definitions
@@ -533,7 +545,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       return self.parse_definition_list(lines, after_blanks, content, nodes);
     }
 
-    self.push_paragraph(&content, nodes);
+    self.push_paragraph(content, nodes);
     end
   }
 
@@ -562,6 +574,12 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     index: usize,
     nodes: &mut Vec<Node<'a>>,
   ) -> usize {
+    // a definition opens with its label, so a block that starts with anything
+    // else holds none and doesn't have to be gathered up to be looked through
+    if !lines[index].starts_with("[") {
+      return index;
+    }
+
     let mut block_end = index + 1;
     while block_end < lines.len()
       && !lines[block_end].is_blank()
@@ -605,7 +623,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       cells: self.parse_table_cells(header_line),
     };
 
-    let mut rows = Vec::new();
+    let mut rows = Vec::with_capacity(lines.len() - delimiter_index - 1);
     let mut end = delimiter_index + 1;
     while end < lines.len() {
       let line = lines[end];
@@ -666,7 +684,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     &self,
     lines: &[ContentLine<'a>],
     marker_index: usize,
-    titles: Vec<ContentLine<'a>>,
+    titles: &[ContentLine<'a>],
     nodes: &mut Vec<Node<'a>>,
   ) -> usize {
     // the list begins where its first term does, which has to be read before
@@ -677,7 +695,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     let mut titles = titles;
 
     loop {
-      for title in &titles {
+      for title in titles {
         let title = title.trimmed().trim_end();
         children.push(
           DefinitionListTitle {
@@ -702,7 +720,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       let Some(group_end) = self.definition_group_end(lines, next) else {
         break;
       };
-      titles = lines[next..group_end].to_vec();
+      titles = &lines[next..group_end];
       end = group_end;
     }
 
@@ -727,7 +745,8 @@ impl<'a, 'c> BlockParser<'a, 'c> {
     };
     let content_indent = lines[index].indent_columns() + 1 + spaces;
 
-    let mut content = vec![after_marker.strip_columns(spaces)];
+    let mut content = Vec::with_capacity(gathered_line_capacity(lines, index));
+    content.push(after_marker.strip_columns(spaces));
     let mut paragraph = OpenParagraph::default();
     paragraph.push(content[0]);
     let mut end = index + 1;
@@ -1486,6 +1505,14 @@ fn table_delimiter_row(text: &str, header: &str) -> Option<Vec<ColumnAlignment>>
 }
 
 // ==== small helpers ====
+
+/// How much room to make for the lines a container is about to gather up.
+///
+/// Most of them run to only a few lines, so this is what it takes to hold one
+/// of those without growing rather than a guess at how long this one runs.
+fn gathered_line_capacity(lines: &[ContentLine<'_>], index: usize) -> usize {
+  (lines.len() - index).min(8)
+}
 
 fn skip_blank_lines(lines: &[ContentLine<'_>], index: usize) -> usize {
   let mut index = index;

--- a/src/parser/inline.rs
+++ b/src/parser/inline.rs
@@ -25,6 +25,34 @@ pub struct InlineContext<'a> {
   /// Whether this is the pass that only looks for definitions, in which case
   /// there's no point in doing the work of parsing inlines.
   pub collect_only: bool,
+  /// The buffers the blocks of the document are parsed in, kept here so that
+  /// each of them doesn't have to ask for its own.
+  scratch: std::cell::RefCell<InlineScratch<'a>>,
+}
+
+impl<'a> InlineContext<'a> {
+  pub fn new(
+    source: &'a str,
+    link_labels: HashSet<String>,
+    footnote_labels: HashSet<String>,
+    collect_only: bool,
+  ) -> InlineContext<'a> {
+    InlineContext {
+      source,
+      link_labels,
+      footnote_labels,
+      collect_only,
+      scratch: Default::default(),
+    }
+  }
+}
+
+/// The working memory of a single block's inline parse, which holds nothing
+/// between blocks and is cleared before each of them.
+#[derive(Default)]
+struct InlineScratch<'a> {
+  nodes: Vec<Option<Node<'a>>>,
+  delimiters: Vec<Delimiter>,
 }
 
 pub fn parse_inlines<'a>(lines: &[ContentLine<'a>], context: &InlineContext<'a>) -> Vec<Node<'a>> {
@@ -32,13 +60,22 @@ pub fn parse_inlines<'a>(lines: &[ContentLine<'a>], context: &InlineContext<'a>)
     return Vec::new();
   }
   let text = InlineText::new(lines, context.source);
+  // inline parsing never begins again while it's underway, so the buffers on
+  // the context are always free; taking fresh ones rather than unwrapping
+  // keeps that an implementation detail rather than something to uphold
+  let mut borrowed = context.scratch.try_borrow_mut().ok();
+  let mut fallback = InlineScratch::default();
+  let scratch = borrowed.as_deref_mut().unwrap_or(&mut fallback);
+  scratch.nodes.clear();
+  scratch.delimiters.clear();
+
   let mut parser = InlineParser {
     text: &text,
     context,
     pos: 0,
     pending_text_start: 0,
-    nodes: Vec::new(),
-    delimiters: Vec::new(),
+    nodes: &mut scratch.nodes,
+    delimiters: &mut scratch.delimiters,
   };
   parser.parse();
   parser.finish()
@@ -70,8 +107,15 @@ impl<'a> InlineText<'a> {
       };
     }
 
-    let mut text = String::new();
-    let mut offsets: Vec<u32> = Vec::new();
+    // the content is as long as the lines it is built from, plus the line
+    // ending written between each pair of them
+    let len = lines
+      .iter()
+      .map(|line| line.virtual_spaces + line.text.len())
+      .sum::<usize>()
+      + lines.len().saturating_sub(1);
+    let mut text = String::with_capacity(len);
+    let mut offsets: Vec<u32> = Vec::with_capacity(len + 1);
     for (index, line) in lines.iter().enumerate() {
       if index > 0 {
         text.push('\n');
@@ -201,8 +245,8 @@ struct InlineParser<'a, 'b> {
   pending_text_start: usize,
   /// The nodes parsed so far. Emphasis leaves holes behind when it wraps the
   /// nodes it spans, so a slot may be empty.
-  nodes: Vec<Option<Node<'a>>>,
-  delimiters: Vec<Delimiter>,
+  nodes: &'b mut Vec<Option<Node<'a>>>,
+  delimiters: &'b mut Vec<Delimiter>,
 }
 
 /// An unmatched `*`, `_`, `~`, `[` or `![` that a later character may pair
@@ -254,7 +298,8 @@ impl<'a, 'b> InlineParser<'a, 'b> {
     self.flush_text(self.text.len());
     self.process_emphasis(0);
     let source = self.text.source();
-    merge_adjacent_text(self.nodes.into_iter().flatten().collect(), source)
+    let nodes = compact(self.nodes);
+    merge_adjacent_text(nodes, source)
   }
 
   // ---- text ----
@@ -553,7 +598,8 @@ impl<'a, 'b> InlineParser<'a, 'b> {
     } else {
       // the text within the brackets is the link's content
       self.process_emphasis(opener_index + 1);
-      let children: Vec<Node<'a>> = self.nodes.drain(node_index + 1..).flatten().collect();
+      let mut children: Vec<Node<'a>> = Vec::with_capacity(self.nodes.len() - node_index - 1);
+      children.extend(self.nodes.drain(node_index + 1..).flatten());
       let children = merge_adjacent_text(children, self.text.source());
       self.nodes[node_index] = None;
       match reference.kind {
@@ -766,10 +812,9 @@ impl<'a, 'b> InlineParser<'a, 'b> {
       self.text.abs(content_start - use_len),
       self.text.abs(content_end + use_len),
     );
-    let children: Vec<Node<'a>> = self.nodes[open_node + 1..close_node]
-      .iter_mut()
-      .filter_map(|slot| slot.take())
-      .collect();
+    let slots = &mut self.nodes[open_node + 1..close_node];
+    let mut children: Vec<Node<'a>> = Vec::with_capacity(slots.len());
+    children.extend(slots.iter_mut().filter_map(|slot| slot.take()));
     let children = merge_adjacent_text(children, self.text.source());
     let decoration: Node<'a> = TextDecoration { span, kind, children }.into();
 
@@ -827,6 +872,14 @@ impl<'a, 'b> InlineParser<'a, 'b> {
   fn run_length(&self, start: usize, byte: u8) -> usize {
     self.text.bytes()[start..].iter().take_while(|b| **b == byte).count()
   }
+}
+
+/// Drops the holes emphasis left behind, keeping the nodes in order and
+/// leaving the buffer they were read into empty for the next block.
+fn compact<'a>(nodes: &mut Vec<Option<Node<'a>>>) -> Vec<Node<'a>> {
+  let mut result = Vec::with_capacity(nodes.len());
+  result.extend(nodes.drain(..).flatten());
+  result
 }
 
 /// Joins the text nodes that ended up beside each other, which happens when a

--- a/src/parser/links.rs
+++ b/src/parser/links.rs
@@ -62,12 +62,12 @@ pub fn match_reference<'a>(
       if label.trim_matches(WHITESPACE).is_empty() {
         // ex. `[name][]`
         let name = text.slice(content_start, close_start);
-        return labels.contains(&normalize_label(&name)).then_some(Reference {
+        return labels.contains(normalize_label(&name).as_ref()).then_some(Reference {
           kind: ReferenceKind::Collapsed,
           end,
         });
       }
-      return labels.contains(&normalize_label(&label)).then_some(Reference {
+      return labels.contains(normalize_label(&label).as_ref()).then_some(Reference {
         kind: ReferenceKind::Full { label },
         end,
       });
@@ -76,7 +76,7 @@ pub fn match_reference<'a>(
 
   // ex. `[name]`
   let name = text.slice(content_start, close_start);
-  labels.contains(&normalize_label(&name)).then_some(Reference {
+  labels.contains(normalize_label(&name).as_ref()).then_some(Reference {
     kind: ReferenceKind::Shortcut,
     end: after_close,
   })
@@ -93,7 +93,7 @@ pub fn match_footnote_reference<'a>(
   }
   let (end, _) = match_label(text, start)?;
   let name = text.source_slice(start + 2, end - 1)?;
-  if name.is_empty() || !labels.contains(&normalize_label(name)) {
+  if name.is_empty() || !labels.contains(normalize_label(name).as_ref()) {
     return None;
   }
   Some((end, name))
@@ -256,7 +256,29 @@ pub fn match_link_reference_definition<'a>(text: &InlineText<'a>, start: usize) 
 
 /// Normalizes a link label the way the CommonMark spec matches them: case
 /// insensitively and with runs of whitespace collapsed.
-pub fn normalize_label(label: &str) -> String {
+///
+/// Most labels are written the way they are matched, and those are borrowed.
+pub fn normalize_label(label: &str) -> Cow<'_, str> {
+  let trimmed = label.trim_matches(WHITESPACE);
+  if is_normalized(trimmed) {
+    return Cow::Borrowed(trimmed);
+  }
+  Cow::Owned(build_normalized_label(label))
+}
+
+/// Whether the label already reads the way a normalized one does, which needs
+/// it to hold nothing written in uppercase and no run of whitespace.
+fn is_normalized(label: &str) -> bool {
+  // a character outside ascii may have a lowercase form of a different length,
+  // so only an ascii label can be known to be normalized without building one
+  label.is_ascii()
+    && !label.as_bytes().windows(2).any(|pair| pair == b"  ")
+    && !label
+      .bytes()
+      .any(|b| b.is_ascii_uppercase() || matches!(b, b'\t' | b'\n' | b'\r'))
+}
+
+fn build_normalized_label(label: &str) -> String {
   let mut result = String::with_capacity(label.len());
   let mut had_whitespace = false;
   for c in label.trim_matches(WHITESPACE).chars() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -60,12 +60,7 @@ pub fn parse(source: &str) -> Result<SourceFile<'_>, ParseError> {
   let (metadata, body_start) = parse_metadata_block(source, &lines);
 
   let (link_labels, footnote_labels) = collect_labels(source, &lines[body_start..]);
-  let context = InlineContext {
-    source,
-    link_labels,
-    footnote_labels,
-    collect_only: false,
-  };
+  let context = InlineContext::new(source, link_labels, footnote_labels, false);
   let parser = BlockParser {
     source,
     context: &context,
@@ -144,12 +139,7 @@ fn collect_labels(source: &str, lines: &[ContentLine<'_>]) -> (HashSet<String>, 
     return (link_labels, footnote_labels);
   }
 
-  let context = InlineContext {
-    source,
-    link_labels: HashSet::new(),
-    footnote_labels: HashSet::new(),
-    collect_only: true,
-  };
+  let context = InlineContext::new(source, HashSet::new(), HashSet::new(), true);
   let parser = BlockParser {
     source,
     context: &context,
@@ -164,10 +154,10 @@ fn collect_node_labels(nodes: &[Node<'_>], link_labels: &mut HashSet<String>, fo
   for node in nodes {
     match node {
       Node::LinkReference(reference) => {
-        link_labels.insert(links::normalize_label(&reference.name));
+        link_labels.insert(links::normalize_label(&reference.name).into_owned());
       }
       Node::FootnoteDefinition(definition) => {
-        footnote_labels.insert(links::normalize_label(definition.name));
+        footnote_labels.insert(links::normalize_label(definition.name).into_owned());
       }
       _ => {}
     }


### PR DESCRIPTION
Formatting a corpus of 3570 real world markdown files (20MB, every `.md` in a populated cargo registry) drops from **0.963s to 0.327s**, and from **10.9 million allocations to 1.0 million**.

| | before | after | |
|---|---|---|---|
| time | 0.963s | **0.327s** | **2.9x** |
| throughput | 20.8 MB/s | **61.3 MB/s** | |
| allocations | 10,896,524 | **1,023,535** | **10.6x fewer** |
| memory asked for | 6117 MB | **524 MB** | **11.7x less** |

What the formatter writes is unchanged: every one of the 3570 files comes out byte for byte what it was before this branch. The spec suite, clippy, rustfmt and the wasm target all pass.

## Compiling a regex per file was over half the time

Four regexes were built for **every file formatted** -- three in `Context::new` and one for the ignore file check -- only ever to ask whether some text is `<!-- dprint-ignore -->`. A few `strip_prefix` calls answer that. There was already a `// todo: don't use regex` sitting on it.

That leaves nothing in the crate using `regex`, so the dependency goes with it. It's no longer in the shipped or wasm dependency tree at all (it remains only as something the test harness pulls in, through `dprint-development`).

One behaviour note worth a look: the directives are now matched **literally** rather than as regex source. The defaults are unaffected and literal matching is what the config documents, but a directive configured with regex metacharacters would have behaved differently before.

## The rest is memory that wasn't needed

- **Words were built one character at a time into a `String` per word**, for prose and for code spans both, then handed to `push_string` -- which copies into the printer's bump allocator and drops what it was given. `push_str` copies straight in, and dprint-core's own docs point at this. A word is a slice of the text it was read from, so both builders track `(start, end)` now. Generation allocations fell 995k -> 117k.
- **A paragraph copied the lines it was handed into a vector.** They're always the contiguous run of lines it reaches, so it borrows them.
- **Inline parsing asked for a fresh node and delimiter buffer for every block.** They're kept on the context and cleared per block.
- `InlineText` grew its content and offset buffers from nothing when it had the length to hand; a list gathered `Vec<Item>` only to re-collect it into `Vec<Node>`; `unindent` gathered the lines up three times over even on the path where it borrows and returns.
- The delimiters of a code span, the hashes of a heading and the marker of a list item went through `format!` or `repeat`. Almost all of them are one of a handful of known strings, and a list marker is written into a buffer on the stack.
- `normalize_label` built a copy of every label it was asked about. Most labels are written the way they're matched, so it returns a `Cow`.

Also, a link reference definition can only open with its label, so a block starting with anything else is no longer gathered up and searched.

## What was left alone

The label collection pre-pass still block-parses the document a second time when the source contains `]:` (~9% of what remains). Skipping it wants a line based scan, which would read a `[foo]: bar` inside a fenced code block as a real definition -- so it stays.