### PR TITLE
feat: format the html written within a markdown file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ name = "parser_specs"
 path = "tests/parser_spec_test.rs"
 harness = false
 
+[[test]]
+name = "html_parser_specs"
+path = "tests/html_parser_spec_test.rs"
+harness = false
+
 [dependencies]
 dprint-core = { version = "0.69.1", features = ["formatting"] }
 dprint-core-macros = "0.1.0"

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -177,6 +177,47 @@
       "description": "The indentation width the plugin that formats the code within a code block should use, overriding that plugin's own `indentWidth` configuration. When not specified, that plugin's configuration is left alone.",
       "type": "number"
     },
+    "html.skipFormat": {
+      "description": "Whether to leave the html written within the file as it was rather than laying out its tags and their content. Html that the formatter can't take apart and put back together -- a block that a blank line has split from its closing tag, for one -- is left as it was written either way.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Leaves the html as it was written."
+      }, {
+        "const": false,
+        "description": "Lays out the tags of the html and their content."
+      }]
+    },
+    "html.useTabs": {
+      "description": "Whether to indent the html written within the file with tabs.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Indents the html with tabs."
+      }, {
+        "const": false,
+        "description": "Indents the html with spaces."
+      }]
+    },
+    "html.indentWidth": {
+      "description": "The number of spaces to indent the html written within the file with.",
+      "type": "number",
+      "default": 2
+    },
+    "html.selfClosingSpace": {
+      "description": "Whether to write a space before the `/>` that closes a self-closing tag, so that a tag is written as `<br />` rather than as `<br/>`.",
+      "type": "boolean",
+      "default": true,
+      "oneOf": [{
+        "const": true,
+        "description": "Writes a self-closing tag as `<br />`."
+      }, {
+        "const": false,
+        "description": "Writes a self-closing tag as `<br/>`."
+      }]
+    },
     "table.skipFormat": {
       "description": "Whether to leave a table's rows as they were written rather than aligning their cells into columns.",
       "type": "boolean",
@@ -279,6 +320,18 @@
     },
     "codeBlock.indentWidth": {
       "$ref": "#/definitions/codeBlock.indentWidth"
+    },
+    "html.skipFormat": {
+      "$ref": "#/definitions/html.skipFormat"
+    },
+    "html.useTabs": {
+      "$ref": "#/definitions/html.useTabs"
+    },
+    "html.indentWidth": {
+      "$ref": "#/definitions/html.indentWidth"
+    },
+    "html.selfClosingSpace": {
+      "$ref": "#/definitions/html.selfClosingSpace"
     },
     "table.skipFormat": {
       "$ref": "#/definitions/table.skipFormat"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -155,6 +155,32 @@ impl ConfigurationBuilder {
     self.insert("codeBlock.indentWidth", (value as i32).into())
   }
 
+  /// Whether to leave the html written within the file as it was rather than
+  /// laying out its tags and their content.
+  /// Default: `false`
+  pub fn html_skip_format(&mut self, value: bool) -> &mut Self {
+    self.insert("html.skipFormat", value.into())
+  }
+
+  /// Whether to indent the html written within the file with tabs.
+  /// Default: `false`
+  pub fn html_use_tabs(&mut self, value: bool) -> &mut Self {
+    self.insert("html.useTabs", value.into())
+  }
+
+  /// The number of spaces to indent the html written within the file with.
+  /// Default: `2`
+  pub fn html_indent_width(&mut self, value: u8) -> &mut Self {
+    self.insert("html.indentWidth", (value as i32).into())
+  }
+
+  /// Whether to write a space before the `/>` that closes a self-closing tag,
+  /// so that a tag is written as `<br />` rather than as `<br/>`.
+  /// Default: `true`
+  pub fn html_self_closing_space(&mut self, value: bool) -> &mut Self {
+    self.insert("html.selfClosingSpace", value.into())
+  }
+
   /// Whether to leave a table's rows as they were written rather than
   /// aligning their cells into columns.
   /// Default: `false`

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -88,6 +88,20 @@ pub fn resolve_config(
     code_block_preserve_blank_lines: get_value(&mut config, "codeBlock.preserveBlankLines", false, &mut diagnostics),
     code_block_use_tabs: get_nullable_value(&mut config, "codeBlock.useTabs", &mut diagnostics),
     code_block_indent_width: get_nullable_value(&mut config, "codeBlock.indentWidth", &mut diagnostics),
+    html_skip_format: get_value(&mut config, "html.skipFormat", false, &mut diagnostics),
+    html_use_tabs: get_value(
+      &mut config,
+      "html.useTabs",
+      global_config.use_tabs.unwrap_or(false),
+      &mut diagnostics,
+    ),
+    html_indent_width: get_value(
+      &mut config,
+      "html.indentWidth",
+      global_config.indent_width.unwrap_or(2),
+      &mut diagnostics,
+    ),
+    html_self_closing_space: get_value(&mut config, "html.selfClosingSpace", true, &mut diagnostics),
     table_skip_format: get_value(&mut config, "table.skipFormat", false, &mut diagnostics),
     table_cell_padding: get_value(
       &mut config,

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -50,6 +50,20 @@ pub struct Configuration {
   /// formats the code within a code block. `None` leaves it to that plugin.
   #[serde(rename = "codeBlock.indentWidth")]
   pub code_block_indent_width: Option<u8>,
+  /// Whether to leave the html written within the file as it was rather than
+  /// laying out its tags and their content.
+  #[serde(rename = "html.skipFormat")]
+  pub html_skip_format: bool,
+  /// Whether to indent the html written within the file with tabs.
+  #[serde(rename = "html.useTabs")]
+  pub html_use_tabs: bool,
+  /// The number of spaces to indent the html written within the file with.
+  #[serde(rename = "html.indentWidth")]
+  pub html_indent_width: u8,
+  /// Whether to write a space before the `/>` that closes a self-closing tag,
+  /// so that a tag is written as `<br />` rather than as `<br/>`.
+  #[serde(rename = "html.selfClosingSpace")]
+  pub html_self_closing_space: bool,
   /// Whether to leave a table's rows as they were written rather than
   /// aligning their cells into columns.
   #[serde(rename = "table.skipFormat")]

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -511,6 +511,22 @@ impl<'a> Context<'a> {
     is_ignore_comment(html_text, &self.configuration.ignore_end_directive)
   }
 
+  /// Whether the html holds a comment that turns formatting off.
+  ///
+  /// A block of html is written out as it was when it holds one, because the
+  /// text an ignore comment covers can be within the block rather than being
+  /// a node of the document the block sits in.
+  pub fn has_ignore_comment(&self, html_text: &str) -> bool {
+    [
+      &self.configuration.ignore_directive,
+      &self.configuration.ignore_start_directive,
+      &self.configuration.ignore_end_directive,
+      &self.configuration.ignore_file_directive,
+    ]
+    .iter()
+    .any(|directive| html_text.contains(directive.as_str()))
+  }
+
   pub fn is_preserving_decorations(&self) -> bool {
     self.decorations_preserved_count > 0
   }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1514,6 +1514,36 @@ fn written_last_char(node: Option<&Node>, parent_content: Option<Span>, context:
 }
 
 fn gen_html(node: &Html, ctx: &mut Context) -> PrintItems {
+  // only a block of html is laid out: an inline tag is one node of the text
+  // around it, where the printer is already deciding where the lines go.
+  // A block written with indentation of its own is left alone, because that
+  // indentation says where the author put the block within what holds it and
+  // laying the block out again would take it somewhere else.
+  let is_indented = node.text.starts_with(SPACES);
+  let is_ignored = ctx.has_ignore_comment(&node.text);
+  if node.is_block && !is_indented && !is_ignored && !ctx.configuration.html_skip_format {
+    let line_width = std::cmp::max(10, ctx.configuration.line_width as i32 - ctx.indent_level as i32) as u32;
+    let options = crate::html::HtmlFormatOptions {
+      line_width,
+      use_tabs: ctx.configuration.html_use_tabs,
+      indent_width: ctx.configuration.html_indent_width,
+      self_closing_space: ctx.configuration.html_self_closing_space,
+    };
+    // an html block is very often a fragment, because a blank line closes the
+    // block and leaves its closing tag to a block of its own -- whatever the
+    // formatter can't take apart and put back together is left as it was
+    if let Ok(text) = crate::html::format_html(&node.text, &options) {
+      // the line an html block starts on is what makes it one, and says where
+      // it ends -- writing that line out differently would leave the rest of
+      // the block to be read as markdown
+      if starts_same_html_block(first_line(&node.text), first_line(&text)) {
+        let mut items = PrintItems::new();
+        items.push_sc(sc!("")); // force first line indentation
+        items.extend(ir_helpers::gen_from_string(&text));
+        return items;
+      }
+    }
+  }
   gen_range(node.span, ctx)
 }
 
@@ -1538,6 +1568,15 @@ fn gen_range(span: Span, ctx: &mut Context) -> PrintItems {
     &strip_raw_block_quote_markers(text, ctx),
   )));
   items
+}
+
+/// The text up to its first line break, which for an html block is the line
+/// that decides whether it is one and where it ends.
+fn first_line(text: &str) -> &str {
+  match text.find('\n') {
+    Some(index) => &text[..index],
+    None => text,
+  }
 }
 
 /// Trims the whitespace written at the end of each line, which is only a space

--- a/src/html/ast.rs
+++ b/src/html/ast.rs
@@ -1,0 +1,159 @@
+//! AST types for the html parser.
+//!
+//! Every node borrows from the html text it was parsed out of, so a document
+//! only allocates for the vectors that hold its children and attributes. The
+//! text of a node is kept exactly as it was written -- nothing is unescaped or
+//! normalized -- because the formatter has to be able to write back out what it
+//! couldn't improve on.
+
+/// A parsed html fragment.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Document<'a> {
+  pub children: Vec<Node<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Node<'a> {
+  Element(Element<'a>),
+  /// Character data between tags, as it was written.
+  Text(&'a str),
+  /// A `<!-- -->` comment, including its delimiters.
+  Comment(&'a str),
+  /// A `<!DOCTYPE html>` or other `<!` declaration, including its delimiters.
+  Doctype(&'a str),
+  /// A `<? ?>` processing instruction, including its delimiters.
+  ProcessingInstruction(&'a str),
+  /// A `<![CDATA[ ]]>` section, including its delimiters.
+  CData(&'a str),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Element<'a> {
+  /// The tag name as it was written, which may be in any case.
+  pub name: &'a str,
+  pub attributes: Vec<Attribute<'a>>,
+  pub children: Vec<Node<'a>>,
+  /// The text between the element's tags, exactly as it was written, which is
+  /// what a preformatted or raw text element is written back out as. It is
+  /// empty for an element that holds nothing, but still borrowed from where
+  /// that content would have been, so its position can be recovered.
+  pub content: &'a str,
+  /// The whole of the element as it was written, from the `<` of its open tag
+  /// to the end of whatever closes it.
+  pub source: &'a str,
+  pub kind: ElementKind,
+  /// Whether the open tag was written with a `/>`. It is kept because a void
+  /// element written as `<br />` renders the same as one written as `<br>`
+  /// and neither is worth rewriting as the other. The space before the slash
+  /// is written the way the configuration says, whatever was written here.
+  pub self_closing_syntax: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ElementKind {
+  /// An element written with both tags (ex. `<p>a</p>`).
+  Normal,
+  /// A void element, which is written with no closing tag at all and can hold
+  /// no content (ex. `<br>`).
+  Void,
+  /// An element written with a self-closing tag (ex. `<circle />`). Only
+  /// foreign elements and void elements are read this way, because a `/>` on
+  /// an ordinary html element opens it rather than closing it.
+  SelfClosing,
+  /// An element whose content is character data rather than markup, which is
+  /// held as a single [`Node::Text`] child (ex. `<script>`).
+  RawText,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Attribute<'a> {
+  /// The attribute name as it was written, which may be in any case.
+  pub name: &'a str,
+  pub value: Option<AttributeValue<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AttributeValue<'a> {
+  /// The value between the quotes, or the bare value when there are none.
+  pub text: &'a str,
+  /// The quote character the value was written with, if any.
+  pub quote: Option<char>,
+}
+
+/// What the spec tests read to say where a node was parsed from. The
+/// formatter itself works from the nodes rather than their positions, so this
+/// is built only along with the tests that check them.
+#[cfg(test)]
+impl<'a> Node<'a> {
+  /// The whole of the node as it was written.
+  pub fn source(&self) -> &'a str {
+    match self {
+      Node::Element(element) => element.source,
+      Node::Text(text)
+      | Node::Comment(text)
+      | Node::Doctype(text)
+      | Node::ProcessingInstruction(text)
+      | Node::CData(text) => text,
+    }
+  }
+
+  pub fn kind(&self) -> &'static str {
+    match self {
+      Node::Element(_) => "Element",
+      Node::Text(_) => "Text",
+      Node::Comment(_) => "Comment",
+      Node::Doctype(_) => "Doctype",
+      Node::ProcessingInstruction(_) => "ProcessingInstruction",
+      Node::CData(_) => "CData",
+    }
+  }
+}
+
+/// The html the parser wouldn't read, which leaves the text to be written back
+/// out as it was.
+///
+/// None of these are errors in the sense that the file is wrong -- an html
+/// block in markdown is very often a fragment, because a blank line closes the
+/// block and leaves its closing tag to a block of its own. They only say that
+/// this text isn't something the formatter can take apart and put back
+/// together with confidence.
+///
+/// The tag names are borrowed from the html rather than copied out of it,
+/// because html the formatter leaves alone is the common case in markdown and
+/// there is nothing to say about it that the text doesn't already hold.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseError<'a> {
+  /// An element was opened and never closed (ex. `<div>` on its own).
+  UnclosedElement { name: &'a str },
+  /// A closing tag was written for an element that isn't open (ex. `</div>` on
+  /// its own).
+  UnexpectedClosingTag { name: &'a str },
+  /// A closing tag doesn't match the element it closes, which means the html
+  /// relies on a browser inferring where the elements end.
+  MismatchedClosingTag { expected: &'a str, found: &'a str },
+  /// A `<!--`, `<![CDATA[`, `<?` or quoted attribute value runs to the end of
+  /// the text without being closed.
+  UnterminatedMarkup,
+  /// A tag is written in a way the parser doesn't read, ex. `<div/>`, which a
+  /// browser reads as opening a div rather than as an empty one.
+  MalformedTag,
+  /// Laying the html out would leave a blank line in it, which closes the html
+  /// block it's written in and would leave the rest of it to be read as
+  /// markdown.
+  WouldSplitTheBlock,
+}
+
+impl std::fmt::Display for ParseError<'_> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ParseError::UnclosedElement { name } => write!(f, "`<{}>` was never closed", name),
+      ParseError::UnexpectedClosingTag { name } => write!(f, "`</{}>` closes an element that isn't open", name),
+      ParseError::MismatchedClosingTag { expected, found } => {
+        write!(f, "`</{}>` was found where `</{}>` was expected", found, expected)
+      }
+      ParseError::UnterminatedMarkup => write!(f, "markup runs past the end of the text without being closed"),
+      ParseError::MalformedTag => write!(f, "a tag is written in a way the parser doesn't read"),
+      ParseError::WouldSplitTheBlock => write!(f, "laying the html out would leave a blank line in it"),
+    }
+  }
+}

--- a/src/html/debug_json.rs
+++ b/src/html/debug_json.rs
@@ -1,0 +1,169 @@
+//! Serializes the html AST to json so that the parser's spec tests can assert
+//! on it.
+//!
+//! Every node reports the span it was parsed from, which is recovered from the
+//! text it borrows by measuring that slice against the start of the source.
+//! Nothing here is part of what the crate hands out -- it exists so that a
+//! spec file can show what the parser read.
+
+use super::ast::*;
+
+pub fn to_json(document: &Document<'_>, source: &str) -> String {
+  let mut writer = JsonWriter {
+    source,
+    text: String::new(),
+    indent: 0,
+  };
+  writer.text.push_str("{\n");
+  writer.indent += 1;
+  writer.property("kind", "Document");
+  writer.write_children(&document.children);
+  writer.close_node();
+  writer.text.push('\n');
+  writer.text
+}
+
+/// The byte the slice starts at within the source it was borrowed from.
+pub fn offset_in(slice: &str, source: &str) -> usize {
+  slice.as_ptr() as usize - source.as_ptr() as usize
+}
+
+struct JsonWriter<'a> {
+  source: &'a str,
+  text: String,
+  indent: usize,
+}
+
+impl JsonWriter<'_> {
+  fn write_node(&mut self, node: &Node<'_>) {
+    self.open_node(node.kind(), node.source());
+    if let Node::Element(element) = node {
+      self.property("name", element.name);
+      self.property("elementKind", &format!("{:?}", element.kind));
+      if element.self_closing_syntax {
+        self.raw_property("selfClosingSyntax", "true");
+      }
+      self.write_attributes(&element.attributes);
+      if !element.content.is_empty() {
+        self.property("content", element.content);
+      }
+      self.write_children(&element.children);
+    }
+    self.close_node();
+  }
+
+  fn write_attributes(&mut self, attributes: &[Attribute<'_>]) {
+    if attributes.is_empty() {
+      return;
+    }
+    self.begin_property("attributes");
+    self.begin_array();
+    for attribute in attributes {
+      self.write_indent();
+      self.text.push_str("{\n");
+      self.indent += 1;
+      self.property("name", attribute.name);
+      if let Some(value) = &attribute.value {
+        self.property("value", value.text);
+        match value.quote {
+          Some(quote) => self.property("quote", &quote.to_string()),
+          None => self.raw_property("quoted", "false"),
+        }
+      }
+      self.close_node();
+      self.text.push_str(",\n");
+    }
+    self.end_array();
+  }
+
+  fn write_children(&mut self, children: &[Node<'_>]) {
+    if children.is_empty() {
+      return;
+    }
+    self.begin_property("children");
+    self.begin_array();
+    for child in children {
+      self.write_indent();
+      self.write_node(child);
+      self.text.push_str(",\n");
+    }
+    self.end_array();
+  }
+
+  // ---- primitives ----
+
+  fn open_node(&mut self, kind: &str, source: &str) {
+    self.text.push_str("{\n");
+    self.indent += 1;
+    self.property("kind", kind);
+    let start = offset_in(source, self.source);
+    self.raw_property("span", &format!("[{}, {}]", start, start + source.len()));
+    self.property("text", source);
+  }
+
+  fn close_node(&mut self) {
+    self.trim_trailing_comma();
+    self.indent -= 1;
+    self.write_indent();
+    self.text.push('}');
+  }
+
+  fn begin_array(&mut self) {
+    self.text.push_str("[\n");
+    self.indent += 1;
+  }
+
+  fn end_array(&mut self) {
+    self.trim_trailing_comma();
+    self.indent -= 1;
+    self.write_indent();
+    self.text.push_str("],\n");
+  }
+
+  fn begin_property(&mut self, name: &str) {
+    self.write_indent();
+    write_json_string(&mut self.text, name);
+    self.text.push_str(": ");
+  }
+
+  fn property(&mut self, name: &str, value: &str) {
+    self.begin_property(name);
+    write_json_string(&mut self.text, value);
+    self.text.push_str(",\n");
+  }
+
+  fn raw_property(&mut self, name: &str, value: &str) {
+    self.begin_property(name);
+    self.text.push_str(value);
+    self.text.push_str(",\n");
+  }
+
+  fn write_indent(&mut self) {
+    for _ in 0..self.indent {
+      self.text.push_str("  ");
+    }
+  }
+
+  fn trim_trailing_comma(&mut self) {
+    if self.text.ends_with(",\n") {
+      self.text.truncate(self.text.len() - 2);
+      self.text.push('\n');
+    }
+  }
+}
+
+fn write_json_string(text: &mut String, value: &str) {
+  text.push('"');
+  for ch in value.chars() {
+    match ch {
+      '"' => text.push_str("\\\""),
+      '\\' => text.push_str("\\\\"),
+      '\n' => text.push_str("\\n"),
+      '\r' => text.push_str("\\r"),
+      '\t' => text.push_str("\\t"),
+      ch if (ch as u32) < 0x20 => text.push_str(&format!("\\u{:04x}", ch as u32)),
+      ch => text.push(ch),
+    }
+  }
+  text.push('"');
+}

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -1,0 +1,19 @@
+//! Formatting for the html written within a markdown file.
+//!
+//! Html in markdown is not a document -- it's whatever fragment of one fits
+//! between the blank lines that close an html block -- so the parser refuses
+//! anything it can't put back together and the printer leaves that text as it
+//! was written. Nothing here ever adds or removes a tag.
+
+mod ast;
+mod parser;
+mod printer;
+mod tags;
+
+#[cfg(test)]
+mod debug_json;
+#[cfg(test)]
+pub mod spec_test;
+
+pub use printer::format_html;
+pub use printer::HtmlFormatOptions;

--- a/src/html/parser.rs
+++ b/src/html/parser.rs
@@ -1,0 +1,710 @@
+//! An html parser written for formatting rather than rendering.
+//!
+//! It reads only the html it can put back together with confidence. Where a
+//! browser would infer a closing tag that wasn't written, or read a tag in a
+//! way that depends on what came before it, this parser stops with a
+//! [`ParseError`] instead and leaves the text to be written out as it was. An
+//! html block in markdown is very often a fragment -- a blank line closes the
+//! block, so `<div>` and its `</div>` end up in separate blocks -- and
+//! refusing those is what keeps the formatter from closing a tag the author
+//! deliberately left open.
+
+use super::ast::*;
+use super::tags;
+
+/// Parses an html fragment.
+pub fn parse(text: &str) -> Result<Document<'_>, ParseError<'_>> {
+  Parser { text }.parse_document()
+}
+
+struct Parser<'a> {
+  text: &'a str,
+}
+
+/// An element that has been opened and is waiting for its closing tag.
+struct Frame<'a> {
+  name: &'a str,
+  attributes: Vec<Attribute<'a>>,
+  children: Vec<Node<'a>>,
+  /// The position the element's open tag starts at.
+  start: usize,
+  /// The position the element's content starts at, which is just past its open
+  /// tag.
+  content_start: usize,
+  /// Whether the element's content is svg or mathml rather than html, where a
+  /// self-closing tag closes the element it's written on.
+  foreign: bool,
+}
+
+/// What was read at a `<`, along with the position just past it.
+struct Markup<'a> {
+  kind: MarkupKind<'a>,
+  end: usize,
+}
+
+enum MarkupKind<'a> {
+  OpenTag {
+    name: &'a str,
+    attributes: Vec<Attribute<'a>>,
+    self_closing: bool,
+  },
+  CloseTag {
+    name: &'a str,
+  },
+  /// A comment, declaration, processing instruction or CDATA section, which
+  /// the formatter keeps exactly as it was written.
+  Verbatim(VerbatimKind),
+}
+
+/// Markup that is written back out as it was, and so is only told apart by
+/// what the printer calls it.
+#[derive(Clone, Copy)]
+enum VerbatimKind {
+  Comment,
+  Doctype,
+  ProcessingInstruction,
+  CData,
+}
+
+impl<'a> Parser<'a> {
+  fn parse_document(&self) -> Result<Document<'a>, ParseError<'a>> {
+    let bytes = self.text.as_bytes();
+    let mut stack: Vec<Frame<'a>> = Vec::new();
+    let mut root: Vec<Node<'a>> = Vec::new();
+    let mut text_start = 0;
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+      if bytes[pos] != b'<' {
+        pos += 1;
+        continue;
+      }
+      let Some(markup) = self.markup_at(pos)? else {
+        // a `<` that doesn't open a tag is text like any other character
+        pos += 1;
+        continue;
+      };
+      let markup_start = pos;
+      if text_start < pos {
+        push_node(&mut stack, &mut root, Node::Text(&self.text[text_start..pos]));
+      }
+      let markup_text = &self.text[markup_start..markup.end];
+      pos = markup.end;
+
+      match markup.kind {
+        MarkupKind::Verbatim(kind) => {
+          let node = match kind {
+            VerbatimKind::Comment => Node::Comment(markup_text),
+            VerbatimKind::Doctype => Node::Doctype(markup_text),
+            VerbatimKind::ProcessingInstruction => Node::ProcessingInstruction(markup_text),
+            VerbatimKind::CData => Node::CData(markup_text),
+          };
+          push_node(&mut stack, &mut root, node);
+        }
+        MarkupKind::CloseTag { name } => {
+          let Some(frame) = stack.pop() else {
+            return Err(ParseError::UnexpectedClosingTag { name });
+          };
+          if !frame.name.eq_ignore_ascii_case(name) {
+            return Err(ParseError::MismatchedClosingTag {
+              expected: frame.name,
+              found: name,
+            });
+          }
+          push_node(
+            &mut stack,
+            &mut root,
+            Node::Element(Element {
+              name: frame.name,
+              attributes: frame.attributes,
+              children: frame.children,
+              content: &self.text[frame.content_start..markup_start],
+              source: &self.text[frame.start..pos],
+              kind: ElementKind::Normal,
+              self_closing_syntax: false,
+            }),
+          );
+        }
+        MarkupKind::OpenTag {
+          name,
+          attributes,
+          self_closing,
+        } => {
+          let foreign = stack.last().is_some_and(|frame| frame.foreign) || tags::is_foreign_root(name);
+          if tags::is_void(name) {
+            push_node(
+              &mut stack,
+              &mut root,
+              Node::Element(Element {
+                name,
+                attributes,
+                children: Vec::new(),
+                content: &self.text[pos..pos],
+                source: &self.text[markup_start..pos],
+                kind: ElementKind::Void,
+                self_closing_syntax: self_closing,
+              }),
+            );
+          } else if tags::is_raw_text(name) {
+            let (content, end) = self.raw_text_content(name, pos)?;
+            pos = end;
+            push_node(
+              &mut stack,
+              &mut root,
+              Node::Element(Element {
+                name,
+                attributes,
+                children: if content.is_empty() {
+                  Vec::new()
+                } else {
+                  vec![Node::Text(content)]
+                },
+                content,
+                source: &self.text[markup_start..pos],
+                kind: ElementKind::RawText,
+                self_closing_syntax: false,
+              }),
+            );
+          } else if self_closing {
+            // a browser reads `<div/>` as opening a div rather than as an empty
+            // one, so a self-closing tag is only read as one where it really
+            // does close the element
+            if !foreign {
+              return Err(ParseError::MalformedTag);
+            }
+            push_node(
+              &mut stack,
+              &mut root,
+              Node::Element(Element {
+                name,
+                attributes,
+                children: Vec::new(),
+                content: &self.text[pos..pos],
+                source: &self.text[markup_start..pos],
+                kind: ElementKind::SelfClosing,
+                self_closing_syntax: true,
+              }),
+            );
+          } else {
+            stack.push(Frame {
+              name,
+              attributes,
+              children: Vec::new(),
+              start: markup_start,
+              content_start: pos,
+              foreign,
+            });
+          }
+        }
+      }
+      text_start = pos;
+    }
+
+    if text_start < bytes.len() {
+      push_node(&mut stack, &mut root, Node::Text(&self.text[text_start..]));
+    }
+    match stack.pop() {
+      Some(frame) => Err(ParseError::UnclosedElement { name: frame.name }),
+      None => Ok(Document { children: root }),
+    }
+  }
+
+  /// Reads the markup at a `<`, or `None` where it's only text.
+  fn markup_at(&self, start: usize) -> Result<Option<Markup<'a>>, ParseError<'a>> {
+    let bytes = self.text.as_bytes();
+    match bytes.get(start + 1) {
+      Some(b'!') => match bytes.get(start + 2) {
+        Some(b'-') if self.text[start..].starts_with("<!--") => {
+          let end = self
+            .find_after(start + 4, "-->")
+            .ok_or(ParseError::UnterminatedMarkup)?;
+          Ok(Some(Markup {
+            kind: MarkupKind::Verbatim(VerbatimKind::Comment),
+            end,
+          }))
+        }
+        Some(b'[') if self.text[start..].starts_with("<![CDATA[") => {
+          let end = self
+            .find_after(start + 9, "]]>")
+            .ok_or(ParseError::UnterminatedMarkup)?;
+          Ok(Some(Markup {
+            kind: MarkupKind::Verbatim(VerbatimKind::CData),
+            end,
+          }))
+        }
+        // a declaration is `<!` followed by an ascii letter
+        Some(byte) if byte.is_ascii_alphabetic() => {
+          let end = self.find_after(start + 2, ">").ok_or(ParseError::UnterminatedMarkup)?;
+          Ok(Some(Markup {
+            kind: MarkupKind::Verbatim(VerbatimKind::Doctype),
+            end,
+          }))
+        }
+        _ => Ok(None),
+      },
+      Some(b'?') => {
+        let end = self.find_after(start + 2, "?>").ok_or(ParseError::UnterminatedMarkup)?;
+        Ok(Some(Markup {
+          kind: MarkupKind::Verbatim(VerbatimKind::ProcessingInstruction),
+          end,
+        }))
+      }
+      Some(b'/') => Ok(self.close_tag_at(start)),
+      Some(byte) if byte.is_ascii_alphabetic() => self.open_tag_at(start),
+      _ => Ok(None),
+    }
+  }
+
+  fn close_tag_at(&self, start: usize) -> Option<Markup<'a>> {
+    let bytes = self.text.as_bytes();
+    let name_start = start + 2;
+    let mut index = name_start;
+    while bytes.get(index).is_some_and(|b| is_tag_name_byte(*b)) {
+      index += 1;
+    }
+    if index == name_start {
+      return None;
+    }
+    let name = &self.text[name_start..index];
+    index = skip_whitespace(bytes, index);
+    if bytes.get(index) != Some(&b'>') {
+      return None;
+    }
+    Some(Markup {
+      kind: MarkupKind::CloseTag { name },
+      end: index + 1,
+    })
+  }
+
+  /// Reads an open tag, or `None` where what looks like one isn't written as a
+  /// tag at all and so is only text.
+  fn open_tag_at(&self, start: usize) -> Result<Option<Markup<'a>>, ParseError<'a>> {
+    let bytes = self.text.as_bytes();
+    let name_start = start + 1;
+    let mut index = name_start;
+    while bytes.get(index).is_some_and(|b| is_tag_name_byte(*b)) {
+      index += 1;
+    }
+    let name = &self.text[name_start..index];
+    let mut attributes = Vec::new();
+
+    loop {
+      let after_whitespace = skip_whitespace(bytes, index);
+      match bytes.get(after_whitespace) {
+        Some(b'>') => {
+          return Ok(Some(Markup {
+            kind: MarkupKind::OpenTag {
+              name,
+              attributes,
+              self_closing: false,
+            },
+            end: after_whitespace + 1,
+          }))
+        }
+        Some(b'/') if bytes.get(after_whitespace + 1) == Some(&b'>') => {
+          return Ok(Some(Markup {
+            kind: MarkupKind::OpenTag {
+              name,
+              attributes,
+              self_closing: true,
+            },
+            end: after_whitespace + 2,
+          }))
+        }
+        // an attribute has to be separated from whatever came before it
+        Some(byte) if is_attribute_name_start(*byte) && after_whitespace > index => {
+          let (attribute, end) = self.attribute_at(after_whitespace)?;
+          attributes.push(attribute);
+          index = end;
+        }
+        _ => return Ok(None),
+      }
+    }
+  }
+
+  fn attribute_at(&self, start: usize) -> Result<(Attribute<'a>, usize), ParseError<'a>> {
+    let bytes = self.text.as_bytes();
+    let mut index = start;
+    while bytes.get(index).is_some_and(|b| is_attribute_name_byte(*b)) {
+      index += 1;
+    }
+    let name = &self.text[start..index];
+    let after_name = index;
+    index = skip_whitespace(bytes, index);
+    if bytes.get(index) != Some(&b'=') {
+      return Ok((Attribute { name, value: None }, after_name));
+    }
+    index = skip_whitespace(bytes, index + 1);
+
+    match bytes.get(index) {
+      Some(quote) if *quote == b'"' || *quote == b'\'' => {
+        let quote = *quote;
+        let value_start = index + 1;
+        let mut end = value_start;
+        while bytes.get(end).is_some_and(|b| *b != quote) {
+          end += 1;
+        }
+        if bytes.get(end).is_none() {
+          return Err(ParseError::UnterminatedMarkup);
+        }
+        Ok((
+          Attribute {
+            name,
+            value: Some(AttributeValue {
+              text: &self.text[value_start..end],
+              quote: Some(quote as char),
+            }),
+          },
+          end + 1,
+        ))
+      }
+      Some(_) => {
+        let value_start = index;
+        while bytes.get(index).is_some_and(|b| is_unquoted_value_byte(*b)) {
+          index += 1;
+        }
+        if index == value_start {
+          return Err(ParseError::MalformedTag);
+        }
+        Ok((
+          Attribute {
+            name,
+            value: Some(AttributeValue {
+              text: &self.text[value_start..index],
+              quote: None,
+            }),
+          },
+          index,
+        ))
+      }
+      None => Err(ParseError::UnterminatedMarkup),
+    }
+  }
+
+  /// Reads the character data of a raw text element, which runs to that
+  /// element's closing tag no matter what markup is written within it.
+  fn raw_text_content(&self, name: &'a str, start: usize) -> Result<(&'a str, usize), ParseError<'a>> {
+    let bytes = self.text.as_bytes();
+    let mut index = start;
+    while index < bytes.len() {
+      if bytes[index] != b'<' || bytes.get(index + 1) != Some(&b'/') {
+        index += 1;
+        continue;
+      }
+      let name_start = index + 2;
+      let name_end = name_start + name.len();
+      if !self
+        .text
+        .get(name_start..name_end)
+        .is_some_and(|found| found.eq_ignore_ascii_case(name))
+      {
+        index += 1;
+        continue;
+      }
+      let after_name = skip_whitespace(bytes, name_end);
+      if bytes.get(after_name) != Some(&b'>') {
+        index += 1;
+        continue;
+      }
+      return Ok((&self.text[start..index], after_name + 1));
+    }
+    Err(ParseError::UnclosedElement { name })
+  }
+
+  fn find_after(&self, start: usize, close: &str) -> Option<usize> {
+    self.text[start..].find(close).map(|index| start + index + close.len())
+  }
+}
+
+fn push_node<'a>(stack: &mut [Frame<'a>], root: &mut Vec<Node<'a>>, node: Node<'a>) {
+  match stack.last_mut() {
+    Some(frame) => frame.children.push(node),
+    None => root.push(node),
+  }
+}
+
+fn skip_whitespace(bytes: &[u8], start: usize) -> usize {
+  let mut index = start;
+  while matches!(bytes.get(index), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+    index += 1;
+  }
+  index
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric() || byte == b'-'
+}
+
+fn is_attribute_name_start(byte: u8) -> bool {
+  byte.is_ascii_alphabetic() || matches!(byte, b'_' | b':' | b'@' | b'#' | b'[' | b'(' | b'.')
+}
+
+fn is_attribute_name_byte(byte: u8) -> bool {
+  !matches!(
+    byte,
+    b' ' | b'\t' | b'\n' | b'\r' | b'"' | b'\'' | b'=' | b'<' | b'>' | b'/' | b'`'
+  )
+}
+
+fn is_unquoted_value_byte(byte: u8) -> bool {
+  !matches!(
+    byte,
+    b' ' | b'\t' | b'\n' | b'\r' | b'"' | b'\'' | b'=' | b'<' | b'>' | b'`'
+  )
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  /// Renders the parsed html compactly so a test can say what it expects on
+  /// one line.
+  fn describe(text: &str) -> String {
+    match parse(text) {
+      Ok(document) => document.children.iter().map(describe_node).collect(),
+      Err(err) => format!("error({})", err),
+    }
+  }
+
+  fn describe_node(node: &Node) -> String {
+    match node {
+      Node::Text(text) => format!("text({:?})", text),
+      Node::Comment(text) => format!("comment({:?})", text),
+      Node::Doctype(text) => format!("doctype({:?})", text),
+      Node::ProcessingInstruction(text) => format!("pi({:?})", text),
+      Node::CData(text) => format!("cdata({:?})", text),
+      Node::Element(element) => {
+        let attributes: String = element
+          .attributes
+          .iter()
+          .map(|attribute| match &attribute.value {
+            Some(value) => format!(" {}={:?}", attribute.name, value.text),
+            None => format!(" {}", attribute.name),
+          })
+          .collect();
+        let kind = match element.kind {
+          ElementKind::Normal => "",
+          ElementKind::Void => "/void",
+          ElementKind::SelfClosing => "/self",
+          ElementKind::RawText => "/raw",
+        };
+        let children: String = element.children.iter().map(describe_node).collect();
+        format!("<{}{}{}>[{}]", element.name, attributes, kind, children)
+      }
+    }
+  }
+
+  // ==== structure ====
+
+  #[test]
+  fn parses_an_element_and_its_text() {
+    assert_eq!(describe("<p>a</p>"), "<p>[text(\"a\")]");
+  }
+
+  #[test]
+  fn parses_nested_elements() {
+    assert_eq!(describe("<div><p>a</p></div>"), "<div>[<p>[text(\"a\")]]");
+  }
+
+  #[test]
+  fn parses_siblings_and_the_text_between_them() {
+    assert_eq!(
+      describe("<p>a</p> <p>b</p>"),
+      "<p>[text(\"a\")]text(\" \")<p>[text(\"b\")]"
+    );
+  }
+
+  #[test]
+  fn parses_an_empty_element() {
+    assert_eq!(describe("<div></div>"), "<div>[]");
+  }
+
+  #[test]
+  fn matches_a_closing_tag_without_case() {
+    assert_eq!(describe("<DIV>a</div>"), "<DIV>[text(\"a\")]");
+    assert_eq!(describe("<div>a</DIV>"), "<div>[text(\"a\")]");
+  }
+
+  #[test]
+  fn keeps_the_content_of_an_element_as_it_was_written() {
+    let document = parse("<div>  a  <b>c</b>  </div>").unwrap();
+    let Node::Element(element) = &document.children[0] else {
+      panic!("expected an element");
+    };
+    assert_eq!(element.content, "  a  <b>c</b>  ");
+  }
+
+  // ==== attributes ====
+
+  #[test]
+  fn parses_a_quoted_attribute_value() {
+    assert_eq!(describe("<a href=\"foo\">x</a>"), "<a href=\"foo\">[text(\"x\")]");
+    assert_eq!(describe("<a href='foo'>x</a>"), "<a href=\"foo\">[text(\"x\")]");
+  }
+
+  #[test]
+  fn parses_an_unquoted_attribute_value() {
+    assert_eq!(describe("<a href=foo>x</a>"), "<a href=\"foo\">[text(\"x\")]");
+  }
+
+  #[test]
+  fn parses_an_attribute_with_no_value() {
+    assert_eq!(describe("<input disabled>"), "<input disabled/void>[]");
+  }
+
+  #[test]
+  fn parses_several_attributes() {
+    assert_eq!(
+      describe("<div class=\"a\" id=\"b\" hidden>x</div>"),
+      "<div class=\"a\" id=\"b\" hidden>[text(\"x\")]"
+    );
+  }
+
+  #[test]
+  fn parses_an_attribute_value_holding_the_other_quote() {
+    assert_eq!(
+      describe("<a title='say \"hi\"'>x</a>"),
+      "<a title=\"say \\\"hi\\\"\">[text(\"x\")]"
+    );
+  }
+
+  #[test]
+  fn parses_an_attribute_written_across_lines() {
+    assert_eq!(
+      describe("<div\n  class=\"a\"\n  id=\"b\"\n>x</div>"),
+      "<div class=\"a\" id=\"b\">[text(\"x\")]"
+    );
+  }
+
+  #[test]
+  fn parses_a_framework_attribute_name() {
+    assert_eq!(
+      describe("<div @click=\"a\" :value=\"b\">x</div>"),
+      "<div @click=\"a\" :value=\"b\">[text(\"x\")]"
+    );
+  }
+
+  // ==== the kinds of element ====
+
+  #[test]
+  fn parses_a_void_element() {
+    assert_eq!(describe("<br>"), "<br/void>[]");
+    assert_eq!(describe("<br />"), "<br/void>[]");
+    assert_eq!(describe("<img src=\"a\">"), "<img src=\"a\"/void>[]");
+  }
+
+  #[test]
+  fn parses_a_self_closing_tag_only_within_foreign_content() {
+    assert_eq!(describe("<svg><circle /></svg>"), "<svg>[<circle/self>[]]");
+    assert_eq!(
+      describe("<div/>"),
+      "error(a tag is written in a way the parser doesn't read)"
+    );
+  }
+
+  #[test]
+  fn parses_a_raw_text_element() {
+    assert_eq!(describe("<script>a < b</script>"), "<script/raw>[text(\"a < b\")]");
+    assert_eq!(describe("<style>.a {}</style>"), "<style/raw>[text(\".a {}\")]");
+  }
+
+  #[test]
+  fn reads_a_tag_within_a_raw_text_element_as_text() {
+    assert_eq!(
+      describe("<script>const a = \"</div>\"</script>"),
+      "<script/raw>[text(\"const a = \\\"</div>\\\"\")]"
+    );
+  }
+
+  #[test]
+  fn parses_an_empty_raw_text_element() {
+    assert_eq!(describe("<script></script>"), "<script/raw>[]");
+  }
+
+  // ==== markup that is kept as it was written ====
+
+  #[test]
+  fn parses_a_comment() {
+    assert_eq!(describe("<!-- a -->"), "comment(\"<!-- a -->\")");
+    assert_eq!(describe("<!--\na\n-->"), "comment(\"<!--\\na\\n-->\")");
+  }
+
+  #[test]
+  fn parses_a_doctype_declaration() {
+    assert_eq!(describe("<!DOCTYPE html>"), "doctype(\"<!DOCTYPE html>\")");
+  }
+
+  #[test]
+  fn parses_a_processing_instruction() {
+    assert_eq!(describe("<?php echo 1; ?>"), "pi(\"<?php echo 1; ?>\")");
+  }
+
+  #[test]
+  fn parses_a_cdata_section() {
+    assert_eq!(describe("<![CDATA[ a < b ]]>"), "cdata(\"<![CDATA[ a < b ]]>\")");
+  }
+
+  // ==== text that only looks like markup ====
+
+  #[test]
+  fn reads_an_angle_bracket_that_opens_no_tag_as_text() {
+    assert_eq!(describe("a < b"), "text(\"a < b\")");
+    assert_eq!(describe("1 <2 3"), "text(\"1 <2 3\")");
+    assert_eq!(describe("a <> b"), "text(\"a <> b\")");
+  }
+
+  #[test]
+  fn reads_a_malformed_tag_as_text() {
+    assert_eq!(describe("<div =foo>"), "text(\"<div =foo>\")");
+  }
+
+  // ==== html the parser refuses ====
+
+  #[test]
+  fn refuses_an_element_that_was_never_closed() {
+    assert_eq!(describe("<div>"), "error(`<div>` was never closed)");
+    assert_eq!(describe("<div><p>a</p>"), "error(`<div>` was never closed)");
+  }
+
+  #[test]
+  fn refuses_a_closing_tag_that_closes_nothing() {
+    assert_eq!(describe("</div>"), "error(`</div>` closes an element that isn't open)");
+  }
+
+  #[test]
+  fn refuses_tags_that_do_not_match() {
+    assert_eq!(
+      describe("<div><p>a</div></p>"),
+      "error(`</div>` was found where `</p>` was expected)"
+    );
+  }
+
+  #[test]
+  fn refuses_html_that_leaves_a_closing_tag_to_be_inferred() {
+    assert_eq!(
+      describe("<ul><li>a<li>b</ul>"),
+      "error(`</ul>` was found where `</li>` was expected)"
+    );
+  }
+
+  #[test]
+  fn refuses_markup_that_was_never_terminated() {
+    assert_eq!(
+      describe("<!-- a"),
+      "error(markup runs past the end of the text without being closed)"
+    );
+    assert_eq!(
+      describe("<![CDATA[ a"),
+      "error(markup runs past the end of the text without being closed)"
+    );
+    assert_eq!(
+      describe("<div title=\"a"),
+      "error(markup runs past the end of the text without being closed)"
+    );
+  }
+
+  #[test]
+  fn refuses_a_raw_text_element_that_was_never_closed() {
+    assert_eq!(describe("<script>a"), "error(`<script>` was never closed)");
+  }
+}

