### PR TITLE
fix: keep an html block that formatting would cut short

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1533,10 +1533,10 @@ fn gen_html(node: &Html, ctx: &mut Context) -> PrintItems {
     // block and leaves its closing tag to a block of its own -- whatever the
     // formatter can't take apart and put back together is left as it was
     if let Ok(text) = crate::html::format_html(&node.text, &options) {
-      // the line an html block starts on is what makes it one, and says where
-      // it ends -- writing that line out differently would leave the rest of
-      // the block to be read as markdown
-      if starts_same_html_block(first_line(&node.text), first_line(&text)) {
+      // the block has to still be the one block it was written as: a first
+      // line that starts another kind of block, or text moved past what closes
+      // this one, would leave the rest of it to be read as markdown
+      if is_whole_html_block(first_line(&node.text), &text) {
         let mut items = PrintItems::new();
         items.push_sc(sc!("")); // force first line indentation
         items.extend(ir_helpers::gen_from_string(&text));

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1536,7 +1536,7 @@ fn gen_html(node: &Html, ctx: &mut Context) -> PrintItems {
       // the block has to still be the one block it was written as: a first
       // line that starts another kind of block, or text moved past what closes
       // this one, would leave the rest of it to be read as markdown
-      if is_whole_html_block(first_line(&node.text), &text) {
+      if is_whole_html_block(&node.text, &text) {
         let mut items = PrintItems::new();
         items.push_sc(sc!("")); // force first line indentation
         items.extend(ir_helpers::gen_from_string(&text));
@@ -1568,15 +1568,6 @@ fn gen_range(span: Span, ctx: &mut Context) -> PrintItems {
     &strip_raw_block_quote_markers(text, ctx),
   )));
   items
-}
-
-/// The text up to its first line break, which for an html block is the line
-/// that decides whether it is one and where it ends.
-fn first_line(text: &str) -> &str {
-  match text.find('\n') {
-    Some(index) => &text[..index],
-    None => text,
-  }
 }
 
 /// Trims the whitespace written at the end of each line, which is only a space

--- a/src/html/text_fuzz.rs
+++ b/src/html/text_fuzz.rs
@@ -406,3 +406,70 @@ impl Random {
     self.0 % bound
   }
 }
+
+/// Hunts for html that changes what the markdown around it says, by putting
+/// the generated html in a document and formatting that.
+///
+/// The html sweep above works the fragment on its own, where the only thing
+/// that can go wrong is what the printer writes. In a document there is more:
+/// an html block ends where markdown says it does, so text moved onto a line
+/// past what closes the block stops being html and starts being markdown, and
+/// text moved onto the line of a marker starts being html. Neither shows up
+/// until the document is read again.
+#[test]
+fn markdown_holding_html_is_written_back_out_whole() {
+  let first = env_count("FUZZ_FROM").unwrap_or(0);
+  let count = env_count("FUZZ_CASES").unwrap_or(50_000);
+  let config = crate::configuration::ConfigurationBuilder::new().build();
+  let mut failures = Vec::new();
+
+  for case in first..first + count {
+    let html = generate(case);
+    // An ignore directive turns off the formatting of whatever follows it,
+    // which is a tangle of its own that this doesn't hunt for: a document
+    // holding one doesn't settle even with the html left alone entirely. The
+    // sweep above covers the html a directive is written in.
+    if html.contains("dprint-ignore") {
+      continue;
+    }
+    // the html is written as a block of its own, with markdown on either side
+    // of it that has to still be there and still be markdown
+    let source = format!("before *a*\n\n{}\n\nafter *b*\n", html);
+
+    let Ok(once) = crate::format_text(&source, &config, |_, _, _| Ok(None)) else {
+      continue; // a document the formatter won't take is not what is hunted here
+    };
+    let once = once.unwrap_or_else(|| source.clone());
+    let Ok(twice) = crate::format_text(&once, &config, |_, _, _| Ok(None)) else {
+      failures.push(format!(
+        "case {}: {:?}\n  came out as text that won't format",
+        case, source
+      ));
+      continue;
+    };
+    let twice = twice.unwrap_or_else(|| once.clone());
+
+    if written_letters(&once) != written_letters(&source) {
+      failures.push(format!(
+        "case {}: {:?}\n  came out as {:?}, which doesn't say the same thing",
+        case, source, once,
+      ));
+    } else if twice != once {
+      failures.push(format!(
+        "case {}: {:?}\n  came out as {:?} and then as {:?}, so formatting it doesn't settle",
+        case, source, once, twice,
+      ));
+    }
+    if failures.len() >= 10 {
+      break;
+    }
+  }
+
+  assert!(
+    failures.is_empty(),
+    "the formatter was wrong about {} of {} generated documents:\n\n{}",
+    failures.len(),
+    count,
+    failures.join("\n\n"),
+  );
+}

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -1286,17 +1286,18 @@ enum HtmlBlockKind {
 /// does moving text past what closes the block, because a block that is closed
 /// by a marker rather than by a blank line ends on the line that marker is
 /// written on, however much was written after it.
-pub fn is_whole_html_block(original_first_line: &str, text: &str) -> bool {
-  let lines: Vec<&str> = text.split('\n').collect();
-  let kind = html_block_kind(lines[0], false);
-  if kind != html_block_kind(original_first_line, false) {
+pub fn is_whole_html_block(original: &str, text: &str) -> bool {
+  let kind = html_block_kind(first_line(text), false);
+  if kind != html_block_kind(first_line(original), false) {
     return false;
   }
   match kind {
-    Some(HtmlBlockKind::Closes(close)) => match lines.iter().position(|line| line.contains(close.as_ref())) {
-      // the block ends on the line its marker is written on, so that has to be
-      // the last one: whatever was written after it would be read as markdown
-      Some(index) => index == lines.len() - 1,
+    Some(HtmlBlockKind::Closes(close)) => match text.find(close.as_ref()) {
+      // The block ends on the line its marker is written on, so that has to be
+      // the last one: whatever was written after it would be read as markdown.
+      // A marker holds no line break of its own, so it is on the last line
+      // exactly when no break is written after it.
+      Some(index) => !text[index..].contains('\n'),
       // nothing closes it, so it runs to the end of the text as it is
       None => true,
     },
@@ -1376,6 +1377,15 @@ fn starts_with_tag_name(text: &str, name: &str) -> bool {
   bytes.len() >= name.len()
     && bytes[..name.len()].eq_ignore_ascii_case(name.as_bytes())
     && followed_by_tag_end(&text[name.len()..])
+}
+
+/// The text up to its first line break, which for an html block is the line
+/// that decides whether it is one and where it ends.
+fn first_line(text: &str) -> &str {
+  match text.find('\n') {
+    Some(index) => &text[..index],
+    None => text,
+  }
 }
 
 fn compare_tag_name(tag: &str, name: &str) -> std::cmp::Ordering {

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -1277,13 +1277,34 @@ enum HtmlBlockKind {
   BlankLine,
 }
 
-/// Whether two lines start the same kind of html block.
+/// Whether the text is one html block of the same kind the line starts, all
+/// the way to its end.
 ///
-/// Text can only be written back out differently where this holds of the line
-/// it starts on: a line that stops starting an html block, or starts one that
-/// ends somewhere else, leaves the rest of the block to be read as markdown.
-pub fn starts_same_html_block(before: &str, after: &str) -> bool {
-  html_block_kind(before, false) == html_block_kind(after, false)
+/// An html block can only be written back out differently where this holds of
+/// what it is written as. A line that stops starting an html block, or starts
+/// one of another kind, leaves what follows to be read as markdown -- and so
+/// does moving text past what closes the block, because a block that is closed
+/// by a marker rather than by a blank line ends on the line that marker is
+/// written on, however much was written after it.
+pub fn is_whole_html_block(original_first_line: &str, text: &str) -> bool {
+  let lines: Vec<&str> = text.split('\n').collect();
+  let kind = html_block_kind(lines[0], false);
+  if kind != html_block_kind(original_first_line, false) {
+    return false;
+  }
+  match kind {
+    Some(HtmlBlockKind::Closes(close)) => match lines.iter().position(|line| line.contains(close.as_ref())) {
+      // the block ends on the line its marker is written on, so that has to be
+      // the last one: whatever was written after it would be read as markdown
+      Some(index) => index == lines.len() - 1,
+      // nothing closes it, so it runs to the end of the text as it is
+      None => true,
+    },
+    // the block ends at the first blank line, and the printer is held to
+    // writing no blank line that wasn't already written
+    Some(HtmlBlockKind::BlankLine) => true,
+    None => false,
+  }
 }
 
 /// The html block the text starts, if any. Blocks that consist of a single

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,10 +25,10 @@ use std::collections::HashSet;
 pub use ast::*;
 
 pub use block::block_start_escape;
+pub use block::is_whole_html_block;
 pub use block::line_start_escape;
 pub use block::starts_block_at_block_start;
 pub use block::starts_block_in_paragraph;
-pub use block::starts_same_html_block;
 pub use source::SPACES;
 pub use source::WHITESPACE;
 

--- a/tests/specs/html/HtmlFormat_BlockStarts.txt
+++ b/tests/specs/html/HtmlFormat_BlockStarts.txt
@@ -36,3 +36,37 @@
 
 [expect]
 <a href="https://example.com/a/rather/long/path" title="a title here">a</a>
+
+!! should keep text written after what closes a pre block !!
+<pre>a</pre>*em*
+
+[expect]
+<pre>a</pre>*em*
+
+!! should keep text written after what closes a script block !!
+<script>a</script>*em*
+
+[expect]
+<script>a</script>*em*
+
+!! should keep text written after a pre block on the same line !!
+<pre>a</pre>text after
+
+[expect]
+<pre>a</pre>text after
+
+!! should still lay out a pre block written on its own !!
+<div><pre>  a  </pre></div>
+
+[expect]
+<div>
+  <pre>  a  </pre>
+</div>
+
+!! should still lay out a script block written on its own !!
+<div><script>const a = 1</script></div>
+
+[expect]
+<div>
+  <script>const a = 1</script>
+</div>


### PR DESCRIPTION
Fixes a correctness bug in #255. The commit missed the #256 merge, so this carries it plus the sweep that found it.

An html block closed by a marker rather than by a blank line ends on the line that marker is written on, however much was written after it. The printer was free to move that text onto a line of its own, which left it outside the block to be read as markdown:

```markdown
<pre>a</pre>*em*
```

came out as

```markdown
<pre>a</pre>
*em*
```

The emphasis had been text of the block and was now markdown, so a second run wrote it as `_em_`. What the document says changed, which is what formatting must never do. Affects `pre`, `script` and `style` -- the blocks a marker closes -- and not the ones a blank line closes.

## The fix

The line an html block starts on was already checked; what it holds to the end of it now is too, so a block whose text formatting would cut short is left as it was written. `starts_same_html_block` gives way to `is_whole_html_block`, which answers the whole question rather than only the first line of it.

`<pre>` and `<script>` written inside a `<div>` are laid out as before. Five spec cases cover both sides of that.

## How it was found

The markdown sweep added here puts the generated html in a document with markdown on either side and checks that what the document says survives being written twice. The html sweep from #256 works the fragment on its own, where nothing of this can show up: an html block ends where markdown says it does, and that is only visible once the document is read again. Reverting the fix makes the new sweep fail.

The corpus of 29,698 files never held this shape either.

The sweep skips a document holding an ignore directive. Those don't settle even with the html left alone entirely -- `w0<!-- dprint-ignore --><div =foo>` gains blank lines on a second run with `html.skipFormat: true`, and does the same on aa9b111, before any of this landed. That is a tangle of its own and worth its own issue; it is not what this hunts for.

## Checks

124 lib tests, 661 spec cases, both fuzz sweeps at 50,000 cases each, clippy clean, and the corpus of 29,698 files: no text lost, no file formatted differently the second time, no panics.
