### PR TITLE
feat: add `html.preferSingleLine` config option, off by default

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -230,6 +230,18 @@
         "description": "Writes a self-closing tag as `<br/>`."
       }]
     },
+    "html.preferSingleLine": {
+      "description": "Whether to write an element's content, or a tag's attributes, on the one line when they fit even where they were written across lines. Off by default, so that content and attributes written across lines are kept that way and only reindented.",
+      "type": "boolean",
+      "default": false,
+      "oneOf": [{
+        "const": true,
+        "description": "Writes content and attributes on one line whenever they fit."
+      }, {
+        "const": false,
+        "description": "Keeps content and attributes that were written across lines on lines of their own."
+      }]
+    },
     "table.skipFormat": {
       "description": "Whether to leave a table's rows as they were written rather than aligning their cells into columns.",
       "type": "boolean",
@@ -347,6 +359,9 @@
     },
     "html.selfClosingSpace": {
       "$ref": "#/definitions/html.selfClosingSpace"
+    },
+    "html.preferSingleLine": {
+      "$ref": "#/definitions/html.preferSingleLine"
     },
     "table.skipFormat": {
       "$ref": "#/definitions/table.skipFormat"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -189,6 +189,13 @@ impl ConfigurationBuilder {
     self.insert("html.selfClosingSpace", value.into())
   }
 
+  /// Whether to write an element's content, or a tag's attributes, on the one
+  /// line when they fit even where they were written across lines.
+  /// Default: `false`
+  pub fn html_prefer_single_line(&mut self, value: bool) -> &mut Self {
+    self.insert("html.preferSingleLine", value.into())
+  }
+
   /// Whether to leave a table's rows as they were written rather than
   /// aligning their cells into columns.
   /// Default: `false`
@@ -275,6 +282,7 @@ mod tests {
       .code_block_preserve_blank_lines(true)
       .code_block_use_tabs(true)
       .code_block_indent_width(2)
+      .html_prefer_single_line(true)
       .table_skip_format(true)
       .table_cell_padding(TableCellPadding::Space)
       .ignore_directive("test")
@@ -283,7 +291,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 24);
+    assert_eq!(inner_config.len(), 25);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -103,6 +103,7 @@ pub fn resolve_config(
       &mut diagnostics,
     ),
     html_self_closing_space: get_value(&mut config, "html.selfClosingSpace", true, &mut diagnostics),
+    html_prefer_single_line: get_value(&mut config, "html.preferSingleLine", false, &mut diagnostics),
     table_skip_format: get_value(&mut config, "table.skipFormat", false, &mut diagnostics),
     table_cell_padding: get_value(
       &mut config,

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -70,6 +70,12 @@ pub struct Configuration {
   /// so that a tag is written as `<br />` rather than as `<br/>`.
   #[serde(rename = "html.selfClosingSpace")]
   pub html_self_closing_space: bool,
+  /// Whether to write an element's content, or a tag's attributes, on the one
+  /// line when they fit even where they were written across lines. Off by
+  /// default, so that content and attributes written across lines are kept
+  /// that way and only reindented.
+  #[serde(rename = "html.preferSingleLine")]
+  pub html_prefer_single_line: bool,
   /// Whether to leave a table's rows as they were written rather than
   /// aligning their cells into columns.
   #[serde(rename = "table.skipFormat")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1545,6 +1545,7 @@ fn gen_html(node: &Html, ctx: &mut Context) -> PrintItems {
       use_tabs: ctx.configuration.html_use_tabs,
       indent_width: ctx.configuration.html_indent_width,
       self_closing_space: ctx.configuration.html_self_closing_space,
+      prefer_single_line: ctx.configuration.html_prefer_single_line,
     };
     // an html block is very often a fragment, because a blank line closes the
     // block and leaves its closing tag to a block of its own -- whatever the

--- a/src/html/printer.rs
+++ b/src/html/printer.rs
@@ -24,6 +24,10 @@ pub struct HtmlFormatOptions {
   pub indent_width: u8,
   /// Whether to write a space before the `/>` that closes a self-closing tag.
   pub self_closing_space: bool,
+  /// Whether to write an element's content, or a tag's attributes, on the one
+  /// line when they fit even where they were written across lines. Otherwise
+  /// what was written across lines stays that way and is only reindented.
+  pub prefer_single_line: bool,
 }
 
 /// Formats an html fragment.
@@ -124,10 +128,24 @@ impl Printer<'_> {
     // an element whose content doesn't fit isn't written twice. Measuring is
     // what keeps the cost of a deeply nested document from doubling with every
     // level of it.
+    // A block's content that was written on lines of its own is kept there
+    // unless a single line is preferred. The whitespace at the edges of an
+    // inline element's content is rendered, so a line break written there is
+    // one the content never fits on a line with anyway.
     let is_block = tags::is_block(element.name);
-    let fits = content_flat_width(&element.children, is_block, self.options).is_some_and(|width| {
-      self.current_column() + width + close_tag_width(element) <= self.options.line_width as usize
-    });
+    let keeps_lines = is_block && !self.options.prefer_single_line && content_on_own_lines(&element.children);
+    let fits = !keeps_lines
+      && content_flat_width(&element.children, is_block, self.options).is_some_and(|width| {
+        self.current_column() + width + close_tag_width(element) <= self.options.line_width as usize
+      });
+    if keeps_lines && trimmed_run(&element.children).is_none() {
+      // nothing but whitespace was written between the tags, so the close tag
+      // goes on the line below the open one rather than on one of its own
+      // below a line that would hold only indentation
+      self.newline(indent);
+      self.print_close_tag(element);
+      return;
+    }
     if fits {
       // every part of the content fits along with the whole of it, so each of
       // them is written on this line in turn
@@ -222,13 +240,21 @@ impl Printer<'_> {
   }
 
   fn print_open_tag(&mut self, element: &Element, indent: usize) {
+    // a tag written partway along a line isn't the place to start writing
+    // attributes on lines of their own: the line it would break is one the
+    // tags around it are sharing, and taking it apart reads worse than
+    // leaving it long
+    if !self.at_line_start() {
+      self.write_open_tag(element);
+      return;
+    }
+    // attributes the author wrote on lines of their own are kept there unless
+    // a single line is preferred
+    let keeps_lines = !self.options.prefer_single_line && attributes_on_own_lines(element);
     let fits = self.current_column() + open_tag_width(element, self.options) <= self.options.line_width as usize;
-    // A lone attribute has nowhere better to go, so it stays where it was
-    // written rather than being pushed onto a line of its own. Nor is a tag
-    // written partway along a line the place to start writing attributes on
-    // lines of their own: the line it would break is one the tags around it
-    // are sharing, and taking it apart reads worse than leaving it long.
-    if fits || element.attributes.len() < 2 || !self.at_line_start() {
+    // a lone attribute has nowhere better to go, so it stays where it was
+    // written rather than being pushed onto a line of its own
+    if !keeps_lines && (fits || element.attributes.len() < 2) {
       self.write_open_tag(element);
       return;
     }
@@ -341,6 +367,44 @@ fn ends_with_whitespace(children: &[Node]) -> bool {
   matches!(children.last(), Some(Node::Text(text)) if text.ends_with(is_html_whitespace))
 }
 
+/// Whether the author wrote an element's content on lines of its own, with a
+/// line break directly after the open tag or directly before the close tag.
+fn content_on_own_lines(children: &[Node]) -> bool {
+  let starts_on_own_line = matches!(
+    children.first(),
+    Some(Node::Text(text)) if leading_whitespace(text).contains('\n')
+  );
+  let ends_on_own_line = matches!(
+    children.last(),
+    Some(Node::Text(text)) if trailing_whitespace(text).contains('\n')
+  );
+  starts_on_own_line || ends_on_own_line
+}
+
+fn leading_whitespace(text: &str) -> &str {
+  &text[..text.len() - text.trim_start_matches(is_html_whitespace).len()]
+}
+
+fn trailing_whitespace(text: &str) -> &str {
+  &text[text.trim_end_matches(is_html_whitespace).len()..]
+}
+
+/// Whether the author wrote a tag's attributes on lines of their own, with a
+/// line break between the tag name and the first of them.
+///
+/// The whitespace within a tag isn't kept by the parser, so this reads it back
+/// off the source the element was parsed out of, which the name and the
+/// attributes borrow from.
+fn attributes_on_own_lines(element: &Element) -> bool {
+  let Some(first) = element.attributes.first() else {
+    return false;
+  };
+  let source_start = element.source.as_ptr() as usize;
+  let name_end = element.name.as_ptr() as usize + element.name.len() - source_start;
+  let first_start = first.name.as_ptr() as usize - source_start;
+  element.source[name_end..first_start].contains('\n')
+}
+
 fn is_block_node(node: &Node) -> bool {
   match node {
     Node::Element(element) => tags::is_block(element.name),
@@ -405,7 +469,11 @@ fn run_flat_width(nodes: &[Node], trim_start: bool, trim_end: bool, options: &Ht
 }
 
 fn element_flat_width(element: &Element, options: &HtmlFormatOptions) -> Option<usize> {
-  // a value written across lines takes the tag with it
+  // A value written across lines takes the tag with it. Attributes being kept
+  // on lines of their own don't come into it: only a block is given a line of
+  // its own to write them from, and a block is never measured as part of a
+  // run, while an inline element sits within one and its attributes stay on
+  // the line the run is on.
   if element
     .attributes
     .iter()
@@ -539,6 +607,7 @@ mod test {
         use_tabs: false,
         indent_width: 2,
         self_closing_space: true,
+        prefer_single_line: true,
       },
     )
     .unwrap_or_else(|err| panic!("expected {:?} to format, but: {}", text, err))
@@ -554,6 +623,7 @@ mod test {
         use_tabs: false,
         indent_width: 2,
         self_closing_space: true,
+        prefer_single_line: true,
       },
     );
     assert!(result.is_err(), "expected {:?} to be kept, but got {:?}", text, result);
@@ -757,6 +827,7 @@ mod test {
           use_tabs: false,
           indent_width: 2,
           self_closing_space: false,
+          prefer_single_line: true,
         },
       )
       .unwrap()

--- a/src/html/text_fuzz.rs
+++ b/src/html/text_fuzz.rs
@@ -171,9 +171,15 @@ fn html_is_read_and_written_back_out_whole() {
     if let Err(message) = validate_coverage(&document, &source) {
       failures.push(format!("case {}: {:?}\n  {}", case, source, message));
     } else {
-      match check_printing(&source, &document) {
-        Ok(was_laid_out) => laid_out += u64::from(was_laid_out),
-        Err(message) => failures.push(format!("case {}: {:?}\n  {}", case, source, message)),
+      // both layouts are reachable from the configuration, so both are checked
+      for prefer_single_line in [false, true] {
+        match check_printing(&source, &document, prefer_single_line) {
+          Ok(was_laid_out) => laid_out += u64::from(was_laid_out && !prefer_single_line),
+          Err(message) => failures.push(format!(
+            "case {} (preferSingleLine: {}): {:?}\n  {}",
+            case, prefer_single_line, source, message
+          )),
+        }
       }
     }
     if failures.len() >= 10 {
@@ -203,12 +209,13 @@ fn html_is_read_and_written_back_out_whole() {
 
 /// Checks what has to hold of the html the printer writes out, giving back
 /// whether it had anything to say about it at all.
-fn check_printing(source: &str, document: &Document<'_>) -> Result<bool, String> {
+fn check_printing(source: &str, document: &Document<'_>, prefer_single_line: bool) -> Result<bool, String> {
   let options = HtmlFormatOptions {
     line_width: 40,
     use_tabs: false,
     indent_width: 2,
     self_closing_space: true,
+    prefer_single_line,
   };
   // html the printer won't lay out is left as it was written, the same as html
   // the parser refuses

--- a/tests/specs/Issues/Issue0124.txt
+++ b/tests/specs/Issues/Issue0124.txt
@@ -55,7 +55,9 @@
     </div>
 
 [expect]
-- <div>Test</div>
+- <div>
+    Test
+  </div>
 
 !! should maintain the indentation in a footnote definition !!
 [^1]: Test

--- a/tests/specs/html/HtmlFormat_KeepLines.txt
+++ b/tests/specs/html/HtmlFormat_KeepLines.txt
@@ -1,0 +1,143 @@
+~~ lineWidth: 60 ~~
+!! should keep content that was written on lines of its own, and reindent it !!
+<div>
+<span>a</span>
+</div>
+
+<div>
+      some text
+</div>
+
+<table>
+  <tr>
+    <td>
+      a
+    </td>
+  </tr>
+</table>
+
+[expect]
+<div>
+  <span>a</span>
+</div>
+
+<div>
+  some text
+</div>
+
+<table>
+  <tr>
+    <td>
+      a
+    </td>
+  </tr>
+</table>
+
+!! should keep content on its own lines where only one of its edges was broken !!
+<div>
+a</div>
+
+<div>a
+</div>
+
+[expect]
+<div>
+  a
+</div>
+
+<div>
+  a
+</div>
+
+!! should keep a block written on one line on it !!
+<div><span>a</span></div>
+
+<div>a</div>
+
+[expect]
+<div><span>a</span></div>
+
+<div>a</div>
+
+!! should write the close tag of an element holding only whitespace on the line below !!
+<div>
+</div>
+
+[expect]
+<div>
+</div>
+
+!! should keep attributes that were written on lines of their own !!
+<div
+  class="a"
+  id="b">x</div>
+
+<div
+  class="a">x</div>
+
+[expect]
+<div
+  class="a"
+  id="b"
+>x</div>
+
+<div
+  class="a"
+>x</div>
+
+!! should keep attributes on one line where they were written on one !!
+<div class="a" id="b">x</div>
+
+[expect]
+<div class="a" id="b">x</div>
+
+!! should open up a block whose child keeps its attributes on lines of their own !!
+<div><p
+  class="a" id="b">x</p></div>
+
+[expect]
+<div>
+  <p
+    class="a"
+    id="b"
+  >x</p>
+</div>
+
+!! should keep the lines of an element holding only whitespace within a list item and another block !!
+- <div>
+  </div>
+
+<div>
+  <p>
+  </p>
+</div>
+
+[expect]
+- <div>
+  </div>
+
+<div>
+  <p>
+  </p>
+</div>
+
+!! should keep the attributes of an inline tag that starts its line !!
+<div>
+  <a
+    href="x" id="y">y</a>
+</div>
+
+[expect]
+<div>
+  <a
+    href="x"
+    id="y"
+  >y</a>
+</div>
+
+!! should keep attributes on the line of an inline tag written within a run !!
+<p>text <a
+  href="x" id="y">y</a></p>
+
+[expect]
+<p>text <a href="x" id="y">y</a></p>

--- a/tests/specs/html/HtmlFormat_PreferSingleLine.txt
+++ b/tests/specs/html/HtmlFormat_PreferSingleLine.txt
@@ -1,0 +1,53 @@
+~~ lineWidth: 60, html.preferSingleLine: true ~~
+!! should write content that fits on the line of its tags !!
+<div>
+<span>a</span>
+</div>
+
+<div>
+      some text
+</div>
+
+<table>
+  <tr>
+    <td>
+      a
+    </td>
+  </tr>
+</table>
+
+[expect]
+<div><span>a</span></div>
+
+<div>some text</div>
+
+<table>
+  <tr>
+    <td>a</td>
+  </tr>
+</table>
+
+!! should write attributes that fit on the line of their tag !!
+<div
+  class="a"
+  id="b">x</div>
+
+[expect]
+<div class="a" id="b">x</div>
+
+!! should still break a long list of attributes onto lines of their own !!
+<div class="one two three" id="the-identifier" data-value="something">a</div>
+
+[expect]
+<div
+  class="one two three"
+  id="the-identifier"
+  data-value="something"
+>a</div>
+
+!! should write the tags of an element holding only whitespace together !!
+<div>
+</div>
+
+[expect]
+<div></div>

--- a/tests/specs/html/HtmlFormat_RawText.txt
+++ b/tests/specs/html/HtmlFormat_RawText.txt
@@ -46,7 +46,9 @@
 </div>
 
 [expect]
-<div><textarea>  keep   this  </textarea></div>
+<div>
+  <textarea>  keep   this  </textarea>
+</div>
 
 !! should keep a cdata section and processing instruction !!
 <div><p><![CDATA[ a < b ]]></p></div>

--- a/tests/specs/html/Html_All.txt
+++ b/tests/specs/html/Html_All.txt
@@ -56,4 +56,6 @@ a 
 </div>
 
 [expect]
-<div>a </div>
+<div>
+  a 
+</div>


### PR DESCRIPTION
The html formatter from #255 writes a block element's content on the line of its tags whenever it fits, and joins attributes written across lines when they fit. That takes apart layouts an author chose deliberately:

```html
<div>
<span>a</span>
</div>
```

became `<div><span>a</span></div>`.

This adds `html.preferSingleLine`, a boolean that's **off by default**, named after the option of the same meaning in dprint-plugin-typescript. When off:

- A block element whose content was written with a line break directly after its open tag or directly before its close tag is kept opened up, and only reindented. An element written on one line stays on it.
- A tag whose attributes were written with a line break after the tag name keeps one attribute per line (with the `>` on its own line, as a long tag already gets), where the tag starts its line. An inline tag within a run keeps its attributes on the run's line, as before.
- A block holding only whitespace is written as `<div>\n</div>` rather than gaining an indentation-only line or being closed up.

Turning it on restores the previous behaviour exactly. The three existing specs that asserted a collapse now assert the kept lines, and `HtmlFormat_KeepLines.txt` / `HtmlFormat_PreferSingleLine.txt` cover the two settings side by side. The html fuzz test now runs both settings.

The parser doesn't keep the whitespace within a tag, so whether attributes were broken after the name is read back off `element.source`, which the name and attribute names borrow from.