--- a/src/html/printer.rs
+++ b/src/html/printer.rs
@@ -1,0 +1,983 @@
+//! Writes a parsed html fragment back out.
+//!
+//! The printer only ever changes whitespace that isn't rendered: the
+//! indentation of an element's children, the runs of whitespace a browser
+//! collapses to a single space, and the line the attributes of a long tag are
+//! written on. Attribute values, character data, comments and the content of a
+//! preformatted or raw text element are all written back byte for byte.
+//!
+//! Elements are laid out by whether the spec renders them as a block, because
+//! that decides whether the whitespace at the edges of their content matters.
+//! Everything the tables don't name is treated as inline, which is both what
+//! the spec says an unknown element is and the careful assumption: the
+//! whitespace around it has to be kept.
+
+use unicode_width::UnicodeWidthStr;
+
+use super::ast::*;
+use super::parser;
+use super::tags;
+
+pub struct HtmlFormatOptions {
+  pub line_width: u32,
+  pub use_tabs: bool,
+  pub indent_width: u8,
+  /// Whether to write a space before the `/>` that closes a self-closing tag.
+  pub self_closing_space: bool,
+}
+
+/// Formats an html fragment.
+///
+/// Returns an error where the html isn't something the formatter can take
+/// apart and put back together, which leaves it to be written out as it was.
+pub fn format_html<'a>(text: &'a str, options: &HtmlFormatOptions) -> Result<String, ParseError<'a>> {
+  let document = parser::parse(text)?;
+  let mut printer = Printer {
+    options,
+    out: String::with_capacity(text.len()),
+  };
+  printer.print_items(&document.children, 0);
+  let result = printer.out;
+
+  // a blank line closes the html block it's written in, so one that wasn't
+  // there before would split the block in two and leave the rest of it to be
+  // read as markdown
+  if has_blank_line(&result) && !has_blank_line(text) {
+    return Err(ParseError::WouldSplitTheBlock);
+  }
+  Ok(result)
+}
+
+struct Printer<'a> {
+  options: &'a HtmlFormatOptions,
+  out: String,
+}
+
+impl Printer<'_> {
+  /// Writes nodes one item to a line, which is how the children of a block
+  /// element and the fragment itself are laid out.
+  ///
+  /// A block is written on a line of its own; everything between two of them
+  /// is one run of text and inline elements, written on a line of its own in
+  /// turn. The caller has already written the indentation of the first line.
+  fn print_items(&mut self, children: &[Node], indent: usize) {
+    let mut wrote_one = false;
+    let mut run_start = 0;
+    for (index, node) in children.iter().enumerate() {
+      if !is_block_node(node) {
+        continue;
+      }
+      self.print_run(&children[run_start..index], indent, &mut wrote_one);
+      if wrote_one {
+        self.newline(indent);
+      }
+      self.print_node(node, indent);
+      wrote_one = true;
+      run_start = index + 1;
+    }
+    self.print_run(&children[run_start..], indent, &mut wrote_one);
+  }
+
+  /// Writes a run of text and inline elements as an item of its own, unless
+  /// there is nothing to it but the whitespace that separates two items.
+  fn print_run(&mut self, run: &[Node], indent: usize, wrote_one: &mut bool) {
+    let Some(run) = trimmed_run(run) else {
+      return;
+    };
+    if *wrote_one {
+      self.newline(indent);
+    }
+    self.print_inline_nodes(run, indent, true, true);
+    *wrote_one = true;
+  }
+
+  fn print_node(&mut self, node: &Node, indent: usize) {
+    match node {
+      Node::Element(element) => self.print_element(element, indent),
+      Node::Text(text) => self.out.push_str(text),
+      Node::Comment(text) | Node::Doctype(text) | Node::ProcessingInstruction(text) | Node::CData(text) => {
+        self.out.push_str(text)
+      }
+    }
+  }
+
+  fn print_element(&mut self, element: &Element, indent: usize) {
+    self.print_open_tag(element, indent);
+    if matches!(element.kind, ElementKind::Void | ElementKind::SelfClosing) {
+      return;
+    }
+
+    // the content of these is character data, which is rendered as it was
+    // written and so can't be touched at all
+    if element.kind == ElementKind::RawText || tags::is_preformatted(element.name) {
+      self.out.push_str(element.content);
+      self.print_close_tag(element);
+      return;
+    }
+
+    if element.children.is_empty() {
+      self.print_close_tag(element);
+      return;
+    }
+
+    // The content is measured rather than written out and looked at, so that
+    // an element whose content doesn't fit isn't written twice. Measuring is
+    // what keeps the cost of a deeply nested document from doubling with every
+    // level of it.
+    let is_block = tags::is_block(element.name);
+    let fits = content_flat_width(&element.children, is_block, self.options).is_some_and(|width| {
+      self.current_column() + width + close_tag_width(element) <= self.options.line_width as usize
+    });
+    if fits {
+      // every part of the content fits along with the whole of it, so each of
+      // them is written on this line in turn
+      if is_block {
+        self.print_items(&element.children, indent + 1);
+      } else {
+        self.print_inline_nodes(&element.children, indent + 1, false, false);
+      }
+      self.print_close_tag(element);
+      return;
+    }
+
+    // Content that won't fit on the line its tags are on is written on lines
+    // of its own, a level further in. The whitespace at the edges of a block's
+    // content isn't rendered, so a block can always be opened up this way; an
+    // inline element can only be broken where whitespace was already written,
+    // because a line break added beside its content is a space that renders.
+    let break_start = is_block || starts_with_whitespace(&element.children);
+    let break_end = is_block || ends_with_whitespace(&element.children);
+
+    if break_start {
+      self.newline(indent + 1);
+    }
+    if is_block {
+      self.print_items(&element.children, indent + 1);
+    } else {
+      self.print_inline_nodes(&element.children, indent + 1, break_start, break_end);
+    }
+    if break_end {
+      self.newline(indent);
+    }
+    self.print_close_tag(element);
+  }
+
+  /// Writes a run of text and inline elements.
+  ///
+  /// Runs of whitespace are written as the single space a browser renders them
+  /// as, except that one holding a line break is written as a line break so
+  /// that the lines the author wrote are kept. When the run is an item of its
+  /// own the whitespace at its edges isn't rendered, so it's dropped.
+  fn print_inline_nodes(&mut self, nodes: &[Node], indent: usize, trim_start: bool, trim_end: bool) {
+    for (index, node) in nodes.iter().enumerate() {
+      match node {
+        Node::Text(text) => {
+          let trim_start = trim_start && index == 0;
+          let trim_end = trim_end && index == nodes.len() - 1;
+          self.print_collapsed_text(text, indent, trim_start, trim_end);
+        }
+        _ => self.print_node(node, indent),
+      }
+    }
+  }
+
+  fn print_collapsed_text(&mut self, text: &str, indent: usize, trim_start: bool, trim_end: bool) {
+    let mut rest = text;
+    if trim_start {
+      rest = rest.trim_start_matches(is_html_whitespace);
+    }
+    if trim_end {
+      rest = rest.trim_end_matches(is_html_whitespace);
+    }
+    let mut chars = rest.char_indices().peekable();
+    let mut word_start = None;
+    while let Some((index, ch)) = chars.next() {
+      if !is_html_whitespace(ch) {
+        word_start.get_or_insert(index);
+        continue;
+      }
+      if let Some(start) = word_start.take() {
+        self.out.push_str(&rest[start..index]);
+      }
+      // a run of whitespace renders as a single space, so only whether there
+      // is one matters -- but a line break is kept as one to leave the lines
+      // the author wrote where they were
+      let mut has_newline = ch == '\n';
+      while let Some((_, next)) = chars.peek() {
+        if !is_html_whitespace(*next) {
+          break;
+        }
+        has_newline |= *next == '\n';
+        chars.next();
+      }
+      if has_newline {
+        self.newline(indent);
+      } else {
+        self.out.push(' ');
+      }
+    }
+    if let Some(start) = word_start {
+      self.out.push_str(&rest[start..]);
+    }
+  }
+
+  fn print_open_tag(&mut self, element: &Element, indent: usize) {
+    let fits = self.current_column() + open_tag_width(element, self.options) <= self.options.line_width as usize;
+    // A lone attribute has nowhere better to go, so it stays where it was
+    // written rather than being pushed onto a line of its own. Nor is a tag
+    // written partway along a line the place to start writing attributes on
+    // lines of their own: the line it would break is one the tags around it
+    // are sharing, and taking it apart reads worse than leaving it long.
+    if fits || element.attributes.len() < 2 || !self.at_line_start() {
+      self.write_open_tag(element);
+      return;
+    }
+
+    self.out.push('<');
+    self.out.push_str(element.name);
+    for attribute in &element.attributes {
+      self.newline(indent + 1);
+      self.write_attribute(attribute);
+    }
+    self.newline(indent);
+    if element.self_closing_syntax {
+      self.out.push_str("/>");
+    } else {
+      self.out.push('>');
+    }
+  }
+
+  fn write_open_tag(&mut self, element: &Element) {
+    self.out.push('<');
+    self.out.push_str(element.name);
+    for attribute in &element.attributes {
+      self.out.push(' ');
+      self.write_attribute(attribute);
+    }
+    if element.self_closing_syntax {
+      if self.options.self_closing_space {
+        self.out.push(' ');
+      }
+      self.out.push_str("/>");
+    } else {
+      self.out.push('>');
+    }
+  }
+
+  /// Writes an attribute, quoting a value that was written without quotes.
+  ///
+  /// The value itself is never touched: whitespace within it is rendered for
+  /// some attributes and is part of the value for the rest.
+  fn write_attribute(&mut self, attribute: &Attribute) {
+    self.out.push_str(attribute.name);
+    let Some(value) = &attribute.value else {
+      return;
+    };
+    let quote = attribute_quote(value);
+    self.out.push('=');
+    self.out.push(quote);
+    self.out.push_str(value.text);
+    self.out.push(quote);
+  }
+
+  fn print_close_tag(&mut self, element: &Element) {
+    self.out.push_str("</");
+    self.out.push_str(element.name);
+    self.out.push('>');
+  }
+
+  fn newline(&mut self, indent: usize) {
+    self.out.push('\n');
+    for _ in 0..indent {
+      if self.options.use_tabs {
+        self.out.push('\t');
+      } else {
+        for _ in 0..self.options.indent_width {
+          self.out.push(' ');
+        }
+      }
+    }
+  }
+
+  /// Whether nothing but indentation has been written on the line so far,
+  /// which is what gives a tag the room to lay its attributes out.
+  fn at_line_start(&self) -> bool {
+    let line = match self.out.rfind('\n') {
+      Some(index) => &self.out[index + 1..],
+      None => &self.out[..],
+    };
+    line.chars().all(|ch| ch == ' ' || ch == '\t')
+  }
+
+  fn current_column(&self) -> usize {
+    match self.out.rfind('\n') {
+      Some(index) => self.out[index + 1..].width(),
+      None => self.out.width(),
+    }
+  }
+}
+
+/// The run without the whitespace at its edges, or `None` where there is
+/// nothing to it but that whitespace.
+///
+/// Text that is only whitespace separates one item from the next, so it is
+/// dropped -- but only where it falls between items, because within a run the
+/// space between two inline elements is rendered.
+fn trimmed_run<'a, 'b>(run: &'b [Node<'a>]) -> Option<&'b [Node<'a>]> {
+  let start = run.iter().position(|node| !is_blank_text(node))?;
+  let end = run.iter().rposition(|node| !is_blank_text(node)).unwrap();
+  Some(&run[start..=end])
+}
+
+/// Whether the whitespace an element's content begins with was written by the
+/// author, which is where a line break can be put without adding one.
+fn starts_with_whitespace(children: &[Node]) -> bool {
+  matches!(children.first(), Some(Node::Text(text)) if text.starts_with(is_html_whitespace))
+}
+
+/// Whether the whitespace an element's content ends with was written by the
+/// author, which is where a line break can be put without adding one.
+fn ends_with_whitespace(children: &[Node]) -> bool {
+  matches!(children.last(), Some(Node::Text(text)) if text.ends_with(is_html_whitespace))
+}
+
+fn is_block_node(node: &Node) -> bool {
+  match node {
+    Node::Element(element) => tags::is_block(element.name),
+    Node::Doctype(_) => true,
+    _ => false,
+  }
+}
+
+fn is_blank_text(node: &Node) -> bool {
+  matches!(node, Node::Text(text) if text.chars().all(is_html_whitespace))
+}
+
+/// The quote to write a value with, which is the one it was written with
+/// unless it was written without any.
+fn attribute_quote(value: &AttributeValue) -> char {
+  match value.quote {
+    Some(quote) => quote,
+    // an unquoted value can always be written with quotes, so long as the
+    // quote isn't one of the characters in it
+    None if value.text.contains('"') => '\'',
+    None => '"',
+  }
+}
+
+/// The columns an element's content takes when it is written on one line, or
+/// `None` when it can't be: it holds a block, or whitespace that has to stay a
+/// line break, or text that is written back out with a line break in it.
+///
+/// This mirrors what the printer writes, so that measuring an element and
+/// writing it out agree. Measuring is what keeps a deeply nested document from
+/// costing twice as much for every level of it, which is what writing the
+/// content out only to find it doesn't fit would do.
+fn content_flat_width(children: &[Node], is_block: bool, options: &HtmlFormatOptions) -> Option<usize> {
+  if children.iter().any(is_block_node) {
+    return None;
+  }
+  if !is_block {
+    // the whitespace at the edges of an inline element's content is rendered,
+    // so it is measured rather than trimmed away
+    return run_flat_width(children, false, false, options);
+  }
+  // with no block among them the children are the one run the printer writes,
+  // without the whitespace at its edges
+  match trimmed_run(children) {
+    Some(run) => run_flat_width(run, true, true, options),
+    None => Some(0),
+  }
+}
+
+fn run_flat_width(nodes: &[Node], trim_start: bool, trim_end: bool, options: &HtmlFormatOptions) -> Option<usize> {
+  let mut total = 0;
+  for (index, node) in nodes.iter().enumerate() {
+    total += match node {
+      Node::Text(text) => collapsed_text_width(text, trim_start && index == 0, trim_end && index == nodes.len() - 1)?,
+      Node::Element(element) => element_flat_width(element, options)?,
+      Node::Comment(text) | Node::Doctype(text) | Node::ProcessingInstruction(text) | Node::CData(text) => {
+        verbatim_width(text)?
+      }
+    };
+  }
+  Some(total)
+}
+
+fn element_flat_width(element: &Element, options: &HtmlFormatOptions) -> Option<usize> {
+  // a value written across lines takes the tag with it
+  if element
+    .attributes
+    .iter()
+    .any(|attribute| attribute.value.as_ref().is_some_and(|value| value.text.contains('\n')))
+  {
+    return None;
+  }
+  let open = open_tag_width(element, options);
+  if matches!(element.kind, ElementKind::Void | ElementKind::SelfClosing) {
+    return Some(open);
+  }
+  if element.kind == ElementKind::RawText || tags::is_preformatted(element.name) {
+    return Some(open + verbatim_width(element.content)? + close_tag_width(element));
+  }
+  let content = content_flat_width(&element.children, tags::is_block(element.name), options)?;
+  Some(open + content + close_tag_width(element))
+}
+
+fn open_tag_width(element: &Element, options: &HtmlFormatOptions) -> usize {
+  let mut width = 1 + element.name.width();
+  for attribute in &element.attributes {
+    width += 1 + attribute.name.width();
+    if let Some(value) = &attribute.value {
+      // the two quotes and the equals sign
+      width += 3 + value.text.width();
+    }
+  }
+  width += if element.self_closing_syntax {
+    if options.self_closing_space {
+      3
+    } else {
+      2
+    }
+  } else {
+    1
+  };
+  width
+}
+
+/// The columns text written back out as it was takes, or `None` where it holds
+/// a line break and so takes more than one line.
+fn verbatim_width(text: &str) -> Option<usize> {
+  (!text.contains('\n')).then(|| text.width())
+}
+
+/// The columns text takes once the runs of whitespace within it are collapsed,
+/// or `None` where one of them holds a line break the printer keeps.
+fn collapsed_text_width(text: &str, trim_start: bool, trim_end: bool) -> Option<usize> {
+  let mut rest = text;
+  if trim_start {
+    rest = rest.trim_start_matches(is_html_whitespace);
+  }
+  if trim_end {
+    rest = rest.trim_end_matches(is_html_whitespace);
+  }
+  let mut width = 0;
+  let mut word_start = None;
+  let mut chars = rest.char_indices().peekable();
+  while let Some((index, ch)) = chars.next() {
+    if !is_html_whitespace(ch) {
+      word_start.get_or_insert(index);
+      continue;
+    }
+    if let Some(start) = word_start.take() {
+      width += rest[start..index].width();
+    }
+    if ch == '\n' {
+      return None;
+    }
+    while let Some((_, next)) = chars.peek() {
+      if !is_html_whitespace(*next) {
+        break;
+      }
+      if *next == '\n' {
+        return None;
+      }
+      chars.next();
+    }
+    // the run renders as the single space it is written back out as
+    width += 1;
+  }
+  if let Some(start) = word_start {
+    width += rest[start..].width();
+  }
+  Some(width)
+}
+
+fn close_tag_width(element: &Element) -> usize {
+  element.name.width() + 3
+}
+
+fn is_html_whitespace(ch: char) -> bool {
+  matches!(ch, ' ' | '\t' | '\n' | '\r' | '\u{000C}')
+}
+
+/// Whether any line of the text holds nothing but whitespace, which is what
+/// closes an html block in markdown.
+///
+/// The empty line that text ending in a newline leaves behind isn't one of
+/// them, because there is no line there at all.
+fn has_blank_line(text: &str) -> bool {
+  let mut lines: Vec<&str> = text.split('\n').collect();
+  if lines.last() == Some(&"") {
+    lines.pop();
+  }
+  lines
+    .iter()
+    .any(|line| line.trim_matches(is_html_whitespace).is_empty())
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[track_caller]
+  fn assert_format(text: &str, expected: &str) {
+    let actual = format_with_width(text, 80);
+    assert_eq!(actual, expected, "\n  input: {:?}", text);
+    // formatting is only worth anything if it settles, which is why the spec
+    // tests run every file through twice as well
+    let again = format_with_width(&actual, 80);
+    assert_eq!(again, actual, "formatting a second time changed the text");
+  }
+
+  #[track_caller]
+  fn format_with_width(text: &str, line_width: u32) -> String {
+    format_html(
+      text,
+      &HtmlFormatOptions {
+        line_width,
+        use_tabs: false,
+        indent_width: 2,
+        self_closing_space: true,
+      },
+    )
+    .unwrap_or_else(|err| panic!("expected {:?} to format, but: {}", text, err))
+  }
+
+  /// Asserts the html is left to be written out as it was.
+  #[track_caller]
+  fn assert_kept(text: &str) {
+    let result = format_html(
+      text,
+      &HtmlFormatOptions {
+        line_width: 80,
+        use_tabs: false,
+        indent_width: 2,
+        self_closing_space: true,
+      },
+    );
+    assert!(result.is_err(), "expected {:?} to be kept, but got {:?}", text, result);
+  }
+
+  // ==== indentation ====
+
+  #[test]
+  fn indents_nested_blocks() {
+    assert_format("<div><p>a</p></div>", "<div>\n  <p>a</p>\n</div>");
+  }
+
+  #[test]
+  fn reindents_blocks_that_were_written_flat() {
+    assert_format(
+      "<table>\n<tr><td>a</td><td>b</td></tr>\n</table>",
+      "<table>\n  <tr>\n    <td>a</td>\n    <td>b</td>\n  </tr>\n</table>",
+    );
+  }
+
+  #[test]
+  fn reindents_blocks_that_were_over_indented() {
+    assert_format(
+      "<div>\n        <p>a</p>\n            <p>b</p>\n</div>",
+      "<div>\n  <p>a</p>\n  <p>b</p>\n</div>",
+    );
+  }
+
+  #[test]
+  fn keeps_a_block_with_short_inline_content_on_one_line() {
+    assert_format("<p>a</p>", "<p>a</p>");
+    assert_format("<div><span>a</span></div>", "<div><span>a</span></div>");
+  }
+
+  #[test]
+  fn drops_the_whitespace_at_the_edges_of_block_content() {
+    assert_format("<div>   <p>a</p>   </div>", "<div>\n  <p>a</p>\n</div>");
+    assert_format("<p>   a   </p>", "<p>a</p>");
+  }
+
+  #[test]
+  fn indents_deeply_nested_blocks() {
+    assert_format(
+      "<div><section><article><p>a</p></article></section></div>",
+      "<div>\n  <section>\n    <article>\n      <p>a</p>\n    </article>\n  </section>\n</div>",
+    );
+  }
+
+  // ==== whitespace ====
+
+  #[test]
+  fn keeps_the_whitespace_around_an_inline_element() {
+    assert_format("<p>some <em>text</em> here</p>", "<p>some <em>text</em> here</p>");
+    assert_format("<p>a<em>b</em>c</p>", "<p>a<em>b</em>c</p>");
+  }
+
+  #[test]
+  fn collapses_a_run_of_whitespace_to_the_space_it_renders_as() {
+    assert_format("<p>a     b</p>", "<p>a b</p>");
+    assert_format("<p>a \t  b</p>", "<p>a b</p>");
+  }
+
+  #[test]
+  fn keeps_a_line_break_the_author_wrote() {
+    assert_format("<p>a\nb</p>", "<p>\n  a\n  b\n</p>");
+  }
+
+  #[test]
+  fn keeps_the_whitespace_between_two_inline_elements() {
+    assert_format(
+      "<p><span>a</span> <span>b</span></p>",
+      "<p><span>a</span> <span>b</span></p>",
+    );
+    assert_format(
+      "<p><span>a</span><span>b</span></p>",
+      "<p><span>a</span><span>b</span></p>",
+    );
+  }
+
+  #[test]
+  fn treats_an_unknown_element_as_inline() {
+    assert_format(
+      "<p>a <my-widget>b</my-widget> c</p>",
+      "<p>a <my-widget>b</my-widget> c</p>",
+    );
+  }
+
+  // ==== an element whose content spans lines ====
+
+  #[test]
+  fn lays_out_an_inline_element_that_spans_lines() {
+    // the author wrote whitespace at both edges, so a line break can be put at
+    // either without adding one that renders
+    assert_format(
+      "<div><a href=\"x\">\n<b>b</b>\ntext\n</a></div>",
+      "<div>\n  <a href=\"x\">\n    <b>b</b>\n    text\n  </a>\n</div>",
+    );
+  }
+
+  #[test]
+  fn only_breaks_an_inline_edge_that_was_written_with_whitespace() {
+    // no whitespace after the open tag, so the content stays beside it -- a
+    // line break there would render as a space the author didn't write
+    assert_format(
+      "<div><a href=\"x\">Get started\n<b>b</b>\n</a></div>",
+      "<div>\n  <a href=\"x\">Get started\n    <b>b</b>\n  </a>\n</div>",
+    );
+    // and none at either edge, so neither can be broken
+    assert_format(
+      "<div><a href=\"x\">Get started\n<b>b</b></a></div>",
+      "<div>\n  <a href=\"x\">Get started\n    <b>b</b></a>\n</div>",
+    );
+  }
+
+  #[test]
+  fn indents_the_content_of_a_nested_inline_element() {
+    assert_format(
+      "<div><p>\n<a href=\"x\">\n<b>b</b>\n</a>\n</p></div>",
+      "<div>\n  <p>\n    <a href=\"x\">\n      <b>b</b>\n    </a>\n  </p>\n</div>",
+    );
+  }
+
+  #[test]
+  fn does_not_break_an_inline_element_that_fits() {
+    assert_format(
+      "<div><p>a <em>b</em> c</p></div>",
+      "<div>\n  <p>a <em>b</em> c</p>\n</div>",
+    );
+  }
+
+  // ==== content that is kept byte for byte ====
+
+  #[test]
+  fn keeps_the_content_of_a_preformatted_element() {
+    assert_format("<pre>  a   b\n   c  </pre>", "<pre>  a   b\n   c  </pre>");
+    assert_format("<div><pre>  a  </pre></div>", "<div>\n  <pre>  a  </pre>\n</div>");
+  }
+
+  #[test]
+  fn keeps_the_tags_written_within_a_preformatted_element() {
+    let text = "<pre>
+<a href=\"https://example.com\">a</a>
+</pre>";
+    assert_format(text, text);
+    assert_format("<pre><b>a</b>  <i>b</i></pre>", "<pre><b>a</b>  <i>b</i></pre>");
+  }
+
+  #[test]
+  fn keeps_the_content_of_a_raw_text_element() {
+    assert_format("<script>const a = 1</script>", "<script>const a = 1</script>");
+    assert_format(
+      "<style>.a {   color: red }</style>",
+      "<style>.a {   color: red }</style>",
+    );
+  }
+
+  #[test]
+  fn reads_markup_within_a_raw_text_element_as_text() {
+    assert_format("<script>if (a < b) { }</script>", "<script>if (a < b) { }</script>");
+    let quoted_close = "<script>const a = \"</div>\"</script>";
+    assert_format(quoted_close, quoted_close);
+  }
+
+  #[test]
+  fn keeps_a_comment_as_it_was_written() {
+    assert_format("<!-- a comment -->", "<!-- a comment -->");
+    assert_format(
+      "<div>\n<!--   spaced   -->\n<p>a</p>\n</div>",
+      "<div>\n  <!--   spaced   -->\n  <p>a</p>\n</div>",
+    );
+  }
+
+  #[test]
+  fn keeps_a_doctype_cdata_and_processing_instruction() {
+    assert_format("<!DOCTYPE html>", "<!DOCTYPE html>");
+    assert_format("<p><![CDATA[ a < b ]]></p>", "<p><![CDATA[ a < b ]]></p>");
+    assert_format("<p><?php echo 1; ?></p>", "<p><?php echo 1; ?></p>");
+  }
+
+  // ==== tags ====
+
+  #[test]
+  fn keeps_the_case_a_tag_was_written_in() {
+    assert_format("<DIV><P>a</P></DIV>", "<DIV>\n  <P>a</P>\n</DIV>");
+  }
+
+  #[test]
+  fn writes_a_void_element_the_way_it_was_written() {
+    assert_format("<br>", "<br>");
+    assert_format("<br />", "<br />");
+    assert_format("<img src=\"a.png\">", "<img src=\"a.png\">");
+  }
+
+  #[test]
+  fn writes_the_space_before_a_self_closing_slash_the_way_the_option_says() {
+    let without_space = |text: &str| {
+      format_html(
+        text,
+        &HtmlFormatOptions {
+          line_width: 80,
+          use_tabs: false,
+          indent_width: 2,
+          self_closing_space: false,
+        },
+      )
+      .unwrap()
+    };
+    // on by default, so a tag is written the one way however it was written
+    assert_format("<br/>", "<br />");
+    assert_format("<br />", "<br />");
+    assert_format("<svg><circle cx=\"1\"/></svg>", "<svg><circle cx=\"1\" /></svg>");
+    // and off, the other way
+    assert_eq!(without_space("<br />"), "<br/>");
+    assert_eq!(without_space("<br/>"), "<br/>");
+    assert_eq!(
+      without_space("<svg><circle cx=\"1\" /></svg>"),
+      "<svg><circle cx=\"1\"/></svg>"
+    );
+  }
+
+  #[test]
+  fn reads_a_self_closing_tag_within_svg() {
+    assert_format("<svg><circle cx=\"1\" /></svg>", "<svg><circle cx=\"1\" /></svg>");
+  }
+
+  #[test]
+  fn keeps_an_empty_element_on_one_line() {
+    assert_format("<div></div>", "<div></div>");
+    assert_format("<div><p></p></div>", "<div>\n  <p></p>\n</div>");
+  }
+
+  // ==== attributes ====
+
+  #[test]
+  fn quotes_a_value_that_was_written_without_quotes() {
+    assert_format("<a href=foo>a</a>", "<a href=\"foo\">a</a>");
+  }
+
+  #[test]
+  fn keeps_the_quote_a_value_was_written_with() {
+    assert_format("<a href='foo'>a</a>", "<a href='foo'>a</a>");
+    assert_format("<a title='say \"hi\"'>a</a>", "<a title='say \"hi\"'>a</a>");
+  }
+
+  #[test]
+  fn writes_an_attribute_that_has_no_value() {
+    assert_format("<input disabled>", "<input disabled>");
+    assert_format(
+      "<button disabled type=\"submit\">a</button>",
+      "<button disabled type=\"submit\">a</button>",
+    );
+  }
+
+  #[test]
+  fn keeps_an_attribute_value_byte_for_byte() {
+    assert_format("<div title=\"a    b\">x</div>", "<div title=\"a    b\">x</div>");
+  }
+
+  #[test]
+  fn breaks_a_long_list_of_attributes_onto_lines_of_their_own() {
+    assert_format(
+      "<div class=\"one two three four five six\" id=\"the-identifier\" data-value=\"something long\">a</div>",
+      "<div\n  class=\"one two three four five six\"\n  id=\"the-identifier\"\n  data-value=\"something long\"\n>a</div>",
+    );
+  }
+
+  #[test]
+  fn only_lays_out_the_attributes_of_a_tag_that_starts_its_line() {
+    // the svg is written partway along a line its siblings are sharing, so
+    // taking its tag apart there would read worse than leaving the line long
+    let span = "<span class=\"ic\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"></svg></span>";
+    assert_eq!(
+      format_with_width(&format!("<div>{}</div>", span), 40),
+      format!("<div>\n  {}\n</div>", span),
+    );
+    // on a line of its own it has the room
+    assert_eq!(
+      format_with_width("<div viewBox=\"0 0 24 24\" fill=\"none\"><p>a</p></div>", 20),
+      "<div\n  viewBox=\"0 0 24 24\"\n  fill=\"none\"\n>\n  <p>a</p>\n</div>",
+    );
+  }
+
+  #[test]
+  fn keeps_a_lone_attribute_on_the_line_its_tag_is_on() {
+    // there is nowhere better for it to go, so a long list of classes is left
+    // where it was written rather than being pushed onto a line of its own
+    let long = "flex items-center justify-between rounded-lg border px-4 py-2 text-sm font-medium shadow";
+    assert_format(
+      &format!("<div class=\"{}\">a</div>", long),
+      &format!("<div class=\"{}\">\n  a\n</div>", long),
+    );
+  }
+
+  // ==== html that is left as it was written ====
+
+  #[test]
+  fn keeps_an_element_that_was_never_closed() {
+    assert_kept("<div align=\"center\">");
+    assert_kept("<div><p>a</p>");
+  }
+
+  #[test]
+  fn keeps_a_closing_tag_that_closes_nothing() {
+    assert_kept("</div>");
+    assert_kept("<p>a</p></div>");
+  }
+
+  #[test]
+  fn keeps_tags_that_dont_match() {
+    assert_kept("<div><p>a</div></p>");
+  }
+
+  #[test]
+  fn keeps_html_that_leaves_a_closing_tag_to_be_inferred() {
+    assert_kept("<ul><li>a<li>b</ul>");
+  }
+
+  #[test]
+  fn keeps_a_self_closing_tag_that_a_browser_reads_as_an_opening_one() {
+    assert_kept("<div/>");
+    assert_kept("<span/>a</span>");
+  }
+
+  #[test]
+  fn keeps_markup_that_was_never_terminated() {
+    assert_kept("<!-- a comment");
+    assert_kept("<p title=\"a</p>");
+  }
+
+  // ==== text that only looks like markup ====
+
+  #[test]
+  fn reads_an_angle_bracket_that_opens_no_tag_as_text() {
+    assert_format("<p>a < b</p>", "<p>a < b</p>");
+    assert_format("<p>1 <2</p>", "<p>1 <2</p>");
+  }
+
+  // ==== line width ====
+
+  #[test]
+  fn breaks_content_that_runs_past_the_line_width() {
+    assert_eq!(
+      format_with_width(
+        "<div><span>this content is long enough that it will not fit</span></div>",
+        40
+      ),
+      "<div>\n  <span>this content is long enough that it will not fit</span>\n</div>",
+    );
+  }
+
+  #[test]
+  fn keeps_content_that_fits_on_the_line_it_is_on() {
+    assert_eq!(
+      format_with_width("<div><span>a</span></div>", 40),
+      "<div><span>a</span></div>"
+    );
+  }
+
+  // ==== text the printer must not touch ====
+
+  #[test]
+  fn keeps_a_character_entity_as_it_was_written() {
+    assert_format("<p>a &amp; b &#38; c</p>", "<p>a &amp; b &#38; c</p>");
+    assert_format("<p>&nbsp;&nbsp;</p>", "<p>&nbsp;&nbsp;</p>");
+  }
+
+  #[test]
+  fn does_not_collapse_a_no_break_space() {
+    // it isn't whitespace a browser collapses, so it is text like any other
+    assert_format("<p>a\u{a0}\u{a0}b</p>", "<p>a\u{a0}\u{a0}b</p>");
+  }
+
+  #[test]
+  fn keeps_an_attribute_value_written_across_lines() {
+    assert_format(
+      "<div class=\"one\n  two\" id=\"b\"><p>a</p></div>",
+      "<div class=\"one\n  two\" id=\"b\">\n  <p>a</p>\n</div>",
+    );
+  }
+
+  #[test]
+  fn keeps_a_comment_holding_text_that_looks_like_markup() {
+    assert_format("<!-- <div> not a tag -->", "<!-- <div> not a tag -->");
+  }
+
+  // ==== whitespace within a run ====
+
+  #[test]
+  fn collapses_a_tab_the_way_a_browser_does() {
+    assert_format("<p>a\t\tb</p>", "<p>a b</p>");
+  }
+
+  #[test]
+  fn keeps_a_void_element_within_a_run_of_text() {
+    assert_format("<p>a<br>b</p>", "<p>a<br>b</p>");
+    assert_format("<p>a <br> b</p>", "<p>a <br> b</p>");
+  }
+
+  #[test]
+  fn lays_out_a_run_that_holds_a_block_beside_it() {
+    assert_format(
+      "<div>text before<p>a</p>text after</div>",
+      "<div>\n  text before\n  <p>a</p>\n  text after\n</div>",
+    );
+  }
+
+  // ==== measuring ====
+
+  #[test]
+  fn measures_a_wide_character_by_the_room_it_takes() {
+    // each of these takes two columns, so the content is 40 columns wide and
+    // doesn't fit beside the tags within a width of 30
+    let wide = "\u{6f22}".repeat(20);
+    assert_eq!(
+      format_with_width(&format!("<div><span>{}</span></div>", wide), 30),
+      format!("<div>\n  <span>{}</span>\n</div>", wide),
+    );
+  }
+
+  #[test]
+  fn lays_out_a_deeply_nested_tree() {
+    assert_format(
+      "<div><section><ul><li><p>a <em>b</em> c</p></li></ul></section></div>",
+      "<div>\n  <section>\n    <ul>\n      <li>\n        <p>a <em>b</em> c</p>\n      </li>\n    </ul>\n  </section>\n</div>",
+    );
+  }
+}

