### PR TITLE
feat: add `wrapUnspacedScripts` config option, off by default

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -42,6 +42,18 @@
         "description": "Writes one sentence per line, ignoring the line width."
       }]
     },
+    "wrapUnspacedScripts": {
+      "description": "Whether to break a line between the characters of a script written without spaces between its words, such as Chinese or Japanese, when wrapping text. Chromium and WebKit render such a break as a space, unlike Firefox, so it's off by default.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Breaks a line between the characters of a script written without spaces between its words."
+      }, {
+        "const": false,
+        "description": "Leaves a run of a script written without spaces between its words on one line, however long it runs, and keeps any line break written within one where it was."
+      }]
+    },
     "emphasisKind": {
       "description": "The character to use for emphasis/italics.",
       "type": "string",
@@ -273,6 +285,9 @@
     },
     "textWrap": {
       "$ref": "#/definitions/textWrap"
+    },
+    "wrapUnspacedScripts": {
+      "$ref": "#/definitions/wrapUnspacedScripts"
     },
     "emphasisKind": {
       "$ref": "#/definitions/emphasisKind"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -61,6 +61,14 @@ impl ConfigurationBuilder {
     self.insert("textWrap", value.to_string().into())
   }
 
+  /// Whether to break a line between the characters of a script written
+  /// without spaces between its words, such as Chinese or Japanese, when
+  /// wrapping text. Chromium and WebKit render such a break as a space.
+  /// Default: `false`
+  pub fn wrap_unspaced_scripts(&mut self, value: bool) -> &mut Self {
+    self.insert("wrapUnspacedScripts", value.into())
+  }
+
   /// The character to use for emphasis/italics.
   /// Default: `EmphasisKind::Underscores`
   pub fn emphasis_kind(&mut self, value: EmphasisKind) -> &mut Self {
@@ -252,6 +260,7 @@ mod tests {
       .new_line_kind(NewLineKind::CarriageReturnLineFeed)
       .line_width(90)
       .text_wrap(TextWrap::Always)
+      .wrap_unspaced_scripts(true)
       .emphasis_kind(EmphasisKind::Asterisks)
       .strong_kind(StrongKind::Underscores)
       .hard_break_kind(HardBreakKind::DoubleSpace)
@@ -274,7 +283,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 23);
+    assert_eq!(inner_config.len(), 24);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -56,6 +56,7 @@ pub fn resolve_config(
       &mut diagnostics,
     ),
     text_wrap: get_value(&mut config, "textWrap", TextWrap::Maintain, &mut diagnostics),
+    wrap_unspaced_scripts: get_value(&mut config, "wrapUnspacedScripts", false, &mut diagnostics),
     emphasis_kind: get_value(&mut config, "emphasisKind", EmphasisKind::Underscores, &mut diagnostics),
     strong_kind: get_value(&mut config, "strongKind", StrongKind::Asterisks, &mut diagnostics),
     hard_break_kind: get_value(&mut config, "hardBreakKind", HardBreakKind::Backslash, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -12,6 +12,12 @@ pub struct Configuration {
   pub line_width: u32,
   pub new_line_kind: NewLineKind,
   pub text_wrap: TextWrap,
+  /// Whether to break a line between the characters of a script written
+  /// without spaces between its words, such as Chinese or Japanese, when
+  /// wrapping text. Off by default, since Chromium and WebKit render such a
+  /// break as a space, unlike Firefox, so a break the formatter wrote would
+  /// show up in the rendered text for most readers.
+  pub wrap_unspaced_scripts: bool,
   pub emphasis_kind: EmphasisKind,
   pub strong_kind: StrongKind,
   pub hard_break_kind: HardBreakKind,

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -457,7 +457,7 @@ impl<'a> Context<'a> {
 
   fn written_char(&self, at: &[(usize, char)], position: usize) -> Option<char> {
     // a break that is kept is still written out, so nothing moves against it
-    if self.configuration.text_wrap.keeps_line_breaks() {
+    if self.configuration.text_wrap.keeps_line_breaks() || !self.configuration.wrap_unspaced_scripts {
       return None;
     }
     at.binary_search_by_key(&position, |(at, _)| *at)

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -138,6 +138,18 @@ fn drops_break_between(last_node: &Node, node: &Node, context: &Context) -> bool
     && can_be_written_beside(last_node, node, context.file_text)
 }
 
+/// Whether the line break between the two nodes is kept where it was written,
+/// which is what a break between two characters of a script written without
+/// spaces gets when the formatter is leaving such breaks alone, even where the
+/// nodes couldn't be drawn together (ex. two decorations whose delimiters would
+/// run into each other).
+fn keeps_break_between(last_node: &Node, node: &Node, context: &Context) -> bool {
+  !context.configuration.wrap_unspaced_scripts
+    && !context.configuration.text_wrap.keeps_line_breaks()
+    && last_node.ends_with_unspaced_script()
+    && node.starts_with_unspaced_script()
+}
+
 fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
 
@@ -225,6 +237,11 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
                   context,
                   sentence_ends_between(last_node, node, context),
                 ));
+              } else if keeps_break_between(last_node, node, context) {
+                // the nodes can't be written beside each other, but the break
+                // between them is left alone all the same rather than written
+                // as a space that would be rendered in every browser
+                items.push_signal(Signal::NewLine);
               } else {
                 items.extend(get_newline_wrapping_based_on_config(
                   context,
@@ -1803,7 +1820,15 @@ fn gen_word_with_sentence_breaks(word: &str) -> PrintItems {
 /// without this it would be written on one line however long it ran. Only a
 /// break with one of its characters on either side can be written: anywhere
 /// else the break would be read back as a space that wasn't written.
+///
+/// This is only done when `wrapUnspacedScripts` is on. A break between two
+/// such characters reads as nothing per the CSS Text spec, but Chromium and
+/// WebKit render it as a space, so by default the run is left whole rather
+/// than have a break the formatter wrote show up in the rendered text.
 fn gen_word_with_unspaced_script_breaks(word: &str, context: &Context) -> PrintItems {
+  if !context.configuration.wrap_unspaced_scripts {
+    return gen_text_with_tabs(word);
+  }
   if context.configuration.text_wrap == TextWrap::Sentence && !context.is_text_wrap_disabled() {
     return gen_word_with_sentence_breaks(word);
   }
@@ -2822,7 +2847,18 @@ fn holds_the_same_kind(nodes: &[Node], kind: TextDecorationKind) -> bool {
 /// What takes the place of a line break that falls between two characters of
 /// a script written without spaces between its words, where the break isn't
 /// rendered as a space and so is dropped rather than turned into one.
+///
+/// Unless `wrapUnspacedScripts` is on the break is kept where it was written,
+/// whatever the wrap mode. Chromium and WebKit render it as a space where the
+/// spec and Firefox render nothing, so moving or dropping it would change what
+/// those readers see, the same as writing a new one would.
 fn get_unspaced_script_newline_wrapping(context: &Context, ends_sentence: bool) -> PrintItems {
+  if !context.configuration.wrap_unspaced_scripts {
+    // where newlines are being forced off (ex. within a heading) the printer
+    // drops this one, which is what should take the place of a break that read
+    // as nothing anyway
+    return Signal::NewLine.into();
+  }
   match context.configuration.text_wrap {
     // the line may still be broken where it was, since the break isn't read
     // as anything either way

--- a/tests/specs/Text/Text_TextWrap_MaintainAndWrap.txt
+++ b/tests/specs/Text/Text_TextWrap_MaintainAndWrap.txt
@@ -124,13 +124,12 @@ inside of it` and more text here
 over lines` and more text that runs past
 the line width here
 
-!! should break a run of a script written without spaces, and keep the break within it !!
+!! should leave a run of a script written without spaces whole by default !!
 一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
 短い行
 
 [expect]
-一二三四五六七八九十一二三四五六七八九十
-一二三四五六七八九十
+一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
 短い行
 
 !! should join a line whose first word alone would start a block, which wrapping could leave it as !!

--- a/tests/specs/Text/Text_TextWrap_MaintainAndWrap_UnspacedScripts.txt
+++ b/tests/specs/Text/Text_TextWrap_MaintainAndWrap_UnspacedScripts.txt
@@ -1,0 +1,9 @@
+~~ lineWidth: 40, textWrap: maintainAndWrap, wrapUnspacedScripts: true ~~
+!! should break a run of a script written without spaces, and keep the break within it !!
+一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十
+短い行
+
+[expect]
+一二三四五六七八九十一二三四五六七八九十
+一二三四五六七八九十
+短い行

--- a/tests/specs/Text/Text_TextWrap_Sentence.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence.txt
@@ -107,15 +107,6 @@ Four.
 | --------- | ------------ |
 | One. Two. | Three. Four. |
 
-!! should break after a sentence of an unspaced script !!
-これは文です。これも文です。
-続き。
-
-[expect]
-これは文です。
-これも文です。
-続き。
-
 !! should keep a hard break !!
 One.\
 Two. Three.

--- a/tests/specs/Text/Text_TextWrap_Sentence_NoWrap.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence_NoWrap.txt
@@ -1,0 +1,22 @@
+~~ lineWidth: 40, textWrap: sentence ~~
+!! should leave the sentences of an unspaced script on one line by default since a break between them renders as a space in chromium and webkit !!
+これは文です。これも文です。続き。
+
+[expect]
+これは文です。これも文です。続き。
+
+!! should keep a line break written between its sentences !!
+これは文です。これも文です。
+続き。
+
+[expect]
+これは文です。これも文です。
+続き。
+
+!! should still break after a sentence where a space follows it !!
+これは文です。 Then English. 続き。
+
+[expect]
+これは文です。
+Then English.
+続き。

--- a/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
+++ b/tests/specs/Text/Text_TextWrap_Sentence_Regressions.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, textWrap: sentence ~~
+~~ lineWidth: 40, textWrap: sentence, wrapUnspacedScripts: true ~~
 !! should not break a word where the break would read as a space !!
 これはテストです。Rustで書かれています。
 
@@ -30,6 +30,15 @@ Done。---
 あ。|---|
 
 Done。---
+
+!! should break after a sentence of an unspaced script !!
+これは文です。これも文です。
+続き。
+
+[expect]
+これは文です。
+これも文です。
+続き。
 
 !! should break a word at the halfwidth full stop as at the full width one !!
 あ｡い｡

--- a/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_InlineNodes.txt
@@ -1,4 +1,4 @@
-~~ textWrap: never ~~
+~~ textWrap: never, wrapUnspacedScripts: true ~~
 !! should drop a line break between a link and such a script !!
 [日](https://dprint.dev)
 日本語

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always.txt
@@ -1,4 +1,4 @@
-~~ textWrap: always, lineWidth: 30 ~~
+~~ textWrap: always, lineWidth: 30, wrapUnspacedScripts: true ~~
 !! should drop a line break between two characters of an unspaced script !!
 日本語
 日本語

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always_NoWrap.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Always_NoWrap.txt
@@ -1,0 +1,57 @@
+~~ textWrap: always, lineWidth: 20 ~~
+!! should leave a run whole by default since a break within it renders as a space in chromium and webkit !!
+これは日本語のテキストです。長い文章を書いています。
+
+[expect]
+これは日本語のテキストです。長い文章を書いています。
+
+!! should still break at a space beside other text !!
+日本語 English は便利です日本語日本語 English
+
+[expect]
+日本語 English
+は便利です日本語日本語
+English
+
+!! should keep a line break written between two of its characters where it was !!
+日本語
+日本語
+
+[expect]
+日本語
+日本語
+
+!! should keep it where it was even where the line runs past the line width !!
+これは日本語のテキストです。長い文章を
+書いています。
+
+[expect]
+これは日本語のテキストです。長い文章を
+書いています。
+
+!! should still drop it where newlines are forced off, and keep it within a link !!
+日本語
+日本語
+===
+
+[日本語
+日本語](https://dprint.dev)
+
+[expect]
+# 日本語日本語
+
+[日本語
+日本語](https://dprint.dev)
+
+!! should still keep a space written between two runs rather than break at it !!
+日本語 日本語 日本語 日本語 日本語
+
+[expect]
+日本語 日本語 日本語 日本語 日本語
+
+!! should leave a line long rather than break where a space would be read back !!
+これはテストです日本語日本語- テスト
+
+[expect]
+これはテストです日本語日本語-
+テスト

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never.txt
@@ -1,4 +1,4 @@
-~~ textWrap: never ~~
+~~ textWrap: never, wrapUnspacedScripts: true ~~
 !! should drop a line break between two characters of an unspaced script !!
 這個段落是那麼長，
 在一行寫不行。最好

--- a/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never_NoWrap.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_TextWrap_Never_NoWrap.txt
@@ -1,0 +1,54 @@
+~~ textWrap: never ~~
+!! should keep a line break between two characters of an unspaced script by default since dropping it changes what chromium and webkit render !!
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+[expect]
+這個段落是那麼長，
+在一行寫不行。最好
+用三行寫。
+
+!! should still turn a line break beside other text into a space !!
+日本語
+English
+は便利
+
+[expect]
+日本語 English は便利
+
+!! should keep a line break between two decorations that can't be written beside each other !!
+*日本語*
+*日本語*
+
+**日本語**
+_日本語_
+
+[expect]
+_日本語_
+_日本語_
+
+**日本語**
+_日本語_
+
+!! should keep the delimiter of a decoration written after a kept break !!
+日本語
+_日本語_ text
+
+[expect]
+日本語
+_日本語_ text
+
+!! should keep a line break beside a link or code span that is read as such a script !!
+[日](https://dprint.dev)
+日本語
+
+`日`
+日本語
+
+[expect]
+[日](https://dprint.dev)
+日本語
+
+`日`
+日本語

--- a/tests/specs/Text/Text_UnspacedScripts_Wrapping.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_Wrapping.txt
@@ -1,4 +1,4 @@
-~~ textWrap: always, lineWidth: 20 ~~
+~~ textWrap: always, lineWidth: 20, wrapUnspacedScripts: true ~~
 !! should break a run that holds no spaces to break at !!
 これは日本語のテキストです。長い文章を書いています。
 

--- a/tests/specs/Text/Text_UnspacedScripts_Wrapping_LineWidth12.txt
+++ b/tests/specs/Text/Text_UnspacedScripts_Wrapping_LineWidth12.txt
@@ -1,4 +1,4 @@
-~~ textWrap: always, lineWidth: 12 ~~
+~~ textWrap: always, lineWidth: 12, wrapUnspacedScripts: true ~~
 !! should not break before a mark that closes or trails a phrase !!
 これはテストです。「かっこ」の中身。
 


### PR DESCRIPTION
Follows up on the concern raised on #231 ([comment](https://github.com/dprint/dprint-plugin-markdown/pull/231#issuecomment-5412528962)): the CSS Text spec and Firefox render a line break between two Chinese/Japanese characters as nothing, but Chromium and WebKit render it as a space. I confirmed this in Chrome 151 by measuring rendered widths — a `\n` between two kanji comes out exactly one space wider than the same text without it. So a break the formatter writes inside such a run shows up as a stray space for most readers, and a break it drops removes one they were seeing.

This adds a boolean `wrapUnspacedScripts` option, **off by default**. When off, the formatter never adds or removes a line break between two characters of a script written without spaces between its words, in any `textWrap` mode:

- A run isn't broken to fit `lineWidth` under `always` / `maintainAndWrap`, and `sentence` doesn't break after `。` within a run.
- A break already written between two such characters is kept where it was, including under `never` and `sentence`, and between two decorations whose delimiters can't sit beside each other (which previously became a rendered space).
- A break beside other text is still turned into a space, a space between two runs is still kept as a space (#127's rule), and a break is still dropped where newlines are forced off (ex. a heading).

Turning it on restores the behaviour of #231 / #127 / #239 exactly.

The existing specs that assert breaking inside a run now set `wrapUnspacedScripts: true` in their header, and new `*_NoWrap` spec files cover the default for `always`, `never`, `sentence`, and `maintainAndWrap`.