--- a/src/html/spec_test.rs
+++ b/src/html/spec_test.rs
@@ -1,0 +1,216 @@
+//! The html parser's spec tests, which pair html text with the json of the ast
+//! it should parse into.
+//!
+//! The files live under `tests/html_parser_specs` and hold any number of
+//! cases, written the same way the markdown parser's are:
+//!
+//! ```
+//! [[test]] a name for the case
+//! <p>some html</p>
+//! [[ast]]
+//! { ...the expected ast... }
+//! ```
+//!
+//! A case written as `[[test:crlf]]` has its line endings turned into `\r\n`
+//! before it's parsed, since the files themselves are kept with `\n` endings.
+//! A case whose html the parser refuses is written with the reason in place of
+//! the ast, which is how the html that is left as it was gets its own cases.
+//!
+//! Every case is also checked against the invariants an ast holds whatever the
+//! expectation says: that each node was parsed from within its parent, and
+//! that the children of a node account for every byte of it (see
+//! [`validate_coverage`]). Nothing may be read and then dropped, because the
+//! formatter has to be able to write back out everything that was read.
+//!
+//! `tests/html_parser_spec_test.rs` is what runs these.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use super::ast::Document;
+use super::ast::Node;
+use super::debug_json::offset_in;
+use super::debug_json::to_json;
+
+/// Reads the case through the parser, giving back the json of the ast it holds
+/// along with whatever it fails of the invariants every ast holds.
+pub fn run_case(case: &SpecCase) -> CaseOutcome {
+  let source = case.source();
+  let document = match super::parser::parse(&source) {
+    Ok(document) => document,
+    // html the parser refuses isn't a failure: an html block in markdown is
+    // very often a fragment, and refusing it is what leaves it as it was
+    Err(err) => {
+      return CaseOutcome {
+        actual: format!("[[refused]] {}\n", err),
+        failures: Vec::new(),
+      }
+    }
+  };
+  let mut failures = Vec::new();
+  if let Err(message) = validate_coverage(&document, &source) {
+    failures.push(message);
+  }
+  CaseOutcome {
+    actual: to_json(&document, &source),
+    failures,
+  }
+}
+
+pub struct CaseOutcome {
+  /// The json of the ast the case parsed into, or why the parser refused it.
+  pub actual: String,
+  /// What the ast failed of the invariants every one of them holds.
+  pub failures: Vec<String>,
+}
+
+pub struct SpecCase {
+  pub name: String,
+  pub input: String,
+  pub expected: String,
+  /// Whether the input is fed to the parser with `\r\n` line endings.
+  pub crlf: bool,
+}
+
+impl SpecCase {
+  pub fn source(&self) -> String {
+    if self.crlf {
+      self.input.replace('\n', "\r\n")
+    } else {
+      self.input.clone()
+    }
+  }
+
+  pub fn header(&self) -> String {
+    let marker = if self.crlf { "[[test:crlf]]" } else { "[[test]]" };
+    format!("{} {}", marker, self.name)
+  }
+}
+
+/// Checks that the ast accounts for every byte of the html it was parsed from.
+///
+/// The children of a node run in order and butt up against one another, from
+/// the first byte of what holds them to the last, so there is nowhere for text
+/// to have been read and then dropped. That is what makes the ast something
+/// the printer can write back out without losing anything.
+pub fn validate_coverage(document: &Document<'_>, source: &str) -> Result<(), String> {
+  tile("the document", &document.children, source, 0, source.len(), source)
+}
+
+fn tile(
+  within: &str,
+  children: &[Node<'_>],
+  content: &str,
+  start: usize,
+  end: usize,
+  source: &str,
+) -> Result<(), String> {
+  if children.is_empty() {
+    return if start == end {
+      Ok(())
+    } else {
+      Err(format!("{} holds no children but covers {:?}", within, content))
+    };
+  }
+
+  let mut position = start;
+  for child in children {
+    let text = child.source();
+    let child_start = offset_in(text, source);
+    if child_start != position {
+      return Err(format!(
+        "{}: the {} at {} doesn't start where the one before it ended, at {}",
+        within,
+        child.kind(),
+        child_start,
+        position,
+      ));
+    }
+    if !source.is_char_boundary(child_start) || !source.is_char_boundary(child_start + text.len()) {
+      return Err(format!(
+        "{}: the {} at {} splits a character",
+        within,
+        child.kind(),
+        child_start
+      ));
+    }
+    position = child_start + text.len();
+
+    if let Node::Element(element) = child {
+      if element.content.is_empty() && element.children.is_empty() {
+        continue;
+      }
+      let content_start = offset_in(element.content, source);
+      let name = format!("`<{}>` at {}", element.name, child_start);
+      tile(
+        &name,
+        &element.children,
+        element.content,
+        content_start,
+        content_start + element.content.len(),
+        source,
+      )?;
+    }
+  }
+
+  if position != end {
+    return Err(format!(
+      "{}: the children stop at {} but what holds them runs to {}",
+      within, position, end
+    ));
+  }
+  Ok(())
+}
+
+pub fn parse_spec_file(file_text: &str, path: &Path) -> Vec<SpecCase> {
+  let mut cases = Vec::new();
+  let mut lines = file_text.lines().peekable();
+
+  while let Some(line) = lines.next() {
+    let (crlf, name) = match line.strip_prefix("[[test:crlf]]") {
+      Some(name) => (true, Some(name)),
+      None => (false, line.strip_prefix("[[test]]")),
+    };
+    let Some(name) = name else {
+      assert!(
+        line.trim().is_empty(),
+        "unexpected text outside of a test case in {}: {}",
+        path.display(),
+        line
+      );
+      continue;
+    };
+
+    let mut input = String::new();
+    let mut found_ast = false;
+    for line in lines.by_ref() {
+      if line == "[[ast]]" {
+        found_ast = true;
+        break;
+      }
+      input.push_str(line);
+      input.push('\n');
+    }
+    assert!(found_ast, "missing [[ast]] in {} for {}", path.display(), name.trim());
+    // the newline before the `[[ast]]` marker isn't part of the input
+    input.pop();
+
+    let mut expected = String::new();
+    while let Some(line) = lines.peek() {
+      if line.starts_with("[[test]]") || line.starts_with("[[test:") {
+        break;
+      }
+      expected.push_str(lines.next().unwrap());
+      expected.push('\n');
+    }
+
+    cases.push(SpecCase {
+      name: name.trim().to_string(),
+      input,
+      expected,
+      crlf,
+    });
+  }
+
+  cases
+}

--- a/src/html/tags.rs
+++ b/src/html/tags.rs
@@ -1,0 +1,155 @@
+//! The tag name tables the parser and printer look elements up in.
+//!
+//! Each table is written in the order `binary_search` needs and compared
+//! without case, because a tag name may be written in any case at all.
+
+/// Whether the element is written with no closing tag and can hold no content.
+pub fn is_void(name: &str) -> bool {
+  contains(&VOID_TAGS, name)
+}
+
+/// Whether the element's content is character data rather than markup, which
+/// means it runs to the element's closing tag no matter what is written in it.
+pub fn is_raw_text(name: &str) -> bool {
+  contains(&RAW_TEXT_TAGS, name)
+}
+
+/// Whether the whitespace within the element is rendered as it was written,
+/// which means the printer has to leave the content exactly as it is.
+pub fn is_preformatted(name: &str) -> bool {
+  contains(&PREFORMATTED_TAGS, name)
+}
+
+/// Whether the element is laid out as a block, where the whitespace at the
+/// start and end of its content isn't rendered.
+///
+/// Everything else is treated as being laid out inline, which is both what the
+/// spec says an unknown element is and the careful assumption to make: the
+/// whitespace around an inline element is rendered, so the printer has to keep
+/// it as it was written.
+pub fn is_block(name: &str) -> bool {
+  contains(&BLOCK_TAGS, name)
+}
+
+/// Whether the element's content is svg or mathml rather than html, where a
+/// self-closing tag closes the element it's written on.
+pub fn is_foreign_root(name: &str) -> bool {
+  name.eq_ignore_ascii_case("svg") || name.eq_ignore_ascii_case("math")
+}
+
+fn contains(tags: &[&str], name: &str) -> bool {
+  tags.binary_search_by(|tag| compare_tag_name(tag, name)).is_ok()
+}
+
+fn compare_tag_name(tag: &str, name: &str) -> std::cmp::Ordering {
+  tag
+    .bytes()
+    .map(|b| b.to_ascii_lowercase())
+    .cmp(name.bytes().map(|b| b.to_ascii_lowercase()))
+}
+
+const VOID_TAGS: [&str; 18] = [
+  "area", "base", "basefont", "br", "col", "embed", "frame", "hr", "img", "input", "isindex", "keygen", "link", "meta",
+  "param", "source", "track", "wbr",
+];
+
+const RAW_TEXT_TAGS: [&str; 4] = ["script", "style", "textarea", "title"];
+
+const PREFORMATTED_TAGS: [&str; 4] = ["listing", "plaintext", "pre", "textarea"];
+
+const BLOCK_TAGS: [&str; 58] = [
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "body",
+  "caption",
+  "center",
+  "col",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "hr",
+  "html",
+  "legend",
+  "li",
+  "main",
+  "menu",
+  "nav",
+  "ol",
+  "optgroup",
+  "option",
+  "p",
+  "pre",
+  "script",
+  "search",
+  "section",
+  "style",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "tr",
+  "ul",
+];
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn tables_are_sorted_for_binary_search() {
+    for table in [
+      &VOID_TAGS[..],
+      &RAW_TEXT_TAGS[..],
+      &PREFORMATTED_TAGS[..],
+      &BLOCK_TAGS[..],
+    ] {
+      let mut sorted = table.to_vec();
+      sorted.sort();
+      assert_eq!(table, sorted, "table is not in sorted order");
+    }
+  }
+
+  #[test]
+  fn looks_tags_up_without_case() {
+    assert!(is_void("BR"));
+    assert!(is_void("Img"));
+    assert!(!is_void("div"));
+    assert!(is_raw_text("SCRIPT"));
+    assert!(is_block("DIV"));
+    assert!(!is_block("span"));
+    assert!(is_preformatted("Pre"));
+  }
+
+  #[test]
+  fn treats_an_unknown_element_as_inline() {
+    assert!(!is_block("my-widget"));
+    assert!(!is_block("Foo"));
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod configuration;
 mod format_text;
 mod generation;
+mod html;
 mod parser;
 
 pub use format_text::format_text;

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -1269,11 +1269,21 @@ fn footnote_definition_name(text: &str) -> Option<&str> {
 }
 
 /// What ends an html block.
+#[derive(PartialEq, Eq)]
 enum HtmlBlockKind {
   /// The line containing the given text.
   Closes(Cow<'static, str>),
   /// The next blank line.
   BlankLine,
+}
+
+/// Whether two lines start the same kind of html block.
+///
+/// Text can only be written back out differently where this holds of the line
+/// it starts on: a line that stops starting an html block, or starts one that
+/// ends somewhere else, leaves the rest of the block to be read as markdown.
+pub fn starts_same_html_block(before: &str, after: &str) -> bool {
+  html_block_kind(before, false) == html_block_kind(after, false)
 }
 
 /// The html block the text starts, if any. Blocks that consist of a single

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -28,6 +28,7 @@ pub use block::block_start_escape;
 pub use block::line_start_escape;
 pub use block::starts_block_at_block_start;
 pub use block::starts_block_in_paragraph;
+pub use block::starts_same_html_block;
 pub use source::SPACES;
 pub use source::WHITESPACE;
 

--- a/tests/html_parser_spec_test.rs
+++ b/tests/html_parser_spec_test.rs
@@ -1,0 +1,88 @@
+//! Runs the html parser's spec tests, one per file under
+//! `tests/html_parser_specs`, with a sub test for each case the file holds.
+//! See [`html::spec_test`] for what a case looks like and what is checked of
+//! it.
+//!
+//! Set `UPDATE=1` to rewrite the files with what the parser currently
+//! produces, which is how a new case is filled in. Always read the result
+//! before committing it.
+
+// the html parser is not part of what the crate hands out, so the tests that
+// read its ast are built with it rather than against it
+#[path = "../src/html/mod.rs"]
+#[allow(unused_imports, dead_code)]
+mod html;
+
+use std::path::PathBuf;
+
+use file_test_runner::collect_and_run_tests;
+use file_test_runner::collection::strategies::TestPerFileCollectionStrategy;
+use file_test_runner::collection::CollectOptions;
+use file_test_runner::RunOptions;
+use file_test_runner::TestResult;
+
+use html::spec_test::parse_spec_file;
+use html::spec_test::run_case;
+use html::spec_test::SpecCase;
+
+fn main() {
+  collect_and_run_tests(
+    CollectOptions {
+      base: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/html_parser_specs"),
+      strategy: Box::new(TestPerFileCollectionStrategy { file_pattern: None }),
+      filter_override: None,
+    },
+    RunOptions::default(),
+    run_file,
+  );
+}
+
+fn run_file(test: &file_test_runner::collection::CollectedTest) -> TestResult {
+  let path = test.path.clone();
+  TestResult::from_maybe_panic(move || {
+    let file_text = std::fs::read_to_string(&path).unwrap().replace("\r\n", "\n");
+    let cases = parse_spec_file(&file_text, &path);
+    assert!(!cases.is_empty(), "no cases in {}", path.display());
+
+    if std::env::var("UPDATE").is_ok() {
+      let updated = cases
+        .iter()
+        .map(|case| {
+          let outcome = run_case(case);
+          assert!(
+            outcome.failures.is_empty(),
+            "{}: {}",
+            case.name,
+            outcome.failures.join("\n")
+          );
+          format!("{}\n{}\n[[ast]]\n{}", case.header(), case.input, outcome.actual)
+        })
+        .collect::<String>();
+      std::fs::write(&path, updated).unwrap();
+      return;
+    }
+
+    let failures = cases.iter().filter_map(check_case).collect::<Vec<_>>();
+    assert!(
+      failures.is_empty(),
+      "{} of {} cases failed:\n\n{}\n\nRe-run with UPDATE=1 to accept the new output.",
+      failures.len(),
+      cases.len(),
+      failures.join("\n\n"),
+    );
+  })
+}
+
+fn check_case(case: &SpecCase) -> Option<String> {
+  let outcome = run_case(case);
+  if !outcome.failures.is_empty() {
+    return Some(format!("case: {}\n  {}", case.name, outcome.failures.join("\n  ")));
+  }
+  if outcome.actual != case.expected {
+    return Some(format!(
+      "case: {}\n  --- expected ---\n{}\n  --- actual ---\n{}",
+      case.name, case.expected, outcome.actual,
+    ));
+  }
+  None
+}

--- a/tests/html_parser_specs/attributes.txt
+++ b/tests/html_parser_specs/attributes.txt
@@ -1,0 +1,347 @@
+[[test]] a double quoted value
+<a href="foo">x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 19],
+      "text": "<a href=\"foo\">x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "href",
+          "value": "foo",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a single quoted value
+<a href='foo'>x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 19],
+      "text": "<a href='foo'>x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "href",
+          "value": "foo",
+          "quote": "'"
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an unquoted value
+<a href=foo>x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 17],
+      "text": "<a href=foo>x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "href",
+          "value": "foo",
+          "quoted": false
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an attribute with no value
+<input disabled>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 16],
+      "text": "<input disabled>",
+      "name": "input",
+      "elementKind": "Void",
+      "attributes": [
+        {
+          "name": "disabled"
+        }
+      ]
+    }
+  ]
+}
+[[test]] several attributes
+<div class="a" id="b" hidden>x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 36],
+      "text": "<div class=\"a\" id=\"b\" hidden>x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "a",
+          "quote": "\""
+        },
+        {
+          "name": "id",
+          "value": "b",
+          "quote": "\""
+        },
+        {
+          "name": "hidden"
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [29, 30],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a value holding the other quote
+<a title='say "hi"'>x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 25],
+      "text": "<a title='say \"hi\"'>x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "title",
+          "value": "say \"hi\"",
+          "quote": "'"
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [20, 21],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an empty value
+<div class="">x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 21],
+      "text": "<div class=\"\">x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] attributes written across lines
+<div
+  class="a"
+  id="b"
+>x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 34],
+      "text": "<div\n  class=\"a\"\n  id=\"b\"\n>x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "a",
+          "quote": "\""
+        },
+        {
+          "name": "id",
+          "value": "b",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [27, 28],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a value holding a line break
+<div class="one
+  two">x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 30],
+      "text": "<div class=\"one\n  two\">x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "one\n  two",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [23, 24],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] framework attribute names
+<div @click="a" :value="b" v-if="c">x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 43],
+      "text": "<div @click=\"a\" :value=\"b\" v-if=\"c\">x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "@click",
+          "value": "a",
+          "quote": "\""
+        },
+        {
+          "name": ":value",
+          "value": "b",
+          "quote": "\""
+        },
+        {
+          "name": "v-if",
+          "value": "c",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [36, 37],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] whitespace around the equals sign
+<a href = "foo">x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 21],
+      "text": "<a href = \"foo\">x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "href",
+          "value": "foo",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [16, 17],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/comments_and_declarations.txt
+++ b/tests/html_parser_specs/comments_and_declarations.txt
@@ -1,0 +1,174 @@
+[[test]] a comment
+<!-- a comment -->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 18],
+      "text": "<!-- a comment -->"
+    }
+  ]
+}
+[[test]] a comment across lines
+<!--
+a
+-->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 10],
+      "text": "<!--\na\n-->"
+    }
+  ]
+}
+[[test]] a comment holding what looks like a tag
+<!-- <div> not a tag -->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 24],
+      "text": "<!-- <div> not a tag -->"
+    }
+  ]
+}
+[[test]] a comment between elements
+<div><!-- a --><p>b</p></div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 29],
+      "text": "<div><!-- a --><p>b</p></div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "<!-- a --><p>b</p>",
+      "children": [
+        {
+          "kind": "Comment",
+          "span": [5, 15],
+          "text": "<!-- a -->"
+        },
+        {
+          "kind": "Element",
+          "span": [15, 23],
+          "text": "<p>b</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "b",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [18, 19],
+              "text": "b"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a doctype
+<!DOCTYPE html>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Doctype",
+      "span": [0, 15],
+      "text": "<!DOCTYPE html>"
+    }
+  ]
+}
+[[test]] a processing instruction
+<?php echo 1; ?>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "ProcessingInstruction",
+      "span": [0, 16],
+      "text": "<?php echo 1; ?>"
+    }
+  ]
+}
+[[test]] a cdata section
+<![CDATA[ a < b ]]>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "CData",
+      "span": [0, 19],
+      "text": "<![CDATA[ a < b ]]>"
+    }
+  ]
+}
+[[test]] an ignore comment within an element
+<div>
+<!-- dprint-ignore -->
+<p>a</p>
+</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 44],
+      "text": "<div>\n<!-- dprint-ignore -->\n<p>a</p>\n</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "\n<!-- dprint-ignore -->\n<p>a</p>\n",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [5, 6],
+          "text": "\n"
+        },
+        {
+          "kind": "Comment",
+          "span": [6, 28],
+          "text": "<!-- dprint-ignore -->"
+        },
+        {
+          "kind": "Text",
+          "span": [28, 29],
+          "text": "\n"
+        },
+        {
+          "kind": "Element",
+          "span": [29, 37],
+          "text": "<p>a</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [32, 33],
+              "text": "a"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [37, 38],
+          "text": "\n"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/crlf.txt
+++ b/tests/html_parser_specs/crlf.txt
@@ -1,0 +1,98 @@
+[[test:crlf]] an element written across lines
+<div>
+  <p>a</p>
+</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 25],
+      "text": "<div>\r\n  <p>a</p>\r\n</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "\r\n  <p>a</p>\r\n",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [5, 9],
+          "text": "\r\n  "
+        },
+        {
+          "kind": "Element",
+          "span": [9, 17],
+          "text": "<p>a</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [12, 13],
+              "text": "a"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [17, 19],
+          "text": "\r\n"
+        }
+      ]
+    }
+  ]
+}
+[[test:crlf]] attributes written across lines
+<div
+  class="a"
+  id="b"
+>x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 37],
+      "text": "<div\r\n  class=\"a\"\r\n  id=\"b\"\r\n>x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "a",
+          "quote": "\""
+        },
+        {
+          "name": "id",
+          "value": "b",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [30, 31],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test:crlf]] a comment across lines
+<!--
+a
+-->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 12],
+      "text": "<!--\r\na\r\n-->"
+    }
+  ]
+}

--- a/tests/html_parser_specs/elements.txt
+++ b/tests/html_parser_specs/elements.txt
@@ -1,0 +1,314 @@
+[[test]] an element and its text
+<p>a</p>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 8],
+      "text": "<p>a</p>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [3, 4],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] nested elements
+<div><p>a</p></div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 19],
+      "text": "<div><p>a</p></div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "<p>a</p>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 13],
+          "text": "<p>a</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [8, 9],
+              "text": "a"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] siblings with text between them
+<p>a</p> <p>b</p>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 8],
+      "text": "<p>a</p>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [3, 4],
+          "text": "a"
+        }
+      ]
+    },
+    {
+      "kind": "Text",
+      "span": [8, 9],
+      "text": " "
+    },
+    {
+      "kind": "Element",
+      "span": [9, 17],
+      "text": "<p>b</p>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "b",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an empty element
+<div></div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 11],
+      "text": "<div></div>",
+      "name": "div",
+      "elementKind": "Normal"
+    }
+  ]
+}
+[[test]] a closing tag matched without case
+<DIV>a</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 12],
+      "text": "<DIV>a</div>",
+      "name": "DIV",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [5, 6],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] text around an element
+before <b>bold</b> after
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 7],
+      "text": "before "
+    },
+    {
+      "kind": "Element",
+      "span": [7, 18],
+      "text": "<b>bold</b>",
+      "name": "b",
+      "elementKind": "Normal",
+      "content": "bold",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [10, 14],
+          "text": "bold"
+        }
+      ]
+    },
+    {
+      "kind": "Text",
+      "span": [18, 24],
+      "text": " after"
+    }
+  ]
+}
+[[test]] an element written across lines
+<div>
+  <p>a</p>
+</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 23],
+      "text": "<div>\n  <p>a</p>\n</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "\n  <p>a</p>\n",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [5, 8],
+          "text": "\n  "
+        },
+        {
+          "kind": "Element",
+          "span": [8, 16],
+          "text": "<p>a</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [11, 12],
+              "text": "a"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [16, 17],
+          "text": "\n"
+        }
+      ]
+    }
+  ]
+}
+[[test]] deeply nested elements
+<section><article><ul><li>a</li></ul></article></section>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 57],
+      "text": "<section><article><ul><li>a</li></ul></article></section>",
+      "name": "section",
+      "elementKind": "Normal",
+      "content": "<article><ul><li>a</li></ul></article>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [9, 47],
+          "text": "<article><ul><li>a</li></ul></article>",
+          "name": "article",
+          "elementKind": "Normal",
+          "content": "<ul><li>a</li></ul>",
+          "children": [
+            {
+              "kind": "Element",
+              "span": [18, 37],
+              "text": "<ul><li>a</li></ul>",
+              "name": "ul",
+              "elementKind": "Normal",
+              "content": "<li>a</li>",
+              "children": [
+                {
+                  "kind": "Element",
+                  "span": [22, 32],
+                  "text": "<li>a</li>",
+                  "name": "li",
+                  "elementKind": "Normal",
+                  "content": "a",
+                  "children": [
+                    {
+                      "kind": "Text",
+                      "span": [26, 27],
+                      "text": "a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] whitespace in a closing tag
+<p>a</p   >
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 11],
+      "text": "<p>a</p   >",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [3, 4],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an unknown element
+<my-widget>a</my-widget>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 24],
+      "text": "<my-widget>a</my-widget>",
+      "name": "my-widget",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [11, 12],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/raw_text.txt
+++ b/tests/html_parser_specs/raw_text.txt
@@ -1,0 +1,259 @@
+[[test]] a script
+<script>const a = 1</script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 28],
+      "text": "<script>const a = 1</script>",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "const a = 1",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 19],
+          "text": "const a = 1"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a script holding what looks like a tag
+<script>const a = "</div>"</script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 35],
+      "text": "<script>const a = \"</div>\"</script>",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "const a = \"</div>\"",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 26],
+          "text": "const a = \"</div>\""
+        }
+      ]
+    }
+  ]
+}
+[[test]] a script holding a less than sign
+<script>if (a < b) { }</script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 31],
+      "text": "<script>if (a < b) { }</script>",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "if (a < b) { }",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 22],
+          "text": "if (a < b) { }"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an empty script
+<script></script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 17],
+      "text": "<script></script>",
+      "name": "script",
+      "elementKind": "RawText"
+    }
+  ]
+}
+[[test]] a script with attributes
+<script type="module">export {}</script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 40],
+      "text": "<script type=\"module\">export {}</script>",
+      "name": "script",
+      "elementKind": "RawText",
+      "attributes": [
+        {
+          "name": "type",
+          "value": "module",
+          "quote": "\""
+        }
+      ],
+      "content": "export {}",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [22, 31],
+          "text": "export {}"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a style
+<style>.a {   color: red }</style>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 34],
+      "text": "<style>.a {   color: red }</style>",
+      "name": "style",
+      "elementKind": "RawText",
+      "content": ".a {   color: red }",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [7, 26],
+          "text": ".a {   color: red }"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a textarea
+<textarea>  keep   this  </textarea>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 36],
+      "text": "<textarea>  keep   this  </textarea>",
+      "name": "textarea",
+      "elementKind": "RawText",
+      "content": "  keep   this  ",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [10, 25],
+          "text": "  keep   this  "
+        }
+      ]
+    }
+  ]
+}
+[[test]] a title
+<title>a</title>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 16],
+      "text": "<title>a</title>",
+      "name": "title",
+      "elementKind": "RawText",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [7, 8],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closing tag matched without case
+<script>a</SCRIPT>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 18],
+      "text": "<script>a</SCRIPT>",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 9],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a preformatted element holds markup as children
+<pre><b>a</b>  <i>b</i></pre>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 29],
+      "text": "<pre><b>a</b>  <i>b</i></pre>",
+      "name": "pre",
+      "elementKind": "Normal",
+      "content": "<b>a</b>  <i>b</i>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 13],
+          "text": "<b>a</b>",
+          "name": "b",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [8, 9],
+              "text": "a"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [13, 15],
+          "text": "  "
+        },
+        {
+          "kind": "Element",
+          "span": [15, 23],
+          "text": "<i>b</i>",
+          "name": "i",
+          "elementKind": "Normal",
+          "content": "b",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [18, 19],
+              "text": "b"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/refused.txt
+++ b/tests/html_parser_specs/refused.txt
@@ -1,0 +1,52 @@
+[[test]] an element that was never closed
+<div>
+[[ast]]
+[[refused]] `<div>` was never closed
+[[test]] an element that was never closed after children
+<div><p>a</p>
+[[ast]]
+[[refused]] `<div>` was never closed
+[[test]] a block that a blank line split from its closing tag
+<div align="center">
+[[ast]]
+[[refused]] `<div>` was never closed
+[[test]] a closing tag that closes nothing
+</div>
+[[ast]]
+[[refused]] `</div>` closes an element that isn't open
+[[test]] a closing tag after a complete element
+<p>a</p></div>
+[[ast]]
+[[refused]] `</div>` closes an element that isn't open
+[[test]] tags that do not match
+<div><p>a</div></p>
+[[ast]]
+[[refused]] `</div>` was found where `</p>` was expected
+[[test]] a closing tag left to be inferred
+<ul><li>a<li>b</ul>
+[[ast]]
+[[refused]] `</ul>` was found where `</li>` was expected
+[[test]] a self closing tag a browser reads as an opening one
+<div/>
+[[ast]]
+[[refused]] a tag is written in a way the parser doesn't read
+[[test]] a self closing span
+<span/>a</span>
+[[ast]]
+[[refused]] a tag is written in a way the parser doesn't read
+[[test]] a comment that was never terminated
+<!-- a comment
+[[ast]]
+[[refused]] markup runs past the end of the text without being closed
+[[test]] a cdata section that was never terminated
+<![CDATA[ a
+[[ast]]
+[[refused]] markup runs past the end of the text without being closed
+[[test]] an attribute value that was never terminated
+<p title="a</p>
+[[ast]]
+[[refused]] markup runs past the end of the text without being closed
+[[test]] a script that was never closed
+<script>a
+[[ast]]
+[[refused]] `<script>` was never closed

--- a/tests/html_parser_specs/text.txt
+++ b/tests/html_parser_specs/text.txt
@@ -1,0 +1,97 @@
+[[test]] an angle bracket that opens no tag
+a < b
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 5],
+      "text": "a < b"
+    }
+  ]
+}
+[[test]] an angle bracket before a digit
+1 <2 3
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 6],
+      "text": "1 <2 3"
+    }
+  ]
+}
+[[test]] an empty angle bracket pair
+a <> b
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 6],
+      "text": "a <> b"
+    }
+  ]
+}
+[[test]] a malformed tag read as text
+<div =foo>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 10],
+      "text": "<div =foo>"
+    }
+  ]
+}
+[[test]] a character entity
+a &amp; b
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 9],
+      "text": "a &amp; b"
+    }
+  ]
+}
+[[test]] text holding a no break space
+a  b
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 6],
+      "text": "a  b"
+    }
+  ]
+}
+[[test]] only text
+just some words
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 15],
+      "text": "just some words"
+    }
+  ]
+}
+[[test]] an empty document
+
+[[ast]]
+{
+  "kind": "Document"
+}

--- a/tests/html_parser_specs/void_and_self_closing.txt
+++ b/tests/html_parser_specs/void_and_self_closing.txt
@@ -1,0 +1,175 @@
+[[test]] a void element
+<br>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 4],
+      "text": "<br>",
+      "name": "br",
+      "elementKind": "Void"
+    }
+  ]
+}
+[[test]] a void element written self closing
+<br />
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 6],
+      "text": "<br />",
+      "name": "br",
+      "elementKind": "Void",
+      "selfClosingSyntax": true
+    }
+  ]
+}
+[[test]] a void element written self closing with no space
+<br/>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 5],
+      "text": "<br/>",
+      "name": "br",
+      "elementKind": "Void",
+      "selfClosingSyntax": true
+    }
+  ]
+}
+[[test]] a void element with attributes
+<img src="a.png" alt="a">
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 25],
+      "text": "<img src=\"a.png\" alt=\"a\">",
+      "name": "img",
+      "elementKind": "Void",
+      "attributes": [
+        {
+          "name": "src",
+          "value": "a.png",
+          "quote": "\""
+        },
+        {
+          "name": "alt",
+          "value": "a",
+          "quote": "\""
+        }
+      ]
+    }
+  ]
+}
+[[test]] a self closing tag within svg
+<svg><circle cx="1" /></svg>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 28],
+      "text": "<svg><circle cx=\"1\" /></svg>",
+      "name": "svg",
+      "elementKind": "Normal",
+      "content": "<circle cx=\"1\" />",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 22],
+          "text": "<circle cx=\"1\" />",
+          "name": "circle",
+          "elementKind": "SelfClosing",
+          "selfClosingSyntax": true,
+          "attributes": [
+            {
+              "name": "cx",
+              "value": "1",
+              "quote": "\""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a self closing tag nested within svg
+<svg><g><path d="M0 0" /></g></svg>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 35],
+      "text": "<svg><g><path d=\"M0 0\" /></g></svg>",
+      "name": "svg",
+      "elementKind": "Normal",
+      "content": "<g><path d=\"M0 0\" /></g>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 29],
+          "text": "<g><path d=\"M0 0\" /></g>",
+          "name": "g",
+          "elementKind": "Normal",
+          "content": "<path d=\"M0 0\" />",
+          "children": [
+            {
+              "kind": "Element",
+              "span": [8, 25],
+              "text": "<path d=\"M0 0\" />",
+              "name": "path",
+              "elementKind": "SelfClosing",
+              "selfClosingSyntax": true,
+              "attributes": [
+                {
+                  "name": "d",
+                  "value": "M0 0",
+                  "quote": "\""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] an svg element written with both tags
+<svg><g></g></svg>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 18],
+      "text": "<svg><g></g></svg>",
+      "name": "svg",
+      "elementKind": "Normal",
+      "content": "<g></g>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 12],
+          "text": "<g></g>",
+          "name": "g",
+          "elementKind": "Normal"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/specs/Issues/Issue0124.txt
+++ b/tests/specs/Issues/Issue0124.txt
@@ -55,9 +55,7 @@
     </div>
 
 [expect]
-- <div>
-      Test
-    </div>
+- <div>Test</div>
 
 !! should maintain the indentation in a footnote definition !!
 [^1]: Test

--- a/tests/specs/html/HtmlFormat_All.txt
+++ b/tests/specs/html/HtmlFormat_All.txt
@@ -1,0 +1,153 @@
+!! should lay out a block of html !!
+<div><p>Testing</p></div>
+
+[expect]
+<div>
+  <p>Testing</p>
+</div>
+
+!! should reindent a table written flat !!
+<table>
+<tr><td>a</td><td>b</td></tr>
+</table>
+
+[expect]
+<table>
+  <tr>
+    <td>a</td>
+    <td>b</td>
+  </tr>
+</table>
+
+!! should reindent a block that was over indented !!
+<div>
+        <p>a</p>
+            <p>b</p>
+</div>
+
+[expect]
+<div>
+  <p>a</p>
+  <p>b</p>
+</div>
+
+!! should lay out a details block !!
+<details>
+<summary>Click to expand</summary>
+<p>Some content.</p>
+</details>
+
+[expect]
+<details>
+  <summary>Click to expand</summary>
+  <p>Some content.</p>
+</details>
+
+!! should keep a block with short content on one line !!
+<div><span>a</span></div>
+
+[expect]
+<div><span>a</span></div>
+
+!! should lay out html between paragraphs !!
+Before.
+
+<div><p>a</p></div>
+
+After.
+
+[expect]
+Before.
+
+<div>
+  <p>a</p>
+</div>
+
+After.
+
+!! should keep the whitespace around an inline element !!
+<div><p>some <em>emphasis</em> here</p></div>
+
+[expect]
+<div>
+  <p>some <em>emphasis</em> here</p>
+</div>
+
+!! should treat an unknown element as inline !!
+<div><p>a <my-widget>b</my-widget> c</p></div>
+
+[expect]
+<div>
+  <p>a <my-widget>b</my-widget> c</p>
+</div>
+
+!! should keep the case a tag was written in !!
+<DIV><P>a</P></DIV>
+
+[expect]
+<DIV>
+  <P>a</P>
+</DIV>
+
+!! should keep a comment as it was written !!
+<div>
+<!--   spaced   -->
+<p>a</p>
+</div>
+
+[expect]
+<div>
+  <!--   spaced   -->
+  <p>a</p>
+</div>
+
+!! should lay out deeply nested blocks !!
+<div><section><article><p>a</p></article></section></div>
+
+[expect]
+<div>
+  <section>
+    <article>
+      <p>a</p>
+    </article>
+  </section>
+</div>
+
+!! should drop the whitespace at the edges of block content !!
+<div>   <p>a</p>   </div>
+
+[expect]
+<div>
+  <p>a</p>
+</div>
+
+!! should collapse a run of whitespace to the space it renders as !!
+<div><p>a     b</p></div>
+
+[expect]
+<div>
+  <p>a b</p>
+</div>
+
+!! should keep an empty element on one line !!
+<div><p></p></div>
+
+[expect]
+<div>
+  <p></p>
+</div>
+
+!! should keep a void element the way it was written !!
+<div><br><hr></div>
+
+[expect]
+<div>
+  <br>
+  <hr>
+</div>
+
+!! should read a self closing tag within svg !!
+<div><svg><circle cx="1" /></svg></div>
+
+[expect]
+<div><svg><circle cx="1" /></svg></div>

--- a/tests/specs/html/HtmlFormat_Attributes.txt
+++ b/tests/specs/html/HtmlFormat_Attributes.txt
@@ -1,0 +1,52 @@
+~~ lineWidth: 60 ~~
+!! should quote a value that was written without quotes !!
+<div><a href=foo>a</a></div>
+
+[expect]
+<div><a href="foo">a</a></div>
+
+!! should keep the quote a value was written with !!
+<div><a href='foo'>a</a></div>
+
+[expect]
+<div><a href='foo'>a</a></div>
+
+!! should keep an attribute that has no value !!
+<div><input disabled></div>
+
+[expect]
+<div><input disabled></div>
+
+!! should keep an attribute value byte for byte !!
+<div title="a    b"><p>x</p></div>
+
+[expect]
+<div title="a    b">
+  <p>x</p>
+</div>
+
+!! should break a long list of attributes onto lines of their own !!
+<div class="one two three" id="the-identifier" data-value="something">a</div>
+
+[expect]
+<div
+  class="one two three"
+  id="the-identifier"
+  data-value="something"
+>a</div>
+
+!! should keep a long list of classes where it was written !!
+<div class="flex items-center justify-between rounded-lg border px-4 py-2 shadow">a</div>
+
+[expect]
+<div class="flex items-center justify-between rounded-lg border px-4 py-2 shadow">
+  a
+</div>
+
+!! should keep a short tag on the line it is on !!
+<div class="a" id="b"><p>x</p></div>
+
+[expect]
+<div class="a" id="b">
+  <p>x</p>
+</div>

--- a/tests/specs/html/HtmlFormat_BlockStarts.txt
+++ b/tests/specs/html/HtmlFormat_BlockStarts.txt
@@ -1,0 +1,38 @@
+~~ lineWidth: 40 ~~
+!! should keep a long img tag on one line because img starts no html block !!
+<img src="https://example.com/a/rather/long/path/to/an/image.svg" width="900">
+
+[expect]
+<img src="https://example.com/a/rather/long/path/to/an/image.svg" width="900">
+
+!! should break a long div tag because div starts an html block either way !!
+<div class="one two three" id="identifier" data-value="something">a</div>
+
+[expect]
+<div
+  class="one two three"
+  id="identifier"
+  data-value="something"
+>a</div>
+
+!! should keep a long span tag on one line because span starts no html block !!
+<span class="one two three" id="identifier" data-value="something">a</span>
+
+[expect]
+<span class="one two three" id="identifier" data-value="something">a</span>
+
+!! should break a long p tag because p starts an html block either way !!
+<p class="one two three" id="identifier" data-value="something">a</p>
+
+[expect]
+<p
+  class="one two three"
+  id="identifier"
+  data-value="something"
+>a</p>
+
+!! should keep a long anchor tag on one line !!
+<a href="https://example.com/a/rather/long/path" title="a title here">a</a>
+
+[expect]
+<a href="https://example.com/a/rather/long/path" title="a title here">a</a>

--- a/tests/specs/html/HtmlFormat_Containers.txt
+++ b/tests/specs/html/HtmlFormat_Containers.txt
@@ -1,0 +1,105 @@
+!! should lay out html in a block quote !!
+> <div>
+> <p>a</p>
+> </div>
+
+[expect]
+> <div>
+>   <p>a</p>
+> </div>
+
+!! should lay out html in a nested block quote !!
+> > <div>
+> > <p>a</p>
+> > </div>
+
+[expect]
+>> <div>
+>>   <p>a</p>
+>> </div>
+
+!! should lay out html in a list item !!
+- <div>
+  <p>a</p>
+  </div>
+
+[expect]
+- <div>
+    <p>a</p>
+  </div>
+
+!! should keep html that is indented within a list !!
+- Test
+
+    <div>
+    </div>
+
+[expect]
+- Test
+
+    <div>
+    </div>
+
+!! should lay out html after a heading !!
+# Heading
+
+<div><p>a</p></div>
+
+[expect]
+# Heading
+
+<div>
+  <p>a</p>
+</div>
+
+!! should not lay out an inline tag !!
+Some inline html <em>Testing</em> testing this out.
+
+[expect]
+Some inline html <em>Testing</em> testing this out.
+
+!! should not lay out html within a code block !!
+```
+<div><p>a</p></div>
+```
+
+[expect]
+```
+<div><p>a</p></div>
+```
+
+!! should keep html an ignore comment covers !!
+<!-- dprint-ignore -->
+<div><p>a</p></div>
+
+[expect]
+<!-- dprint-ignore -->
+<div><p>a</p></div>
+
+!! should keep an html block that holds an ignore region !!
+<diagram class="size-40">
+<!-- dprint-ignore-start -->
+flowchart TD
+example-testing-testing
+<!-- dprint-ignore-end -->
+</diagram>
+
+[expect]
+<diagram class="size-40">
+<!-- dprint-ignore-start -->
+flowchart TD
+example-testing-testing
+<!-- dprint-ignore-end -->
+</diagram>
+
+!! should keep an html block that holds an ignore comment !!
+<div>
+<!-- dprint-ignore -->
+<p>a    b</p>
+</div>
+
+[expect]
+<div>
+<!-- dprint-ignore -->
+<p>a    b</p>
+</div>

--- a/tests/specs/html/HtmlFormat_Fragments.txt
+++ b/tests/specs/html/HtmlFormat_Fragments.txt
@@ -1,0 +1,99 @@
+!! should keep a block that a blank line split from its closing tag !!
+<div align="center">
+
+**Some markdown.**
+
+</div>
+
+[expect]
+<div align="center">
+
+**Some markdown.**
+
+</div>
+
+!! should keep a centered badge block that holds markdown !!
+<p align="center">
+
+[![build](https://example.com/build.svg)](https://example.com)
+
+</p>
+
+[expect]
+<p align="center">
+
+[![build](https://example.com/build.svg)](https://example.com)
+
+</p>
+
+!! should keep an element that was never closed !!
+<div>
+<p>a</p>
+
+[expect]
+<div>
+<p>a</p>
+
+!! should keep a closing tag that closes nothing !!
+</div>
+
+[expect]
+</div>
+
+!! should keep tags that do not match !!
+<div><p>a</div></p>
+
+[expect]
+<div><p>a</div></p>
+
+!! should keep html that leaves a closing tag to be inferred !!
+<ul><li>a<li>b</ul>
+
+[expect]
+<ul><li>a<li>b</ul>
+
+!! should keep a self closing tag that a browser reads as an opening one !!
+<div/>
+
+[expect]
+<div/>
+
+!! should keep a comment that was never terminated !!
+<!-- unterminated
+
+[expect]
+<!-- unterminated
+
+!! should keep the details block that markdown is written inside of !!
+<details>
+<summary>Click</summary>
+
+Some **markdown** here.
+
+</details>
+
+[expect]
+<details>
+<summary>Click</summary>
+
+Some **markdown** here.
+
+</details>
+
+!! should still lay out the blocks around a fragment !!
+<div><p>a</p></div>
+
+<div>
+
+<div><p>b</p></div>
+
+[expect]
+<div>
+  <p>a</p>
+</div>
+
+<div>
+
+<div>
+  <p>b</p>
+</div>

--- a/tests/specs/html/HtmlFormat_IndentWidth.txt
+++ b/tests/specs/html/HtmlFormat_IndentWidth.txt
@@ -1,0 +1,20 @@
+~~ lineWidth: 40, html.indentWidth: 4 ~~
+!! should indent html with the given width !!
+<div><section><p>a</p></section></div>
+
+[expect]
+<div>
+    <section>
+        <p>a</p>
+    </section>
+</div>
+
+!! should indent the attributes of a long tag with the given width !!
+<div class="one two three" id="identifier" data-value="something">a</div>
+
+[expect]
+<div
+    class="one two three"
+    id="identifier"
+    data-value="something"
+>a</div>

--- a/tests/specs/html/HtmlFormat_RawText.txt
+++ b/tests/specs/html/HtmlFormat_RawText.txt
@@ -1,0 +1,65 @@
+!! should keep the content of a script !!
+<div>
+<script>const a = 1;   const b = 2</script>
+</div>
+
+[expect]
+<div>
+  <script>const a = 1;   const b = 2</script>
+</div>
+
+!! should keep the content of a style !!
+<div>
+<style>.a {   color: red }</style>
+</div>
+
+[expect]
+<div>
+  <style>.a {   color: red }</style>
+</div>
+
+!! should read markup within a script as text !!
+<div>
+<script>if (a < b) { c() }</script>
+</div>
+
+[expect]
+<div>
+  <script>if (a < b) { c() }</script>
+</div>
+
+!! should keep the content of a preformatted element !!
+<div>
+<pre>  a   b
+   c  </pre>
+</div>
+
+[expect]
+<div>
+  <pre>  a   b
+   c  </pre>
+</div>
+
+!! should keep the content of a textarea !!
+<div>
+<textarea>  keep   this  </textarea>
+</div>
+
+[expect]
+<div><textarea>  keep   this  </textarea></div>
+
+!! should keep a cdata section and processing instruction !!
+<div><p><![CDATA[ a < b ]]></p></div>
+
+[expect]
+<div>
+  <p><![CDATA[ a < b ]]></p>
+</div>
+
+!! should read an angle bracket that opens no tag as text !!
+<div><p>a < b</p></div>
+
+[expect]
+<div>
+  <p>a < b</p>
+</div>

--- a/tests/specs/html/HtmlFormat_SelfClosingSpace.txt
+++ b/tests/specs/html/HtmlFormat_SelfClosingSpace.txt
@@ -1,0 +1,18 @@
+~~ html.selfClosingSpace: false ~~
+!! should write a self closing tag with no space before the slash !!
+<div><br/><br /></div>
+
+[expect]
+<div><br/><br/></div>
+
+!! should write a self closing tag within svg with no space !!
+<div><svg><circle cx="1" /></svg></div>
+
+[expect]
+<div><svg><circle cx="1"/></svg></div>
+
+!! should leave a tag that was not written self closing alone !!
+<div><br><img src="a.png"></div>
+
+[expect]
+<div><br><img src="a.png"></div>

--- a/tests/specs/html/HtmlFormat_SelfClosingSpaceDefault.txt
+++ b/tests/specs/html/HtmlFormat_SelfClosingSpaceDefault.txt
@@ -1,0 +1,11 @@
+!! should write a space before the slash by default !!
+<div><br/><br /></div>
+
+[expect]
+<div><br /><br /></div>
+
+!! should normalize a self closing tag within svg !!
+<div><svg><circle cx="1"/></svg></div>
+
+[expect]
+<div><svg><circle cx="1" /></svg></div>

--- a/tests/specs/html/HtmlFormat_SkipFormat.txt
+++ b/tests/specs/html/HtmlFormat_SkipFormat.txt
@@ -1,0 +1,26 @@
+~~ html.skipFormat: true ~~
+!! should keep a block of html as it was written !!
+<div><p>Testing</p></div>
+
+[expect]
+<div><p>Testing</p></div>
+
+!! should keep a table as it was written !!
+<table>
+<tr><td>a</td><td>b</td></tr>
+</table>
+
+[expect]
+<table>
+<tr><td>a</td><td>b</td></tr>
+</table>
+
+!! should still format the markdown around it !!
+Some    text.
+
+<div><p>a</p></div>
+
+[expect]
+Some text.
+
+<div><p>a</p></div>

--- a/tests/specs/html/HtmlFormat_UseTabs.txt
+++ b/tests/specs/html/HtmlFormat_UseTabs.txt
@@ -1,0 +1,20 @@
+~~ html.useTabs: true ~~
+!! should indent html with tabs !!
+<div><section><p>a</p></section></div>
+
+[expect]
+<div>
+	<section>
+		<p>a</p>
+	</section>
+</div>
+
+!! should indent the content of a block quote with tabs !!
+> <div>
+> <p>a</p>
+> </div>
+
+[expect]
+> <div>
+> 	<p>a</p>
+> </div>

--- a/tests/specs/html/Html_All.txt
+++ b/tests/specs/html/Html_All.txt
@@ -13,11 +13,11 @@ paragraph text
 
 [expect]
 <dl>
-    <dt>Definition list</dt>
-    <dd>Testing</dd>
-    <dd>Testing</dd>
-<dd>Testing</dd>
-testing this out
+  <dt>Definition list</dt>
+  <dd>Testing</dd>
+  <dd>Testing</dd>
+  <dd>Testing</dd>
+  testing this out
 </dl>
 
 paragraph text
@@ -56,6 +56,4 @@ a 
 </div>
 
 [expect]
-<div>
-a 
-</div>
+<div>a </div>

--- a/tests/specs/html/Html_TextWrap_Always.txt
+++ b/tests/specs/html/Html_TextWrap_Always.txt
@@ -13,11 +13,11 @@ this should be wrapped because it is outside the html
 
 [expect]
 <dl>
-    <dt>Definition list</dt>
-    <dd>Testing</dd>
-    <dd>Testing</dd>
-<dd>Testing</dd>
-this should not be wrapped because it is inside html
+  <dt>Definition list</dt>
+  <dd>Testing</dd>
+  <dd>Testing</dd>
+  <dd>Testing</dd>
+  this should not be wrapped because it is inside html
 </dl>
 
 this should be wrapped because it is


### PR DESCRIPTION
Lays out the tags of a block of html and their content, with a parser and printer written for this rather than a dependency on one written for html files.

Html in markdown is not a document -- it's whatever fragment of one fits between the blank lines that close an html block -- so the parser refuses anything it can't put back together, and the printer leaves that text as it was written. **Nothing here ever adds or removes a tag.**

```html
<!-- in -->
<table>
<tr><td>a</td><td>b</td></tr>
</table>

<!-- out -->
<table>
  <tr>
    <td>a</td>
    <td>b</td>
  </tr>
</table>
```

## Left as it was written

- a fragment, ex. the `<div align="center">` that a blank line splits from its `</div>` -- the most common shape of html in a readme
- html that leaves a closing tag to a browser to infer, ex. `<ul><li>a<li>b</ul>`
- a `<div/>`, which a browser reads as opening a div rather than as an empty one
- a block written with indentation of its own, which says where the author put it within what holds it
- a block holding an ignore comment, whose text can't be reached from the markdown around it
- output whose first line would start a different kind of html block than the line it was written on, which would leave the rest of the block to be read as markdown

## Whitespace

Only ever changed where it isn't rendered: the indentation of an element's children, the runs a browser collapses, and the line the attributes of a long tag are written on. Attribute values, character data, comments, and the content of a preformatted or raw text element are written back byte for byte.

An inline element is only broken at an edge where whitespace was already written, because a line break put beside its content renders as a space that wasn't there:

```html
<a class="btn" href="#install">Get started
  <svg viewBox="0 0 24 24"></svg>
</a>
```

An element the tables don't name is treated as inline, which is both what the spec says an unknown element is and the careful assumption.

## Configuration

| option | default | |
| --- | --- | --- |
| `html.skipFormat` | `false` | leave the html as it was written |
| `html.useTabs` | `useTabs` | indent the html with tabs |
| `html.indentWidth` | `indentWidth` | spaces to indent the html with |
| `html.selfClosingSpace` | `true` | write `<br />` rather than `<br/>` |

`html.skipFormat` defaults to `false`, matching `codeBlock.skipFormat` and `table.skipFormat`. Worth a second opinion -- it changes the output of files that already hold html.

## Why not a dependency

`markup_fmt` was the obvious candidate and does this well, but bundling it grows the wasm plugin from 665 KB to 1,175 KB (+81%) for a feature most markdown files don't use. Written here it costs +39 KB (+5.9%). Delegating to the host's html plugin was the other option, and is the more dprint-shaped answer, but it leaves the feature inert until someone configures one.

## Tests

- 70 html parser spec cases under `tests/html_parser_specs`, in the same format as `tests/parser_specs` (`UPDATE=1` to regenerate). Html the parser refuses is a case like any other, written with the reason in place of the ast. Every case is also checked for byte coverage: the children of a node tile it from first byte to last, so nothing can be read and then dropped.
- 84 unit tests over the printer, tags, and the refused cases.
- 60 formatting spec cases across 11 files under `tests/specs/html`.
- A corpus of **29,698** markdown files: no text lost, no file formatted differently the second time, no panics.

Four existing spec expectations changed, each rendering identically to before: the `<dl>` block in `Html_All` and `Html_TextWrap_Always` now indents, and two cases in `Issue0124`.

## Notes for the reviewer

- `starts_same_html_block` is new in `src/parser/block.rs`. It's what stops a long `<img ...>` from being broken across lines: `img` doesn't start a type-6 html block, so `<img` alone on the first line would end the block and leave the trailing `>` to be read as a block quote marker.
- The printer measures content rather than writing it out to see whether it fits. Writing it out and looking at it doubles the work at every level of nesting, which took a 384-byte document 3 seconds before this was fixed.

Closes https://github.com/dprint/dprint-plugin-markdown/issues/168