### PR TITLE
fix: mistakes found reviewing the parser, formatter and html, with tests

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -76,7 +76,7 @@ impl ConfigurationBuilder {
   }
 
   /// The character to use for strong emphasis/bold.
-  /// Default: `StrongKind::Underscores`
+  /// Default: `StrongKind::Asterisks`
   pub fn strong_kind(&mut self, value: StrongKind) -> &mut Self {
     self.insert("strongKind", value.to_string().into())
   }
@@ -282,6 +282,10 @@ mod tests {
       .code_block_preserve_blank_lines(true)
       .code_block_use_tabs(true)
       .code_block_indent_width(2)
+      .html_skip_format(true)
+      .html_use_tabs(true)
+      .html_indent_width(4)
+      .html_self_closing_space(false)
       .html_prefer_single_line(true)
       .table_skip_format(true)
       .table_cell_padding(TableCellPadding::Space)
@@ -291,7 +295,7 @@ mod tests {
       .ignore_end_directive("test");
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 25);
+    assert_eq!(inner_config.len(), 29);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -154,6 +154,39 @@ pub fn resolve_config(
 /// Reads a property, falling back to the deprecated name the property used to
 /// go by. Both names are taken from the map so that a deprecated one isn't
 /// reported as unknown.
+/// A key written under a name the plugin has since renamed, which is what
+/// `dprint config update` moves over.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigKeyRename {
+  pub old_key: &'static str,
+  pub new_key: &'static str,
+  /// The value to write under the new key, or `None` when the new key was
+  /// already set and the old one is only to be dropped.
+  pub value: Option<ConfigKeyValue>,
+}
+
+/// Finds the keys of a configuration that are written under a deprecated name.
+pub fn get_config_key_renames(config: &ConfigKeyMap) -> Vec<ConfigKeyRename> {
+  RENAMED_KEYS
+    .iter()
+    .filter_map(|(old_key, new_key)| {
+      let value = config.get(*old_key)?;
+      Some(ConfigKeyRename {
+        old_key,
+        new_key,
+        value: (!config.contains_key(*new_key)).then(|| value.clone()),
+      })
+    })
+    .collect()
+}
+
+/// Each key that was renamed, as the old name then the new one.
+const RENAMED_KEYS: &[(&str, &str)] = &[
+  ("headingKind", "heading.kind"),
+  ("unorderedListKind", "list.unorderedMarker"),
+  ("listIndentKind", "list.indentKind"),
+];
+
 fn get_renamed_value<T>(
   config: &mut ConfigKeyMap,
   key: &str,
@@ -255,5 +288,190 @@ fn fill_deno_config(config: &mut ConfigKeyMap) {
     if !config.contains_key(key) {
       config.insert(key.clone(), value.clone());
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn renames_deprecated_keys() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "setext".into());
+    config.insert("unorderedListKind".into(), "asterisks".into());
+    config.insert("listIndentKind".into(), "pythonMarkdown".into());
+    config.insert("textWrap".into(), "always".into());
+
+    assert_eq!(
+      get_config_key_renames(&config),
+      vec![
+        ConfigKeyRename {
+          old_key: "headingKind",
+          new_key: "heading.kind",
+          value: Some("setext".into()),
+        },
+        ConfigKeyRename {
+          old_key: "unorderedListKind",
+          new_key: "list.unorderedMarker",
+          value: Some("asterisks".into()),
+        },
+        ConfigKeyRename {
+          old_key: "listIndentKind",
+          new_key: "list.indentKind",
+          value: Some("pythonMarkdown".into()),
+        },
+      ]
+    );
+  }
+
+  #[test]
+  fn rename_keeps_the_new_key_when_both_are_set() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "setext".into());
+    config.insert("heading.kind".into(), "atx".into());
+
+    assert_eq!(
+      get_config_key_renames(&config),
+      vec![ConfigKeyRename {
+        old_key: "headingKind",
+        new_key: "heading.kind",
+        value: None,
+      }]
+    );
+  }
+
+  #[test]
+  fn no_renames_for_a_current_config() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("heading.kind".into(), "setext".into());
+    assert!(get_config_key_renames(&config).is_empty());
+    assert!(get_config_key_renames(&ConfigKeyMap::new()).is_empty());
+  }
+
+  #[test]
+  fn deprecated_key_is_used_when_the_new_one_is_not_set() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "setext".into());
+    config.insert("unorderedListKind".into(), "asterisks".into());
+    config.insert("listIndentKind".into(), "pythonMarkdown".into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert_eq!(result.config.heading_kind, HeadingKind::Setext);
+    assert_eq!(result.config.list_unordered_marker, ListUnorderedMarker::Asterisks);
+    assert_eq!(result.config.list_indent_kind, ListIndentKind::PythonMarkdown);
+  }
+
+  #[test]
+  fn new_key_wins_over_deprecated_key() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("headingKind".into(), "setext".into());
+    config.insert("heading.kind".into(), "atx".into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert_eq!(result.config.heading_kind, HeadingKind::Atx);
+  }
+
+  #[test]
+  fn unknown_property_diagnostic() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("unknownKey".into(), true.into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].property_name, "unknownKey");
+    assert_eq!(
+      result.diagnostics[0].message,
+      "Unknown property in configuration: unknownKey"
+    );
+  }
+
+  #[test]
+  fn invalid_enum_value_uses_default() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("textWrap".into(), "bogus".into());
+
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].property_name, "textWrap");
+    assert!(result.diagnostics[0].message.contains("bogus"));
+    assert_eq!(result.config.text_wrap, TextWrap::Maintain);
+  }
+
+  #[test]
+  fn invalid_value_type_uses_default() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("lineWidth".into(), "abc".into());
+    config.insert("codeBlock.useTabs".into(), "yes".into());
+    config.insert("heading.blankLinesAbove".into(), "x".into());
+    config.insert("html.indentWidth".into(), 300.into());
+
+    let result = resolve_config(config, &Default::default());
+    let mut names = result
+      .diagnostics
+      .iter()
+      .map(|diagnostic| diagnostic.property_name.as_str())
+      .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(
+      names,
+      vec![
+        "codeBlock.useTabs",
+        "heading.blankLinesAbove",
+        "html.indentWidth",
+        "lineWidth"
+      ]
+    );
+    assert_eq!(result.config.line_width, 80);
+    assert_eq!(result.config.code_block_use_tabs, None);
+    assert_eq!(result.config.heading_blank_lines_above, None);
+    assert_eq!(result.config.html_indent_width, 2);
+  }
+
+  #[test]
+  fn deno_fills_defaults_without_overriding_explicit_values() {
+    let mut config = ConfigKeyMap::new();
+    config.insert("deno".into(), true.into());
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert_eq!(result.config.text_wrap, TextWrap::Always);
+    assert_eq!(result.config.ignore_directive, "deno-fmt-ignore");
+    assert_eq!(result.config.ignore_file_directive, "deno-fmt-ignore-file");
+    assert_eq!(result.config.ignore_start_directive, "deno-fmt-ignore-start");
+    assert_eq!(result.config.ignore_end_directive, "deno-fmt-ignore-end");
+
+    let mut config = ConfigKeyMap::new();
+    config.insert("deno".into(), true.into());
+    config.insert("textWrap".into(), "never".into());
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 0);
+    assert_eq!(result.config.text_wrap, TextWrap::Never);
+
+    let mut config = ConfigKeyMap::new();
+    config.insert("deno".into(), "yes".into());
+    let result = resolve_config(config, &Default::default());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].property_name, "deno");
+  }
+
+  #[test]
+  fn html_indentation_falls_back_to_global_config() {
+    let mut global_config = ConfigKeyMap::new();
+    global_config.insert("useTabs".into(), true.into());
+    global_config.insert("indentWidth".into(), 4.into());
+    let global_config = resolve_global_config(&mut global_config).config;
+
+    let result = resolve_config(ConfigKeyMap::new(), &global_config);
+    assert_eq!(result.config.html_use_tabs, true);
+    assert_eq!(result.config.html_indent_width, 4);
+    // the code block indentation is only ever what was asked for
+    assert_eq!(result.config.code_block_use_tabs, None);
+    assert_eq!(result.config.code_block_indent_width, None);
+
+    let result = resolve_config(ConfigKeyMap::new(), &Default::default());
+    assert_eq!(result.config.html_use_tabs, false);
+    assert_eq!(result.config.html_indent_width, 2);
   }
 }

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -95,7 +95,7 @@ pub struct Configuration {
 }
 
 /// Text wrapping possibilities.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TextWrap {
   /// Always wraps text.
@@ -138,7 +138,7 @@ generate_str_to_from![
 ];
 
 /// The character to use for emphasis/italics.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EmphasisKind {
   /// Uses asterisks (*) for emphasis.
@@ -150,7 +150,7 @@ pub enum EmphasisKind {
 generate_str_to_from![EmphasisKind, [Asterisks, "asterisks"], [Underscores, "underscores"]];
 
 /// The character to use for strong emphasis/bold.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum StrongKind {
   /// Uses asterisks (**) for strong emphasis (default).
@@ -166,7 +166,7 @@ generate_str_to_from![StrongKind, [Asterisks, "asterisks"], [Underscores, "under
 /// [ATX](https://spec.commonmark.org/0.31.2/#atx-headings). Level 3 and
 /// higher headings always use ATX headings, since Markdown only supports
 /// setext headers for levels 1 and 2.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum HeadingKind {
   /// Uses an underline of `=` or `-` beneath the heading text for level 1 and
@@ -180,7 +180,7 @@ generate_str_to_from![HeadingKind, [Setext, "setext"], [Atx, "atx"]];
 
 /// The style of [hard line break](https://spec.commonmark.org/0.31.2/#hard-line-breaks)
 /// to use.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum HardBreakKind {
   /// Uses a trailing backslash (default).
@@ -195,7 +195,7 @@ pub enum HardBreakKind {
 generate_str_to_from![HardBreakKind, [Backslash, "backslash"], [DoubleSpace, "doubleSpace"]];
 
 /// The padding to write around the text of a table's cells.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TableCellPadding {
   /// Pads a cell out to the width of its column, which aligns the cells of a
@@ -219,7 +219,7 @@ generate_str_to_from![TableCellPadding, [Align, "align"], [Space, "space"], [Non
 /// separated by other paragraphs. This parameter defines which character should be used as primary
 /// list character, i.e., either '-' (default) or '*'. The alternate list character will be the one
 /// which is _not_ primary.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ListUnorderedMarker {
   /// Uses dashes (-) as primary character for lists (default).
@@ -253,7 +253,7 @@ generate_str_to_from![ListUnorderedMarker, [Dashes, "dashes"], [Asterisks, "aste
 /// (e.g. 3 spaces for `1. `, 4 spaces for `10. `). PythonMarkdown uses a fixed
 /// 4-space indent regardless of marker width, which is required by tools like
 /// mkdocs-material.
-#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ListIndentKind {
   /// Indents continuation lines to align with the content after the list marker (default).

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -251,6 +251,157 @@ not  code
     );
   }
 
+  #[test]
+  fn empty_and_whitespace_only_files() {
+    let config = ConfigurationBuilder::new().build();
+    assert_eq!(format_text("", &config, |_, _, _| Ok(None)).unwrap(), None);
+    for input_text in ["\n", "\n\n\n", "   \n  \n", "\u{FEFF}", "\u{FEFF}\n"] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(None)).unwrap();
+      assert_eq!(result, Some(String::new()), "{:?}", input_text);
+    }
+  }
+
+  #[test]
+  fn ends_the_file_with_a_single_newline() {
+    let config = ConfigurationBuilder::new().build();
+    for (input_text, expected) in [("a", Some("a\n")), ("a\n", None), ("a\n\n", Some("a\n"))] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(None)).unwrap();
+      assert_eq!(result.as_deref(), expected, "{:?}", input_text);
+    }
+  }
+
+  #[test]
+  fn new_line_kind() {
+    let config = ConfigurationBuilder::new().build();
+    let result = format_text("a\r\nb\r\n", &config, |_, _, _| Ok(None)).unwrap();
+    assert_eq!(result.as_deref(), Some("a\nb\n"));
+
+    let config = ConfigurationBuilder::new()
+      .new_line_kind(dprint_core::configuration::NewLineKind::Auto)
+      .build();
+    for (input_text, expected) in [
+      ("a\r\nb\r\n", None),
+      ("a\nb\r\n", Some("a\r\nb\r\n")),
+      ("a\r\nb", Some("a\r\nb\r\n")),
+      ("\u{FEFF}a\r\nb\r\n", Some("a\r\nb\r\n")),
+    ] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(None)).unwrap();
+      assert_eq!(result.as_deref(), expected, "{:?}", input_text);
+    }
+  }
+
+  #[test]
+  fn ignore_file_directive_variants() {
+    let config = ConfigurationBuilder::new().build();
+    for input_text in [
+      "<!-- dprint-ignore-file -->\n#  a",
+      "\u{FEFF}<!-- dprint-ignore-file -->\n#  a",
+      "<!-- dprint-ignore-file -->\r\n#  a",
+      "---\na: b\n---\n\n<!-- dprint-ignore-file -->\n#  a",
+    ] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(None)).unwrap();
+      assert_eq!(result, None, "{:?}", input_text);
+    }
+  }
+
+  #[test]
+  fn code_block_callback_return_values() {
+    let config = ConfigurationBuilder::new().build();
+    let input_text = "```js\nx\n```\n";
+    for returned in ["formatted", "formatted\n", "formatted\r\n", "formatted\n\n"] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(Some(returned.to_string()))).unwrap();
+      assert_eq!(result.as_deref(), Some("```js\nformatted\n```\n"), "{:?}", returned);
+    }
+    for returned in ["", "\n"] {
+      let result = format_text(input_text, &config, |_, _, _| Ok(Some(returned.to_string()))).unwrap();
+      assert_eq!(result.as_deref(), Some("```js\n```\n"), "{:?}", returned);
+    }
+    let result = format_text(input_text, &config, |_, text, _| Ok(Some(text.to_string()))).unwrap();
+    assert_eq!(result, None);
+  }
+
+  #[test]
+  fn code_block_callback_receives_tag_text_and_width() {
+    let config = ConfigurationBuilder::new().line_width(12).build();
+    let mut calls = Vec::new();
+    let input_text = "```rust,ignore\nx\n```\n\n```JS\r\ny\r\nz\r\n```\r\n\n> - ```ts\n>   w\n>   ```\n";
+    format_text(input_text, &config, |tag, text, width| {
+      calls.push(format!("{} {:?} {}", tag, text, width));
+      Ok(None)
+    })
+    .unwrap();
+    // the tag is passed as written and the width is what is left after the
+    // indentation, though never below 10
+    assert_eq!(calls, vec!["rust \"x\" 12", "JS \"y\\nz\" 12", "ts \"w\" 10"]);
+  }
+
+  #[test]
+  fn code_block_callback_not_called() {
+    let mut calls = 0;
+    let mut count = |_: &str, _: &str, _: u32| {
+      calls += 1;
+      Ok(None)
+    };
+    let config = ConfigurationBuilder::new().code_block_skip_format(true).build();
+    assert_eq!(format_text("```js\nx\n```\n", &config, &mut count).unwrap(), None);
+    let config = ConfigurationBuilder::new().build();
+    for input_text in [
+      "<!-- dprint-ignore-start -->\n\n```js\nx\n```\n\n<!-- dprint-ignore-end -->\n",
+      "```\nx\n```\n",
+      "    x\n",
+    ] {
+      assert_eq!(
+        format_text(input_text, &config, &mut count).unwrap(),
+        None,
+        "{:?}",
+        input_text
+      );
+    }
+    assert_eq!(calls, 0);
+  }
+
+  #[test]
+  fn nested_markdown_forwards_inner_tags() {
+    let config = ConfigurationBuilder::new().build();
+    for outer_tag in ["markdown", "md", "MD", "Markdown"] {
+      let input_text = format!("````{}\n#  Title\n\n```js\nx\n```\n````\n", outer_tag);
+      let mut tags = Vec::new();
+      let result = format_text(&input_text, &config, |tag, _, _| {
+        tags.push(tag.to_string());
+        Ok(None)
+      })
+      .unwrap();
+      assert_eq!(tags, vec!["js"], "{}", outer_tag);
+      let expected = format!("````{}\n# Title\n\n```js\nx\n```\n````\n", outer_tag);
+      assert_eq!(result.as_deref(), Some(expected.as_str()));
+    }
+  }
+
+  #[test]
+  fn preserve_options_pass_text_through() {
+    let config = ConfigurationBuilder::new()
+      .code_block_preserve_indentation(true)
+      .build();
+    let mut seen = Vec::new();
+    format_text("```js\n    x\n```\n", &config, |_, text, _| {
+      seen.push(text.to_string());
+      Ok(None)
+    })
+    .unwrap();
+    assert_eq!(seen, vec!["    x"]);
+
+    let config = ConfigurationBuilder::new()
+      .code_block_preserve_blank_lines(true)
+      .build();
+    let mut seen = Vec::new();
+    format_text("```js\n\nx\n\n```\n", &config, |_, text, _| {
+      seen.push(text.to_string());
+      Ok(None)
+    })
+    .unwrap();
+    assert_eq!(seen, vec!["\nx\n"]);
+  }
+
   /// A configuration that fails a file for an error a code block's plugin runs
   /// into.
   fn raise_errors_config() -> Configuration {

--- a/src/generation/gen_types.rs
+++ b/src/generation/gen_types.rs
@@ -365,6 +365,12 @@ impl<'a> Context<'a> {
     self.block_quote_base_indents.len()
   }
 
+  /// The indentation of what's being generated beyond the block quote it is
+  /// within, which is what the list items inside that quote write.
+  pub fn indent_within_block_quote(&self) -> u32 {
+    self.indent_level - self.block_quote_base_indents.last().copied().unwrap_or(0)
+  }
+
   /// Writes out the text decorations within with the characters they were
   /// written with, which the name of a reference depends on.
   pub fn with_preserved_decorations<T>(&mut self, func: impl FnOnce(&mut Context) -> T) -> T {
@@ -547,7 +553,7 @@ impl<'a> Context<'a> {
   pub fn format_text<'b>(&mut self, tag: &str, text: &'b str) -> FormatResult {
     let line_width = std::cmp::max(10, self.configuration.line_width as i32 - self.indent_level as i32) as u32;
 
-    match tag {
+    match tag.to_lowercase().as_str() {
       "markdown" | "md" => format_text(text, self.configuration, |tag, file_text, line_width| {
         (self.format_code_block_text)(tag, file_text, line_width)
       }),

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -119,6 +119,28 @@ fn push_dropped_breaks(nodes: &[Node], context: &Context, dropped: &mut DroppedB
   }
 }
 
+/// Whether the node is written within a paragraph rather than as a block.
+fn is_inline_node(node: &Node) -> bool {
+  matches!(
+    node,
+    Node::Code(_)
+      | Node::SoftBreak(_)
+      | Node::HardBreak(_)
+      | Node::TextDecoration(_)
+      | Node::FootnoteReference(_)
+      | Node::InlineLink(_)
+      | Node::ReferenceLink(_)
+      | Node::ShortcutLink(_)
+      | Node::AutoLink(_)
+      | Node::Text(_)
+      | Node::InlineImage(_)
+      | Node::ReferenceImage(_)
+      | Node::ShortcutImage(_)
+      | Node::InlineMath(_)
+      | Node::DisplayMath(_)
+  )
+}
+
 /// The nodes written within this one, which hold breaks of their own.
 fn written_children<'a>(node: &'a Node<'a>) -> Option<&'a [Node<'a>]> {
   match node {
@@ -199,11 +221,15 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
           | Node::DefinitionList(_)
           | Node::Table(_)
           | Node::MetadataBlock(_)
-          | Node::BlockQuote(_)
-          | Node::DisplayMath(_) => {
+          | Node::BlockQuote(_) => {
             items.extend(get_conditional_blank_line(node, context));
           }
-          Node::Code(_)
+          // display math is a block of its own only where it is written as one
+          Node::DisplayMath(_) if !is_inline_node(node) => {
+            items.extend(get_conditional_blank_line(node, context));
+          }
+          Node::DisplayMath(_)
+          | Node::Code(_)
           | Node::SoftBreak(_)
           | Node::TextDecoration(_)
           | Node::FootnoteReference(_)
@@ -348,11 +374,17 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
             items.push_signal(Signal::NewLine);
           }
 
-          // include the leading indent
+          // the node's line is written from its start, so that the indentation
+          // written before an indented code block is kept
           let node_span = node.span();
-          let text_start = utils::get_leading_non_space_tab_byte_pos(context.file_text, node_span.start);
-          items.extend(ir_helpers::gen_from_raw_string(
-            context.file_text[text_start..node_span.end].trim_end_matches(WHITESPACE),
+          let line_start = context.file_text[..node_span.start]
+            .rfind('\n')
+            .map(|index| index + 1)
+            .unwrap_or(0);
+          items.extend(gen_ignored_text(
+            context.file_text[line_start..node_span.end].trim_end_matches(WHITESPACE),
+            true,
+            context,
           ));
 
           last_node = Some(node);
@@ -377,11 +409,13 @@ fn gen_nodes_within_breaks(nodes: &[Node], context: &mut Context) -> PrintItems 
           .unwrap_or_else(|| last_node.unwrap().span().end);
         let ignore_text = &context.file_text[start..end];
         if let Some(end_comment) = end_comment {
-          items.extend(ir_helpers::gen_from_raw_string(ignore_text));
+          items.extend(gen_ignored_text(ignore_text, false, context));
           items.extend(gen_html(end_comment, context));
         } else {
-          items.extend(ir_helpers::gen_from_raw_string(
+          items.extend(gen_ignored_text(
             ignore_text.trim_end_matches(WHITESPACE),
+            false,
+            context,
           ));
         }
       }
@@ -1573,6 +1607,51 @@ fn gen_inline_math(node: &InlineMath, ctx: &mut Context) -> PrintItems {
   gen_range(node.span, ctx)
 }
 
+/// Writes out text the formatter was told to leave alone as it was written,
+/// apart from what the containers around it write out themselves: the block
+/// quote markers and the indentation of the list items each line is within.
+/// Every line is written as a line of its own, so that the printer writes
+/// that prefix before it the way it does for any other line.
+///
+/// The first line is stripped of its prefix only where it starts a line of
+/// the file, as text that follows a comment on its line is written on from
+/// where the comment ends.
+fn gen_ignored_text(text: &str, starts_line: bool, context: &Context) -> PrintItems {
+  let mut items = PrintItems::new();
+  for (index, line) in text.split('\n').enumerate() {
+    if index > 0 {
+      items.push_signal(Signal::NewLine);
+    }
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    let line = if index > 0 || starts_line {
+      strip_container_prefix(line, context)
+    } else {
+      line
+    };
+    if !line.is_empty() {
+      items.extend(ir_helpers::gen_from_raw_string(line));
+    }
+  }
+  items
+}
+
+/// Strips what the containers the line is within write before it: the marker
+/// of each block quote, then the indentation of the list items inside the
+/// innermost one. Only as much indentation as those items write is stripped,
+/// so that anything indented further keeps what it was indented by.
+fn strip_container_prefix<'a>(line: &'a str, context: &Context) -> &'a str {
+  let mut rest = strip_markers_of_depth(line, context.block_quote_depth());
+  let mut columns = context.indent_within_block_quote();
+  while columns > 0 {
+    let Some(stripped) = rest.strip_prefix([' ', '\t']) else {
+      break;
+    };
+    columns = columns.saturating_sub(if rest.starts_with('\t') { 4 } else { 1 });
+    rest = stripped;
+  }
+  rest
+}
+
 /// Writes out the text of the span as it is in the file, apart from the block
 /// quote markers that the printer writes out itself.
 fn gen_range(span: Span, ctx: &mut Context) -> PrintItems {
@@ -1615,7 +1694,7 @@ fn strip_raw_block_quote_markers<'a>(text: &'a str, context: &Context) -> Cow<'a
   // the first line is written out where the printer has already put the
   // markers, so only what follows it can have picked any up
   let continued_lines = || text.split('\n').skip(1);
-  if depth == 0 || !continued_lines().any(|line| strip_markers(line, depth).len() != line.len()) {
+  if depth == 0 || !continued_lines().any(|line| strip_markers_of_depth(line, depth).len() != line.len()) {
     return Cow::Borrowed(text);
   }
 
@@ -1623,28 +1702,29 @@ fn strip_raw_block_quote_markers<'a>(text: &'a str, context: &Context) -> Cow<'a
   result.push_str(text.split('\n').next().unwrap_or(""));
   for line in continued_lines() {
     result.push('\n');
-    result.push_str(strip_markers(line, depth));
+    result.push_str(strip_markers_of_depth(line, depth));
   }
-  return Cow::Owned(result);
+  Cow::Owned(result)
+}
 
-  fn strip_markers(line: &str, depth: usize) -> &str {
-    let mut line = line;
-    for _ in 0..depth {
-      let trimmed = line.trim_start_matches([' ', '\t']);
-      let Some(rest) = trimmed.strip_prefix('>') else {
-        return line;
-      };
-      // a single space after a marker is part of it
-      line = rest.strip_prefix(' ').unwrap_or(rest);
-    }
-    line
+/// Strips the markers of as many block quotes as the line is written within.
+fn strip_markers_of_depth(line: &str, depth: usize) -> &str {
+  let mut line = line;
+  for _ in 0..depth {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+    let Some(rest) = trimmed.strip_prefix('>') else {
+      return line;
+    };
+    // a single space after a marker is part of it
+    line = rest.strip_prefix(' ').unwrap_or(rest);
   }
+  line
 }
 
 fn gen_footnote_reference(footnote_reference: &FootnoteReference, _: &mut Context) -> PrintItems {
   let mut items = PrintItems::new();
   items.push_string(format!("[^{}]", footnote_reference.name.trim_matches(WHITESPACE)));
-  ir_helpers::with_no_new_lines(items)
+  ir_helpers::new_line_group(items)
 }
 
 fn gen_footnote_definition(footnote_definition: &FootnoteDefinition, context: &mut Context) -> PrintItems {
@@ -2105,6 +2185,10 @@ fn gen_list(list: &List, is_alternate: bool, context: &mut Context) -> PrintItem
         let end_char = if is_alternate { ")" } else { "." };
         let display_index = if is_all_ones_list(list, context) {
           1
+        } else if start_index + list.children.len() as u64 > MAX_LIST_NUMBER + 1 {
+          // a marker of more than nine digits starts no list item, so the
+          // numbers are kept as written rather than counted past that
+          written_list_number(child, context).unwrap_or(start_index + index as u64)
         } else {
           start_index + index as u64
         };
@@ -2240,9 +2324,14 @@ fn gen_task_list_marker_children(
   marker: Option<&TaskListMarker>,
   context: &mut Context,
 ) -> PrintItems {
+  // the split below is only for the marker, and it would separate an ignore
+  // comment from the node it applies to
+  let Some(_) = marker else {
+    return gen_nodes(children, context);
+  };
   let mut items = PrintItems::new();
   // indent the children to beyond the task list marker
-  let marker_indent = if marker.is_some() { 4 } else { 0 };
+  let marker_indent = 4;
   context.raw_indent_level += marker_indent;
   let indent_child_index_end = children
     .iter()
@@ -2901,6 +2990,23 @@ fn get_newline_wrapping_based_on_config(context: &Context, ends_sentence: bool) 
 }
 
 /// If the list's first items are both 1s
+/// The largest number an ordered list item can be marked with, as CommonMark
+/// allows a marker no more than nine digits.
+const MAX_LIST_NUMBER: u64 = 999_999_999;
+
+/// The number the item was marked with in the file.
+fn written_list_number(item: &Node, context: &Context) -> Option<u64> {
+  match item {
+    Node::Item(item) => item
+      .marker_span
+      .text(context.file_text)
+      .trim_end_matches(['.', ')'])
+      .parse()
+      .ok(),
+    _ => None,
+  }
+}
+
 fn is_all_ones_list(list: &List, context: &Context) -> bool {
   list.start_index == Some(1)
     && matches!(

--- a/src/generation/utils.rs
+++ b/src/generation/utils.rs
@@ -384,18 +384,6 @@ pub fn is_ignore_comment(text: &str, directive: &str) -> bool {
   rest.trim_start().starts_with("-->")
 }
 
-pub fn get_leading_non_space_tab_byte_pos(text: &str, pos: usize) -> usize {
-  let text_bytes = text.as_bytes();
-  for i in (0..pos).rev() {
-    let current_char = text_bytes.get(i);
-    if current_char != Some(&(b' ')) && current_char != Some(&(b'\t')) {
-      return i + 1;
-    }
-  }
-
-  0
-}
-
 /// Removes the indentation every line of the text shares.
 pub fn unindent(text: &str) -> Cow<'_, str> {
   // a character that only looks like a space, such as a non-breaking one, is

--- a/src/html/ast.rs
+++ b/src/html/ast.rs
@@ -49,6 +49,22 @@ pub struct Element<'a> {
   pub self_closing_syntax: bool,
 }
 
+impl<'a> Element<'a> {
+  /// The name written in the element's close tag, which may be in a different
+  /// case than the open tag's. An element written without one has only the
+  /// open tag's name.
+  pub fn close_tag_name(&self) -> &'a str {
+    match self.kind {
+      ElementKind::Normal | ElementKind::RawText => self
+        .source
+        .rsplit_once("</")
+        .map(|(_, close)| close.trim_end_matches('>').trim_end())
+        .unwrap_or(self.name),
+      ElementKind::Void | ElementKind::SelfClosing => self.name,
+    }
+  }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ElementKind {
   /// An element written with both tags (ex. `<p>a</p>`).

--- a/src/html/parser.rs
+++ b/src/html/parser.rs
@@ -215,9 +215,7 @@ impl<'a> Parser<'a> {
     match bytes.get(start + 1) {
       Some(b'!') => match bytes.get(start + 2) {
         Some(b'-') if self.text[start..].starts_with("<!--") => {
-          let end = self
-            .find_after(start + 4, "-->")
-            .ok_or(ParseError::UnterminatedMarkup)?;
+          let end = self.comment_end(start + 4).ok_or(ParseError::UnterminatedMarkup)?;
           Ok(Some(Markup {
             kind: MarkupKind::Verbatim(VerbatimKind::Comment),
             end,
@@ -409,6 +407,25 @@ impl<'a> Parser<'a> {
       return Ok((&self.text[start..index], after_name + 1));
     }
     Err(ParseError::UnclosedElement { name })
+  }
+
+  /// Where a comment whose text starts at the position ends. As in a browser,
+  /// `<!-->` and `<!--->` are comments closed abruptly, and `--!>` closes a
+  /// comment as `-->` does.
+  fn comment_end(&self, start: usize) -> Option<usize> {
+    let rest = &self.text[start..];
+    if rest.starts_with('>') {
+      return Some(start + 1);
+    }
+    if rest.starts_with("->") {
+      return Some(start + 2);
+    }
+    let closed = self.find_after(start, "-->");
+    let closed_abruptly = self.find_after(start, "--!>");
+    match (closed, closed_abruptly) {
+      (Some(a), Some(b)) => Some(a.min(b)),
+      (a, b) => a.or(b),
+    }
   }
 
   fn find_after(&self, start: usize, close: &str) -> Option<usize> {

--- a/src/html/printer.rs
+++ b/src/html/printer.rs
@@ -308,7 +308,7 @@ impl Printer<'_> {
 
   fn print_close_tag(&mut self, element: &Element) {
     self.out.push_str("</");
-    self.out.push_str(element.name);
+    self.out.push_str(element.close_tag_name());
     self.out.push('>');
   }
 

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -215,7 +215,7 @@ impl<'a, 'c> BlockParser<'a, 'c> {
       let line = lines[end];
       match &kind {
         HtmlBlockKind::Closes(close) => {
-          let contains_close = line.text.contains(close.as_ref());
+          let contains_close = find_ignore_ascii_case(line.text, close).is_some();
           end += 1;
           if contains_close {
             break;
@@ -1031,6 +1031,9 @@ fn is_thematic_break(text: &str) -> bool {
 #[derive(Default)]
 struct OpenParagraph<'a> {
   fence: Option<CodeFenceInfo>,
+  /// The html block the content ends within, which runs until what closes
+  /// that kind of block and holds no paragraph.
+  html: Option<HtmlBlockKind>,
   is_open: bool,
   /// The single line the open paragraph holds so far, which a delimiter row
   /// would turn into a table's header.
@@ -1051,6 +1054,23 @@ impl<'a> OpenParagraph<'a> {
         self.fence = None;
       }
       return;
+    }
+    // an html block runs until its close marker, or until a blank line, and
+    // holds no paragraph either way
+    match &self.html {
+      Some(HtmlBlockKind::Closes(close)) => {
+        if find_ignore_ascii_case(line.text, close).is_some() {
+          self.html = None;
+        }
+        return;
+      }
+      Some(HtmlBlockKind::BlankLine) => {
+        if !line.is_blank() {
+          return;
+        }
+        self.html = None;
+      }
+      None => {}
     }
     if line.is_blank() {
       self.is_open = false;
@@ -1107,7 +1127,15 @@ impl<'a> OpenParagraph<'a> {
       return;
     }
     // the blocks that hold no paragraph of their own end on their own line
-    if atx_heading_level(rest).is_some() || is_thematic_break(rest) || html_block_kind(rest, false).is_some() {
+    if atx_heading_level(rest).is_some() || is_thematic_break(rest) {
+      return;
+    }
+    if let Some(kind) = html_block_kind(rest, false) {
+      // a block closed by a marker may be closed on the line that opens it
+      let closed = matches!(&kind, HtmlBlockKind::Closes(close) if find_ignore_ascii_case(rest, close).is_some());
+      if !closed {
+        self.html = Some(kind);
+      }
       return;
     }
     // what's open within a container is what a lazy line would continue,
@@ -1292,7 +1320,7 @@ pub fn is_whole_html_block(original: &str, text: &str) -> bool {
     return false;
   }
   match kind {
-    Some(HtmlBlockKind::Closes(close)) => match text.find(close.as_ref()) {
+    Some(HtmlBlockKind::Closes(close)) => match find_ignore_ascii_case(text, &close) {
       // The block ends on the line its marker is written on, so that has to be
       // the last one: whatever was written after it would be read as markdown.
       // A marker holds no line break of its own, so it is on the last line
@@ -1367,6 +1395,18 @@ fn html_block_kind(text: &str, interrupting: bool) -> Option<HtmlBlockKind> {
     .trim_matches(SPACES)
     .is_empty()
     .then_some(HtmlBlockKind::BlankLine)
+}
+
+/// Where the marker is first written in the text, matched without regard to
+/// case as a close tag can be written in any.
+fn find_ignore_ascii_case(text: &str, marker: &str) -> Option<usize> {
+  // compared as bytes because the marker is ascii, so a match can only start
+  // on a character boundary
+  let marker = marker.as_bytes();
+  text
+    .as_bytes()
+    .windows(marker.len())
+    .position(|window| window.eq_ignore_ascii_case(marker))
 }
 
 /// Whether the text starts with the tag name, which is matched without regard

--- a/src/parser/inline.rs
+++ b/src/parser/inline.rs
@@ -481,6 +481,16 @@ impl<'a, 'b> InlineParser<'a, 'b> {
         continue;
       }
       if self.text.starts_with_at(search, delimiter) && search > content_start {
+        // a closing `$` must not follow whitespace nor be followed by a digit,
+        // so that an amount of money is left as text
+        if !is_display {
+          let after_whitespace = matches!(self.text.byte(search - 1), Some(b' ') | Some(b'\t') | Some(b'\n'));
+          let before_digit = self.text.byte(search + 1).is_some_and(|byte| byte.is_ascii_digit());
+          if after_whitespace || before_digit {
+            search += 1;
+            continue;
+          }
+        }
         let end = search + delimiter.len();
         let span = self.text.span(start, end);
         let text = self.text.slice(content_start, search);
@@ -721,6 +731,10 @@ impl<'a, 'b> InlineParser<'a, 'b> {
   /// Pairs up the emphasis delimiters at or after `bottom`, wrapping the nodes
   /// they surround.
   fn process_emphasis(&mut self, bottom: usize) {
+    // where a closer found no opener, no closer of the same kind after it will
+    // find one below it either, so the search for one starts there instead of
+    // going over all of them again
+    let mut openers_bottom = std::collections::HashMap::<(u8, usize, bool), usize>::new();
     let mut closer_index = bottom;
     while closer_index < self.delimiters.len() {
       let closer = &self.delimiters[closer_index];
@@ -733,7 +747,10 @@ impl<'a, 'b> InlineParser<'a, 'b> {
         continue;
       }
 
-      let Some(opener_index) = self.find_opener(bottom, closer_index, byte) else {
+      let key = (byte, closer.original_len % 3, closer.can_open);
+      let lower = openers_bottom.get(&key).copied().unwrap_or(bottom).max(bottom);
+      let Some(opener_index) = self.find_opener(lower, closer_index, byte) else {
+        openers_bottom.insert(key, closer_index);
         // a closer with no opener can still open emphasis of its own
         if !self.delimiters[closer_index].can_open {
           self.delimiters[closer_index].can_close = false;
@@ -748,10 +765,10 @@ impl<'a, 'b> InlineParser<'a, 'b> {
     self.delimiters.truncate(bottom);
   }
 
-  fn find_opener(&self, bottom: usize, closer_index: usize, byte: u8) -> Option<usize> {
+  fn find_opener(&self, lower: usize, closer_index: usize, byte: u8) -> Option<usize> {
     let closer = &self.delimiters[closer_index];
     let closer_len = closer.original_len;
-    for index in (bottom..closer_index).rev() {
+    for index in (lower..closer_index).rev() {
       let opener = &self.delimiters[index];
       match opener.kind {
         // a bracket that never became a link is nothing but the text of it,

--- a/src/parser/links.rs
+++ b/src/parser/links.rs
@@ -304,7 +304,7 @@ pub fn match_autolink(text: &InlineText<'_>, start: usize) -> Option<usize> {
   while let Some(byte) = text.byte(index) {
     match byte {
       b'>' => {
-        let is_autolink = has_scheme || has_at && index > start + 1;
+        let is_autolink = has_scheme || has_at && is_email_address(text.str_between(start + 1, index));
         return (index > start + 1 && is_autolink).then_some(index + 1);
       }
       b' ' | b'\t' | b'\n' | b'<' => return None,
@@ -330,12 +330,39 @@ pub fn match_autolink(text: &InlineText<'_>, start: usize) -> Option<usize> {
   None
 }
 
+/// Whether the text is an email address of the form an autolink holds: a
+/// local part of ascii letters, digits and some punctuation, then a domain of
+/// labels that start and end with a letter or digit.
+fn is_email_address(text: &str) -> bool {
+  let Some((local, domain)) = text.split_once('@') else {
+    return false;
+  };
+  let is_local_char = |c: char| c.is_ascii_alphanumeric() || ".!#$%&'*+/=?^_`{|}~-".contains(c);
+  let is_label = |label: &str| {
+    !label.is_empty()
+      && label.len() <= 63
+      && !label.starts_with('-')
+      && !label.ends_with('-')
+      && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+  };
+  !local.is_empty() && local.chars().all(is_local_char) && domain.split('.').all(is_label)
+}
+
 /// Matches a raw html tag, comment, processing instruction, declaration or
 /// CDATA section.
 pub fn match_html_tag(text: &InlineText<'_>, start: usize) -> Option<usize> {
   match text.byte(start + 1)? {
     b'!' => match text.byte(start + 2) {
-      Some(b'-') if text.starts_with_at(start, "<!--") => find_after(text, start + 4, "-->"),
+      Some(b'-') if text.starts_with_at(start, "<!--") => {
+        // `<!-->` and `<!--->` are comments closed as soon as they open
+        if text.starts_with_at(start + 4, ">") {
+          Some(start + 5)
+        } else if text.starts_with_at(start + 4, "->") {
+          Some(start + 6)
+        } else {
+          find_after(text, start + 4, "-->")
+        }
+      }
       Some(b'[') if text.starts_with_at(start, "<![CDATA[") => find_after(text, start + 9, "]]>"),
       // a declaration is `<!` followed by an ascii letter
       Some(byte) if byte.is_ascii_alphabetic() => find_after(text, start + 2, ">"),

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -5,6 +5,7 @@ use dprint_core::configuration::GlobalConfiguration;
 use dprint_core::generate_plugin_code;
 use dprint_core::plugins::CheckConfigUpdatesMessage;
 use dprint_core::plugins::ConfigChange;
+use dprint_core::plugins::ConfigChangeKind;
 use dprint_core::plugins::FileMatchingInfo;
 use dprint_core::plugins::FormatError as CoreFormatError;
 use dprint_core::plugins::FormatRange;
@@ -15,6 +16,7 @@ use dprint_core::plugins::SyncFormatRequest;
 use dprint_core::plugins::SyncHostFormatRequest;
 use dprint_core::plugins::SyncPluginHandler;
 
+use super::configuration::get_config_key_renames;
 use super::configuration::resolve_config;
 use super::configuration::Configuration;
 
@@ -47,8 +49,21 @@ impl SyncPluginHandler<Configuration> for MarkdownPluginHandler {
     }
   }
 
-  fn check_config_updates(&self, _message: CheckConfigUpdatesMessage) -> Result<Vec<ConfigChange>, CoreFormatError> {
-    Ok(Vec::new())
+  fn check_config_updates(&self, message: CheckConfigUpdatesMessage) -> Result<Vec<ConfigChange>, CoreFormatError> {
+    let mut changes = Vec::new();
+    for rename in get_config_key_renames(&message.config) {
+      if let Some(value) = rename.value {
+        changes.push(ConfigChange {
+          path: vec![rename.new_key.to_string().into()],
+          kind: ConfigChangeKind::Add(value),
+        });
+      }
+      changes.push(ConfigChange {
+        path: vec![rename.old_key.to_string().into()],
+        kind: ConfigChangeKind::Remove,
+      });
+    }
+    Ok(changes)
   }
 
   fn plugin_info(&mut self) -> PluginInfo {

--- a/tests/corpus_check.rs
+++ b/tests/corpus_check.rs
@@ -36,8 +36,7 @@ fn checks_a_corpus() {
     }
     // formatting decides how the text is written, never what it says, so every
     // letter that went in comes back out
-    let text = text.strip_prefix('\u{feff}').unwrap_or(&text);
-    if written_letters(text) != written_letters(&once) {
+    if written_letters(&text) != written_letters(&once) {
       report(format_args!("LOSTTEXT {}", path.display()));
     }
     let elapsed = started.elapsed();
@@ -86,7 +85,8 @@ fn collect(directory: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
 fn written_letters(text: &str) -> String {
   text
     .chars()
-    .filter(|c| c.is_alphabetic() || !c.is_ascii())
+    // formatting strips the byte order mark, so it is not a letter that has to come back
+    .filter(|c| (c.is_alphabetic() || !c.is_ascii()) && *c != '\u{feff}')
     .flat_map(|c| c.to_lowercase())
     .collect()
 }

--- a/tests/html_parser_specs/attributes.txt
+++ b/tests/html_parser_specs/attributes.txt
@@ -345,3 +345,188 @@
     }
   ]
 }
+[[test]] a slash within an unquoted value
+<br a=b/>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 9],
+      "text": "<br a=b/>",
+      "name": "br",
+      "elementKind": "Void",
+      "attributes": [
+        {
+          "name": "a",
+          "value": "b/",
+          "quoted": false
+        }
+      ]
+    }
+  ]
+}
+[[test]] an unquoted value that is a path
+<a href=/foo/>x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 19],
+      "text": "<a href=/foo/>x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "href",
+          "value": "/foo/",
+          "quoted": false
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a slash ending an unquoted value does not self close
+<div class=a/>x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 21],
+      "text": "<div class=a/>x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "a/",
+          "quoted": false
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] whitespace after the equals
+<a b= "x">x</a>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 15],
+      "text": "<a b= \"x\">x</a>",
+      "name": "a",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "b",
+          "value": "x",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [10, 11],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a non ascii unquoted value
+<div class=é>x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 21],
+      "text": "<div class=é>x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "class",
+          "value": "é",
+          "quoted": false
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] framework attribute names
+<div [class]="a" (click)="b" #ref v-on:x="c">x</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 52],
+      "text": "<div [class]=\"a\" (click)=\"b\" #ref v-on:x=\"c\">x</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "attributes": [
+        {
+          "name": "[class]",
+          "value": "a",
+          "quote": "\""
+        },
+        {
+          "name": "(click)",
+          "value": "b",
+          "quote": "\""
+        },
+        {
+          "name": "#ref"
+        },
+        {
+          "name": "v-on:x",
+          "value": "c",
+          "quote": "\""
+        }
+      ],
+      "content": "x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [45, 46],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/comments_and_declarations.txt
+++ b/tests/html_parser_specs/comments_and_declarations.txt
@@ -172,3 +172,114 @@ a
     }
   ]
 }
+[[test]] an empty comment closed abruptly
+<!-->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 5],
+      "text": "<!-->"
+    }
+  ]
+}
+[[test]] an empty comment closed abruptly with a dash
+<!--->
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 6],
+      "text": "<!--->"
+    }
+  ]
+}
+[[test]] a comment closed with a bang
+<!-- a --!>b
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Comment",
+      "span": [0, 11],
+      "text": "<!-- a --!>"
+    },
+    {
+      "kind": "Text",
+      "span": [11, 12],
+      "text": "b"
+    }
+  ]
+}
+[[test]] a doctype ends at the first angle bracket
+<!DOCTYPE a "b>c">
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Doctype",
+      "span": [0, 15],
+      "text": "<!DOCTYPE a \"b>"
+    },
+    {
+      "kind": "Text",
+      "span": [15, 18],
+      "text": "c\">"
+    }
+  ]
+}
+[[test]] a bang that opens no declaration
+<!>x
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 4],
+      "text": "<!>x"
+    }
+  ]
+}
+[[test]] cdata holding its own close brackets
+<![CDATA[a]]b]]>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "CData",
+      "span": [0, 16],
+      "text": "<![CDATA[a]]b]]>"
+    }
+  ]
+}
+[[test]] a conditional comment
+<div><!--[if IE]><p>x</p><![endif]--></div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 43],
+      "text": "<div><!--[if IE]><p>x</p><![endif]--></div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "<!--[if IE]><p>x</p><![endif]-->",
+      "children": [
+        {
+          "kind": "Comment",
+          "span": [5, 37],
+          "text": "<!--[if IE]><p>x</p><![endif]-->"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/elements.txt
+++ b/tests/html_parser_specs/elements.txt
@@ -312,3 +312,83 @@ before <b>bold</b> after
     }
   ]
 }
+[[test]] a close tag spanning a line
+<p>a</p
+>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 9],
+      "text": "<p>a</p\n>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [3, 4],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a close tag in another case than the open tag
+<DIV>a</div>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 12],
+      "text": "<DIV>a</div>",
+      "name": "DIV",
+      "elementKind": "Normal",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [5, 6],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a paragraph within a paragraph
+<p><p>a</p></p>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 15],
+      "text": "<p><p>a</p></p>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "<p>a</p>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [3, 11],
+          "text": "<p>a</p>",
+          "name": "p",
+          "elementKind": "Normal",
+          "content": "a",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [6, 7],
+              "text": "a"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/raw_text.txt
+++ b/tests/html_parser_specs/raw_text.txt
@@ -257,3 +257,99 @@
     }
   ]
 }
+[[test]] a close tag matched without case and with trailing whitespace
+<script>a</SCRIPT >
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 19],
+      "text": "<script>a</SCRIPT >",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 9],
+          "text": "a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a close tag of a longer name does not end a script
+<script>a</scripts>b</script>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 29],
+      "text": "<script>a</scripts>b</script>",
+      "name": "script",
+      "elementKind": "RawText",
+      "content": "a</scripts>b",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 20],
+          "text": "a</scripts>b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a script ends at its first close tag even within a comment
+<script><!-- </script> --></script>
+[[ast]]
+[[refused]] `</script>` closes an element that isn't open
+[[test]] markup within a title is text
+<title>a<b>c</title>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 20],
+      "text": "<title>a<b>c</title>",
+      "name": "title",
+      "elementKind": "RawText",
+      "content": "a<b>c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [7, 12],
+          "text": "a<b>c"
+        }
+      ]
+    }
+  ]
+}
+[[test]] markup within a textarea is text
+<textarea><b>x</b></textarea>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 29],
+      "text": "<textarea><b>x</b></textarea>",
+      "name": "textarea",
+      "elementKind": "RawText",
+      "content": "<b>x</b>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [10, 18],
+          "text": "<b>x</b>"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/html_parser_specs/refused.txt
+++ b/tests/html_parser_specs/refused.txt
@@ -50,3 +50,47 @@
 <script>a
 [[ast]]
 [[refused]] `<script>` was never closed
+[[test]] attributes not separated by whitespace
+<a b="x"c="y">x</a>
+[[ast]]
+[[refused]] `</a>` closes an element that isn't open
+[[test]] a slash that is not followed by the end of the tag
+<a href="x" / >x</a>
+[[ast]]
+[[refused]] `</a>` closes an element that isn't open
+[[test]] an equals with no value
+<a b=>x</a>
+[[ast]]
+[[refused]] a tag is written in a way the parser doesn't read
+[[test]] a non ascii attribute name
+<div é="a">x</div>
+[[ast]]
+[[refused]] `</div>` closes an element that isn't open
+[[test]] a dollar attribute name
+<div $x="a">x</div>
+[[ast]]
+[[refused]] `</div>` closes an element that isn't open
+[[test]] a close tag with whitespace before its name
+<div>a</ div>
+[[ast]]
+[[refused]] `<div>` was never closed
+[[test]] a raw text element written as self closing
+<textarea/>
+[[ast]]
+[[refused]] `<textarea>` was never closed
+[[test]] a script written as self closing
+<script src="x"/>
+[[ast]]
+[[refused]] `<script>` was never closed
+[[test]] a script whose close tag is written as self closing
+<script>a</script/>
+[[ast]]
+[[refused]] `<script>` was never closed
+[[test]] a close tag for a void element
+<br>a</br>
+[[ast]]
+[[refused]] `</br>` closes an element that isn't open
+[[test]] a processing instruction that never ends
+<?php
+[[ast]]
+[[refused]] markup runs past the end of the text without being closed

--- a/tests/html_parser_specs/text.txt
+++ b/tests/html_parser_specs/text.txt
@@ -95,3 +95,118 @@ just some words
 {
   "kind": "Document"
 }
+[[test]] multi byte text around an element
+<p>é<b>ü</b>ç</p>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 20],
+      "text": "<p>é<b>ü</b>ç</p>",
+      "name": "p",
+      "elementKind": "Normal",
+      "content": "é<b>ü</b>ç",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [3, 5],
+          "text": "é"
+        },
+        {
+          "kind": "Element",
+          "span": [5, 14],
+          "text": "<b>ü</b>",
+          "name": "b",
+          "elementKind": "Normal",
+          "content": "ü",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [8, 10],
+              "text": "ü"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [14, 16],
+          "text": "ç"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a void tag with whitespace after its slash is text
+<br/ >
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 6],
+      "text": "<br/ >"
+    }
+  ]
+}
+[[test]] a tag name holding an underscore is text
+<a_b>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 5],
+      "text": "<a_b>"
+    }
+  ]
+}
+[[test]] a tag name starting with a digit is text
+<1>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 3],
+      "text": "<1>"
+    }
+  ]
+}
+[[test]] text around an element at the root
+leading<div>text</div>trailing
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Text",
+      "span": [0, 7],
+      "text": "leading"
+    },
+    {
+      "kind": "Element",
+      "span": [7, 22],
+      "text": "<div>text</div>",
+      "name": "div",
+      "elementKind": "Normal",
+      "content": "text",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 16],
+          "text": "text"
+        }
+      ]
+    },
+    {
+      "kind": "Text",
+      "span": [22, 30],
+      "text": "trailing"
+    }
+  ]
+}

--- a/tests/html_parser_specs/void_and_self_closing.txt
+++ b/tests/html_parser_specs/void_and_self_closing.txt
@@ -173,3 +173,88 @@
     }
   ]
 }
+[[test]] a self closing svg
+<svg/>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 6],
+      "text": "<svg/>",
+      "name": "svg",
+      "elementKind": "SelfClosing",
+      "selfClosingSyntax": true
+    }
+  ]
+}
+[[test]] a self closing html element within a foreign object
+<svg><foreignObject><div/></foreignObject></svg>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 48],
+      "text": "<svg><foreignObject><div/></foreignObject></svg>",
+      "name": "svg",
+      "elementKind": "Normal",
+      "content": "<foreignObject><div/></foreignObject>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [5, 42],
+          "text": "<foreignObject><div/></foreignObject>",
+          "name": "foreignObject",
+          "elementKind": "Normal",
+          "content": "<div/>",
+          "children": [
+            {
+              "kind": "Element",
+              "span": [20, 26],
+              "text": "<div/>",
+              "name": "div",
+              "elementKind": "SelfClosing",
+              "selfClosingSyntax": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] math
+<math><mi>x</mi></math>
+[[ast]]
+{
+  "kind": "Document",
+  "children": [
+    {
+      "kind": "Element",
+      "span": [0, 23],
+      "text": "<math><mi>x</mi></math>",
+      "name": "math",
+      "elementKind": "Normal",
+      "content": "<mi>x</mi>",
+      "children": [
+        {
+          "kind": "Element",
+          "span": [6, 16],
+          "text": "<mi>x</mi>",
+          "name": "mi",
+          "elementKind": "Normal",
+          "content": "x",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [10, 11],
+              "text": "x"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/code_edge_cases.txt
+++ b/tests/parser_specs/code_edge_cases.txt
@@ -210,3 +210,167 @@ text
     }
   ]
 }
+[[test]] a backtick within a longer code span
+`` ` ``
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "`` ` ``",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 7],
+      "text": "`` ` ``",
+      "children": [
+        {
+          "kind": "Code",
+          "span": [0, 7],
+          "text": "`` ` ``",
+          "content": "`"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a code span of spaces
+`  `
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "`  `",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "`  `",
+      "children": [
+        {
+          "kind": "Code",
+          "span": [0, 4],
+          "text": "`  `",
+          "content": "  "
+        }
+      ]
+    }
+  ]
+}
+[[test]] one sided padding is kept
+` a`
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "` a`",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "` a`",
+      "children": [
+        {
+          "kind": "Code",
+          "span": [0, 4],
+          "text": "` a`",
+          "content": " a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a backtick in a backtick fence info string
+```a`b
+x
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 8],
+  "text": "```a`b\nx",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 8],
+      "text": "```a`b\nx",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 6],
+          "text": "```a`b"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [6, 7],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [7, 8],
+          "text": "x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an indented close fence is content
+```
+a
+    ```
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 13],
+  "text": "```\na\n    ```",
+  "children": [
+    {
+      "kind": "CodeBlock",
+      "span": [0, 13],
+      "text": "```\na\n    ```",
+      "isFenced": true,
+      "fence": "```",
+      "content": "a\n    ```\n"
+    }
+  ]
+}
+[[test]] an indented fence strips its indentation from the content
+   ```
+ a
+    b
+```
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 19],
+  "text": "   ```\n a\n    b\n```",
+  "children": [
+    {
+      "kind": "CodeBlock",
+      "span": [3, 19],
+      "text": "```\n a\n    b\n```",
+      "isFenced": true,
+      "fence": "```",
+      "content": "a\n b\n"
+    }
+  ]
+}
+[[test]] a shorter tilde run and backticks within a tilde fence
+~~~~
+```
+~~~
+~~~~
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 17],
+  "text": "~~~~\n```\n~~~\n~~~~",
+  "children": [
+    {
+      "kind": "CodeBlock",
+      "span": [0, 17],
+      "text": "~~~~\n```\n~~~\n~~~~",
+      "isFenced": true,
+      "fence": "~~~~",
+      "content": "```\n~~~\n"
+    }
+  ]
+}

--- a/tests/parser_specs/emphasis_rules.txt
+++ b/tests/parser_specs/emphasis_rules.txt
@@ -325,3 +325,267 @@ a*b*c
     }
   ]
 }
+[[test]] a run of three shared between strong and emphasis
+***foo***
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "***foo***",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 9],
+      "text": "***foo***",
+      "children": [
+        {
+          "kind": "TextDecoration",
+          "span": [0, 9],
+          "text": "***foo***",
+          "decoration": "Emphasis",
+          "children": [
+            {
+              "kind": "TextDecoration",
+              "span": [1, 8],
+              "text": "**foo**",
+              "decoration": "Strong",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [3, 6],
+                  "text": "foo"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a single star within strong is text
+**foo*bar**
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "**foo*bar**",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 11],
+      "text": "**foo*bar**",
+      "children": [
+        {
+          "kind": "TextDecoration",
+          "span": [0, 11],
+          "text": "**foo*bar**",
+          "decoration": "Strong",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [2, 9],
+              "text": "foo*bar"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a code span within emphasis holding a star
+*a `*` b*
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "*a `*` b*",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 9],
+      "text": "*a `*` b*",
+      "children": [
+        {
+          "kind": "TextDecoration",
+          "span": [0, 9],
+          "text": "*a `*` b*",
+          "decoration": "Emphasis",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [1, 2],
+              "text": "a"
+            },
+            {
+              "kind": "Code",
+              "span": [3, 6],
+              "text": "`*`",
+              "content": "*"
+            },
+            {
+              "kind": "Text",
+              "span": [7, 8],
+              "text": "b"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] an underscore unmatched across a star
+*foo _bar* baz_
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 15],
+  "text": "*foo _bar* baz_",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 15],
+      "text": "*foo _bar* baz_",
+      "children": [
+        {
+          "kind": "TextDecoration",
+          "span": [0, 10],
+          "text": "*foo _bar*",
+          "decoration": "Emphasis",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [1, 9],
+              "text": "foo _bar"
+            }
+          ]
+        },
+        {
+          "kind": "Text",
+          "span": [11, 15],
+          "text": "baz_"
+        }
+      ]
+    }
+  ]
+}
+[[test]] strong holding emphasis with a shared closer
+**a *b***
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "**a *b***",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 9],
+      "text": "**a *b***",
+      "children": [
+        {
+          "kind": "TextDecoration",
+          "span": [0, 9],
+          "text": "**a *b***",
+          "decoration": "Strong",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [2, 3],
+              "text": "a"
+            },
+            {
+              "kind": "TextDecoration",
+              "span": [4, 7],
+              "text": "*b*",
+              "decoration": "Emphasis",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [5, 6],
+                  "text": "b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closer after whitespace cannot close
+*a  
+*
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "*a  \n*",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 6],
+      "text": "*a  \n*",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 2],
+          "text": "*a"
+        },
+        {
+          "kind": "HardBreak",
+          "span": [2, 4],
+          "text": "  "
+        },
+        {
+          "kind": "Text",
+          "span": [5, 6],
+          "text": "*"
+        }
+      ]
+    }
+  ]
+}
+[[test]] strikethrough of unequal runs is text
+a ~~ b ~~~c~~~
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 14],
+  "text": "a ~~ b ~~~c~~~",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 14],
+      "text": "a ~~ b ~~~c~~~",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 14],
+          "text": "a ~~ b ~~~c~~~"
+        }
+      ]
+    }
+  ]
+}
+[[test]] many closers without an opener
+a* b* c* d* e* f*
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 17],
+  "text": "a* b* c* d* e* f*",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 17],
+      "text": "a* b* c* d* e* f*",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 17],
+          "text": "a* b* c* d* e* f*"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/escapes.txt
+++ b/tests/parser_specs/escapes.txt
@@ -86,3 +86,160 @@ a \b c
     }
   ]
 }
+[[test]] escaped block starts
+\# a
+\- b
+1\. c
+\> d
+\[a]: /u
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 29],
+  "text": "\\# a\n\\- b\n1\\. c\n\\> d\n\\[a]: /u",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 29],
+      "text": "\\# a\n\\- b\n1\\. c\n\\> d\n\\[a]: /u",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "\\# a"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [4, 5],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [5, 9],
+          "text": "\\- b"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [9, 10],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [10, 15],
+          "text": "1\\. c"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [15, 16],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [16, 20],
+          "text": "\\> d"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [20, 21],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [21, 29],
+          "text": "\\[a]: /u"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an escaped backslash before a line end is no hard break
+a\
+b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "a\\\nb",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "a\\\nb",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 1],
+          "text": "a"
+        },
+        {
+          "kind": "HardBreak",
+          "span": [1, 2],
+          "text": "\\"
+        },
+        {
+          "kind": "Text",
+          "span": [3, 4],
+          "text": "b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a backslash at the end of a paragraph is text
+a\
+
+b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 5],
+  "text": "a\\\n\nb",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 2],
+      "text": "a\\",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 2],
+          "text": "a\\"
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [4, 5],
+      "text": "b",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [4, 5],
+          "text": "b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] entities are text
+&amp; &#123; &#x1F600; &notanentity
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 35],
+  "text": "&amp; &#123; &#x1F600; &notanentity",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 35],
+      "text": "&amp; &#123; &#x1F600; &notanentity",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 35],
+          "text": "&amp; &#123; &#x1F600; &notanentity"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/footnotes.txt
+++ b/tests/parser_specs/footnotes.txt
@@ -141,3 +141,192 @@ Text[^1]
     }
   ]
 }
+[[test]] a definition with a lazy tail
+[^1]: a
+    b
+
+    c
+d
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 22],
+  "text": "[^1]: a\n    b\n\n    c\nd",
+  "children": [
+    {
+      "kind": "FootnoteDefinition",
+      "span": [0, 22],
+      "text": "[^1]: a\n    b\n\n    c\nd",
+      "name": "1",
+      "children": [
+        {
+          "kind": "Paragraph",
+          "span": [6, 13],
+          "text": "a\n    b",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [6, 7],
+              "text": "a"
+            },
+            {
+              "kind": "SoftBreak",
+              "span": [7, 8],
+              "text": "\n"
+            },
+            {
+              "kind": "Text",
+              "span": [12, 13],
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "Paragraph",
+          "span": [19, 22],
+          "text": "c\nd",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [19, 20],
+              "text": "c"
+            },
+            {
+              "kind": "SoftBreak",
+              "span": [20, 21],
+              "text": "\n"
+            },
+            {
+              "kind": "Text",
+              "span": [21, 22],
+              "text": "d"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a definition with no name is a paragraph
+[^]: a
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "[^]: a",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 6],
+      "text": "[^]: a",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 6],
+          "text": "[^]: a"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a definition interrupts a paragraph
+para
+[^1]: note
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 15],
+  "text": "para\n[^1]: note",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "para",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "para"
+        }
+      ]
+    },
+    {
+      "kind": "FootnoteDefinition",
+      "span": [5, 15],
+      "text": "[^1]: note",
+      "name": "1",
+      "children": [
+        {
+          "kind": "Paragraph",
+          "span": [11, 15],
+          "text": "note",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [11, 15],
+              "text": "note"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a footnote reference within a link
+[a [^1]](b)
+
+[^1]: c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 20],
+  "text": "[a [^1]](b)\n\n[^1]: c",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 11],
+      "text": "[a [^1]](b)",
+      "children": [
+        {
+          "kind": "InlineLink",
+          "span": [0, 11],
+          "text": "[a [^1]](b)",
+          "url": "b",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [1, 2],
+              "text": "a"
+            },
+            {
+              "kind": "FootnoteReference",
+              "span": [3, 7],
+              "text": "[^1]",
+              "name": "1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FootnoteDefinition",
+      "span": [13, 20],
+      "text": "[^1]: c",
+      "name": "1",
+      "children": [
+        {
+          "kind": "Paragraph",
+          "span": [19, 20],
+          "text": "c",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [19, 20],
+              "text": "c"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/headings.txt
+++ b/tests/parser_specs/headings.txt
@@ -359,3 +359,151 @@ there
     }
   ]
 }
+[[test]] an empty heading with a closing sequence
+### ###
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "### ###",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 7],
+      "text": "### ###",
+      "level": 3,
+      "headingStyle": "Atx"
+    }
+  ]
+}
+[[test]] an escaped hash is not a closing sequence
+# foo \#
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 8],
+  "text": "# foo \\#",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 8],
+      "text": "# foo \\#",
+      "level": 1,
+      "headingStyle": "Atx",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [2, 8],
+          "text": "foo \\#"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closing sequence must follow a space
+# a ##b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "# a ##b",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 7],
+      "text": "# a ##b",
+      "level": 1,
+      "headingStyle": "Atx",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [2, 7],
+          "text": "a ##b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a single dash underline
+foo
+-
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 5],
+  "text": "foo\n-",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 5],
+      "text": "foo\n-",
+      "level": 2,
+      "headingStyle": "Setext",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 3],
+          "text": "foo"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an underline indented four spaces is text
+foo
+    ===
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "foo\n    ===",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 11],
+      "text": "foo\n    ===",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 3],
+          "text": "foo"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [3, 4],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [8, 11],
+          "text": "==="
+        }
+      ]
+    }
+  ]
+}
+[[test]] trailing spaces before an underline are no hard break
+foo  
+===
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "foo  \n===",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 9],
+      "text": "foo  \n===",
+      "level": 1,
+      "headingStyle": "Setext",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 3],
+          "text": "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/html.txt
+++ b/tests/parser_specs/html.txt
@@ -214,3 +214,70 @@ Text
     }
   ]
 }
+[[test]] pre block ended by a close tag in another case
+<pre>
+a</PRE>
+text *x*
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 22],
+  "text": "<pre>\na</PRE>\ntext *x*",
+  "children": [
+    {
+      "kind": "Html",
+      "span": [0, 13],
+      "text": "<pre>\na</PRE>",
+      "isBlock": true
+    },
+    {
+      "kind": "Paragraph",
+      "span": [14, 22],
+      "text": "text *x*",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 18],
+          "text": "text"
+        },
+        {
+          "kind": "TextDecoration",
+          "span": [19, 22],
+          "text": "*x*",
+          "decoration": "Emphasis",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [20, 21],
+              "text": "x"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] script block ended by the first close tag in any case
+<script>
+var s = "</SCRIPT>";
+</script>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 39],
+  "text": "<script>\nvar s = \"</SCRIPT>\";\n</script>",
+  "children": [
+    {
+      "kind": "Html",
+      "span": [0, 29],
+      "text": "<script>\nvar s = \"</SCRIPT>\";",
+      "isBlock": true
+    },
+    {
+      "kind": "Html",
+      "span": [30, 39],
+      "text": "</script>",
+      "isBlock": true
+    }
+  ]
+}

--- a/tests/parser_specs/html_edge_cases.txt
+++ b/tests/parser_specs/html_edge_cases.txt
@@ -200,3 +200,241 @@ text
     }
   ]
 }
+[[test]] an inline comment closed abruptly
+a <!--> b <!---> c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 18],
+  "text": "a <!--> b <!---> c",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 18],
+      "text": "a <!--> b <!---> c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 1],
+          "text": "a"
+        },
+        {
+          "kind": "Html",
+          "span": [2, 7],
+          "text": "<!-->",
+          "isBlock": false
+        },
+        {
+          "kind": "Text",
+          "span": [8, 9],
+          "text": "b"
+        },
+        {
+          "kind": "Html",
+          "span": [10, 16],
+          "text": "<!--->",
+          "isBlock": false
+        },
+        {
+          "kind": "Text",
+          "span": [17, 18],
+          "text": "c"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an inline comment holding a tag
+a <!-- <b> --> c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 16],
+  "text": "a <!-- <b> --> c",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 16],
+      "text": "a <!-- <b> --> c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 1],
+          "text": "a"
+        },
+        {
+          "kind": "Html",
+          "span": [2, 14],
+          "text": "<!-- <b> -->",
+          "isBlock": false
+        },
+        {
+          "kind": "Text",
+          "span": [15, 16],
+          "text": "c"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an inline tag that never closes is text
+a <a foo="x
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "a <a foo=\"x",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 11],
+      "text": "a <a foo=\"x",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 11],
+          "text": "a <a foo=\"x"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an attribute value spanning lines
+<a href="x
+y">t</a>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 19],
+  "text": "<a href=\"x\ny\">t</a>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 19],
+      "text": "<a href=\"x\ny\">t</a>",
+      "children": [
+        {
+          "kind": "Html",
+          "span": [0, 14],
+          "text": "<a href=\"x\ny\">",
+          "isBlock": false
+        },
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "t"
+        },
+        {
+          "kind": "Html",
+          "span": [15, 19],
+          "text": "</a>",
+          "isBlock": false
+        }
+      ]
+    }
+  ]
+}
+[[test]] a bare closing tag starts a block
+</a  >
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "</a  >",
+  "children": [
+    {
+      "kind": "Html",
+      "span": [0, 6],
+      "text": "</a  >",
+      "isBlock": true
+    }
+  ]
+}
+[[test]] a tag with trailing text is a paragraph
+<a href="x">y
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 13],
+  "text": "<a href=\"x\">y",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 13],
+      "text": "<a href=\"x\">y",
+      "children": [
+        {
+          "kind": "Html",
+          "span": [0, 12],
+          "text": "<a href=\"x\">",
+          "isBlock": false
+        },
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "y"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a comment block spans a blank line
+<!-- a
+
+b -->
+c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 15],
+  "text": "<!-- a\n\nb -->\nc",
+  "children": [
+    {
+      "kind": "Html",
+      "span": [0, 13],
+      "text": "<!-- a\n\nb -->",
+      "isBlock": true
+    },
+    {
+      "kind": "Paragraph",
+      "span": [14, 15],
+      "text": "c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [14, 15],
+          "text": "c"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a comment block closed on its first line
+<!-- a --> b
+c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 14],
+  "text": "<!-- a --> b\nc",
+  "children": [
+    {
+      "kind": "Html",
+      "span": [0, 12],
+      "text": "<!-- a --> b",
+      "isBlock": true
+    },
+    {
+      "kind": "Paragraph",
+      "span": [13, 14],
+      "text": "c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [13, 14],
+          "text": "c"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/lazy_continuation_html.txt
+++ b/tests/parser_specs/lazy_continuation_html.txt
@@ -1,0 +1,406 @@
+[[test]] a lazy line does not continue an html block within a block quote
+> <div>
+> x
+y
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 13],
+  "text": "> <div>\n> x\ny",
+  "children": [
+    {
+      "kind": "BlockQuote",
+      "span": [0, 11],
+      "text": "> <div>\n> x",
+      "children": [
+        {
+          "kind": "Html",
+          "span": [2, 11],
+          "text": "<div>\n> x",
+          "isBlock": true,
+          "content": "<div>\nx"
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [12, 13],
+      "text": "y",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "y"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a lazy line does not continue an html block within a list item
+- <div>
+  x
+y
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 13],
+  "text": "- <div>\n  x\ny",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 11],
+      "text": "- <div>\n  x",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 11],
+          "text": "- <div>\n  x",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 11],
+              "text": "<div>\n  x",
+              "isBlock": true,
+              "content": "<div>\nx"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [12, 13],
+      "text": "y",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "y"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a lazy line does not continue a comment block within a list item
+- <!-- a
+  b
+c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 14],
+  "text": "- <!-- a\n  b\nc",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 12],
+      "text": "- <!-- a\n  b",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 12],
+          "text": "- <!-- a\n  b",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 12],
+              "text": "<!-- a\n  b",
+              "isBlock": true,
+              "content": "<!-- a\nb"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [13, 14],
+      "text": "c",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [13, 14],
+          "text": "c"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a lazy line does not continue a pre block within a list item
+- <pre>
+  x
+y
+  </pre>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 22],
+  "text": "- <pre>\n  x\ny\n  </pre>",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 11],
+      "text": "- <pre>\n  x",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 11],
+          "text": "- <pre>\n  x",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 11],
+              "text": "<pre>\n  x",
+              "isBlock": true,
+              "content": "<pre>\nx"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [12, 22],
+      "text": "y\n  </pre>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 13],
+          "text": "y"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [13, 14],
+          "text": "\n"
+        },
+        {
+          "kind": "Html",
+          "span": [16, 22],
+          "text": "</pre>",
+          "isBlock": false
+        }
+      ]
+    }
+  ]
+}
+[[test]] an html block within a container ends on the line its close marker is on
+- <pre>
+  x</pre>
+  y
+z
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 23],
+  "text": "- <pre>\n  x</pre>\n  y\nz",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 23],
+      "text": "- <pre>\n  x</pre>\n  y\nz",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 23],
+          "text": "- <pre>\n  x</pre>\n  y\nz",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 17],
+              "text": "<pre>\n  x</pre>",
+              "isBlock": true,
+              "content": "<pre>\nx</pre>"
+            },
+            {
+              "kind": "Paragraph",
+              "span": [20, 23],
+              "text": "y\nz",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [20, 21],
+                  "text": "y"
+                },
+                {
+                  "kind": "SoftBreak",
+                  "span": [21, 22],
+                  "text": "\n"
+                },
+                {
+                  "kind": "Text",
+                  "span": [22, 23],
+                  "text": "z"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] an html block within a container closed on the line it opens
+- <pre>x</pre>
+  y
+z
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 20],
+  "text": "- <pre>x</pre>\n  y\nz",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 20],
+      "text": "- <pre>x</pre>\n  y\nz",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 20],
+          "text": "- <pre>x</pre>\n  y\nz",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 14],
+              "text": "<pre>x</pre>",
+              "isBlock": true
+            },
+            {
+              "kind": "Paragraph",
+              "span": [17, 20],
+              "text": "y\nz",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [17, 18],
+                  "text": "y"
+                },
+                {
+                  "kind": "SoftBreak",
+                  "span": [18, 19],
+                  "text": "\n"
+                },
+                {
+                  "kind": "Text",
+                  "span": [19, 20],
+                  "text": "z"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a single line html block within a list item
+- <div>
+y
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "- <div>\ny",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 7],
+      "text": "- <div>",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 7],
+          "text": "- <div>",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Html",
+              "span": [2, 7],
+              "text": "<div>",
+              "isBlock": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [8, 9],
+      "text": "y",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [8, 9],
+          "text": "y"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an html block within a block quote ends at a blank line
+> <div>
+> x
+>
+> y
+z
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 19],
+  "text": "> <div>\n> x\n>\n> y\nz",
+  "children": [
+    {
+      "kind": "BlockQuote",
+      "span": [0, 19],
+      "text": "> <div>\n> x\n>\n> y\nz",
+      "children": [
+        {
+          "kind": "Html",
+          "span": [2, 11],
+          "text": "<div>\n> x",
+          "isBlock": true,
+          "content": "<div>\nx"
+        },
+        {
+          "kind": "Paragraph",
+          "span": [16, 19],
+          "text": "y\nz",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [16, 17],
+              "text": "y"
+            },
+            {
+              "kind": "SoftBreak",
+              "span": [17, 18],
+              "text": "\n"
+            },
+            {
+              "kind": "Text",
+              "span": [18, 19],
+              "text": "z"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/links.txt
+++ b/tests/parser_specs/links.txt
@@ -465,3 +465,193 @@
     }
   ]
 }
+[[test]] an email autolink needs a local part
+<@a>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "<@a>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "<@a>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "<@a>"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an email autolink needs a domain
+<a@>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "<a@>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "<a@>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "<a@>"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an email autolink holds no backslash
+<foo\+@bar.example.com>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 23],
+  "text": "<foo\\+@bar.example.com>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 23],
+      "text": "<foo\\+@bar.example.com>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 23],
+          "text": "<foo\\+@bar.example.com>"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an email autolink
+<foo+bar@example.com>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 21],
+  "text": "<foo+bar@example.com>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 21],
+      "text": "<foo+bar@example.com>",
+      "children": [
+        {
+          "kind": "AutoLink",
+          "span": [0, 21],
+          "text": "<foo+bar@example.com>",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [1, 20],
+              "text": "foo+bar@example.com"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a domain label does not start with a dash
+<a@-b.c>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 8],
+  "text": "<a@-b.c>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 8],
+      "text": "<a@-b.c>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 8],
+          "text": "<a@-b.c>"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an autolink scheme in any case
+<MAILTO:FOO@BAR.BAZ>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 20],
+  "text": "<MAILTO:FOO@BAR.BAZ>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 20],
+      "text": "<MAILTO:FOO@BAR.BAZ>",
+      "children": [
+        {
+          "kind": "AutoLink",
+          "span": [0, 20],
+          "text": "<MAILTO:FOO@BAR.BAZ>",
+          "children": [
+            {
+              "kind": "Text",
+              "span": [1, 19],
+              "text": "MAILTO:FOO@BAR.BAZ"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a scheme of one letter is too short
+<m:abc>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "<m:abc>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 7],
+      "text": "<m:abc>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 7],
+          "text": "<m:abc>"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an autolink holds no spaces
+< http://x>
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "< http://x>",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 11],
+      "text": "< http://x>",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 11],
+          "text": "< http://x>"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/lists_edge_cases.txt
+++ b/tests/parser_specs/lists_edge_cases.txt
@@ -537,3 +537,476 @@
     }
   ]
 }
+[[test]] mixed markers nest
+- a
+  * b
+    + c
+- d
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 21],
+  "text": "- a\n  * b\n    + c\n- d",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 21],
+      "text": "- a\n  * b\n    + c\n- d",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 17],
+          "text": "- a\n  * b\n    + c",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [2, 3],
+              "text": "a",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [2, 3],
+                  "text": "a"
+                }
+              ]
+            }
+          ],
+          "subLists": [
+            {
+              "kind": "List",
+              "span": [6, 17],
+              "text": "* b\n    + c",
+              "markerChar": "*",
+              "listKind": "Bullet",
+              "children": [
+                {
+                  "kind": "Item",
+                  "span": [6, 17],
+                  "text": "* b\n    + c",
+                  "markerSpan": [6, 7],
+                  "children": [
+                    {
+                      "kind": "Paragraph",
+                      "span": [8, 9],
+                      "text": "b",
+                      "children": [
+                        {
+                          "kind": "Text",
+                          "span": [8, 9],
+                          "text": "b"
+                        }
+                      ]
+                    }
+                  ],
+                  "subLists": [
+                    {
+                      "kind": "List",
+                      "span": [14, 17],
+                      "text": "+ c",
+                      "markerChar": "+",
+                      "listKind": "Bullet",
+                      "children": [
+                        {
+                          "kind": "Item",
+                          "span": [14, 17],
+                          "text": "+ c",
+                          "markerSpan": [14, 15],
+                          "children": [
+                            {
+                              "kind": "Paragraph",
+                              "span": [16, 17],
+                              "text": "c",
+                              "children": [
+                                {
+                                  "kind": "Text",
+                                  "span": [16, 17],
+                                  "text": "c"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Item",
+          "span": [18, 21],
+          "text": "- d",
+          "markerSpan": [18, 19],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [20, 21],
+              "text": "d",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [20, 21],
+                  "text": "d"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a change of delimiter splits an ordered list
+1. a
+2) b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "1. a\n2) b",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 4],
+      "text": "1. a",
+      "markerChar": ".",
+      "startIndex": 1,
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 4],
+          "text": "1. a",
+          "markerSpan": [0, 2],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [3, 4],
+              "text": "a",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [3, 4],
+                  "text": "a"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "List",
+      "span": [5, 9],
+      "text": "2) b",
+      "markerChar": ")",
+      "startIndex": 2,
+      "children": [
+        {
+          "kind": "Item",
+          "span": [5, 9],
+          "text": "2) b",
+          "markerSpan": [5, 7],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [8, 9],
+              "text": "b",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [8, 9],
+                  "text": "b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a marker of ten digits is text
+1. a
+1234567890. b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 18],
+  "text": "1. a\n1234567890. b",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 18],
+      "text": "1. a\n1234567890. b",
+      "markerChar": ".",
+      "startIndex": 1,
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 18],
+          "text": "1. a\n1234567890. b",
+          "markerSpan": [0, 2],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [3, 18],
+              "text": "a\n1234567890. b",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [3, 4],
+                  "text": "a"
+                },
+                {
+                  "kind": "SoftBreak",
+                  "span": [4, 5],
+                  "text": "\n"
+                },
+                {
+                  "kind": "Text",
+                  "span": [5, 18],
+                  "text": "1234567890. b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] an empty middle item
+- a
+-
+- c
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "- a\n-\n- c",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 9],
+      "text": "- a\n-\n- c",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 3],
+          "text": "- a",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [2, 3],
+              "text": "a",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [2, 3],
+                  "text": "a"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Item",
+          "span": [4, 5],
+          "text": "-",
+          "markerSpan": [4, 5]
+        },
+        {
+          "kind": "Item",
+          "span": [6, 9],
+          "text": "- c",
+          "markerSpan": [6, 7],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [8, 9],
+              "text": "c",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [8, 9],
+                  "text": "c"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a lower number cannot interrupt a paragraph
+a
+2. b
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "a\n2. b",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 6],
+      "text": "a\n2. b",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 1],
+          "text": "a"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [1, 2],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [2, 6],
+          "text": "2. b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an empty item cannot interrupt a paragraph
+a
++
+b
+-
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "a\n+\nb\n-",
+  "children": [
+    {
+      "kind": "Heading",
+      "span": [0, 7],
+      "text": "a\n+\nb\n-",
+      "level": 2,
+      "headingStyle": "Setext",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 1],
+          "text": "a"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [1, 2],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [2, 3],
+          "text": "+"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [3, 4],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [4, 5],
+          "text": "b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a task list marker with nothing after it
+- [ ]
+- [x]
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "- [ ]\n- [x]",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 11],
+      "text": "- [ ]\n- [x]",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 5],
+          "text": "- [ ]",
+          "markerSpan": [0, 1],
+          "marker": {
+            "kind": "TaskListMarker",
+            "span": [2, 5],
+            "text": "[ ]",
+            "isChecked": false
+          }
+        },
+        {
+          "kind": "Item",
+          "span": [6, 11],
+          "text": "- [x]",
+          "markerSpan": [6, 7],
+          "marker": {
+            "kind": "TaskListMarker",
+            "span": [8, 11],
+            "text": "[x]",
+            "isChecked": true
+          }
+        }
+      ]
+    }
+  ]
+}
+[[test]] a task list marker needs a space after it
+- [ ]a
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "- [ ]a",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 6],
+      "text": "- [ ]a",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 6],
+          "text": "- [ ]a",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [2, 6],
+              "text": "[ ]a",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [2, 6],
+                  "text": "[ ]a"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/math.txt
+++ b/tests/parser_specs/math.txt
@@ -101,3 +101,167 @@ Costs $5 today
     }
   ]
 }
+[[test]] amounts of money are not math
+costs $5 and $10 today
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 22],
+  "text": "costs $5 and $10 today",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 22],
+      "text": "costs $5 and $10 today",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 22],
+          "text": "costs $5 and $10 today"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closer after whitespace does not close math
+$x $
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "$x $",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "$x $",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "$x $"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closer before a digit does not close math
+$a$1
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 4],
+  "text": "$a$1",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 4],
+      "text": "$a$1",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 4],
+          "text": "$a$1"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a closer later on closes math
+$a $b$
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "$a $b$",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 6],
+      "text": "$a $b$",
+      "children": [
+        {
+          "kind": "InlineMath",
+          "span": [0, 6],
+          "text": "$a $b$",
+          "content": "a $b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] an escaped dollar within math
+$a\$b$
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 6],
+  "text": "$a\\$b$",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 6],
+      "text": "$a\\$b$",
+      "children": [
+        {
+          "kind": "InlineMath",
+          "span": [0, 6],
+          "text": "$a\\$b$",
+          "content": "a\\$b"
+        }
+      ]
+    }
+  ]
+}
+[[test]] display math has no closer rules
+$$a $$1
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 7],
+  "text": "$$a $$1",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 7],
+      "text": "$$a $$1",
+      "children": [
+        {
+          "kind": "DisplayMath",
+          "span": [0, 6],
+          "text": "$$a $$",
+          "content": "a "
+        },
+        {
+          "kind": "Text",
+          "span": [6, 7],
+          "text": "1"
+        }
+      ]
+    }
+  ]
+}
+[[test]] math spanning a line
+$a
+b$
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 5],
+  "text": "$a\nb$",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 5],
+      "text": "$a\nb$",
+      "children": [
+        {
+          "kind": "InlineMath",
+          "span": [0, 5],
+          "text": "$a\nb$",
+          "content": "a\nb"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parser_specs/tables_edge_cases.txt
+++ b/tests/parser_specs/tables_edge_cases.txt
@@ -466,3 +466,349 @@ text
     }
   ]
 }
+[[test]] a list ends a table
+|a|
+|-|
+- x
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 11],
+  "text": "|a|\n|-|\n- x",
+  "children": [
+    {
+      "kind": "Table",
+      "span": [0, 7],
+      "text": "|a|\n|-|",
+      "columnAlignment": ["None"],
+      "header": {
+        "kind": "TableHead",
+        "span": [0, 3],
+        "text": "|a|",
+        "cells": [
+          {
+            "kind": "TableCell",
+            "span": [1, 2],
+            "text": "a",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [1, 2],
+                "text": "a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "kind": "List",
+      "span": [8, 11],
+      "text": "- x",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [8, 11],
+          "text": "- x",
+          "markerSpan": [8, 9],
+          "children": [
+            {
+              "kind": "Paragraph",
+              "span": [10, 11],
+              "text": "x",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [10, 11],
+                  "text": "x"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] an escaped pipe in a header is one cell
+| \| | b |
+|---|---|
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 20],
+  "text": "| \\| | b |\n|---|---|",
+  "children": [
+    {
+      "kind": "Table",
+      "span": [0, 20],
+      "text": "| \\| | b |\n|---|---|",
+      "columnAlignment": ["None", "None"],
+      "header": {
+        "kind": "TableHead",
+        "span": [0, 10],
+        "text": "| \\| | b |",
+        "cells": [
+          {
+            "kind": "TableCell",
+            "span": [2, 4],
+            "text": "\\|",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [2, 4],
+                "text": "\\|"
+              }
+            ]
+          },
+          {
+            "kind": "TableCell",
+            "span": [7, 8],
+            "text": "b",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [7, 8],
+                "text": "b"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+[[test]] an escaped pipe in the delimiter row
+|a|
+|-\|-|
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 10],
+  "text": "|a|\n|-\\|-|",
+  "children": [
+    {
+      "kind": "Paragraph",
+      "span": [0, 10],
+      "text": "|a|\n|-\\|-|",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [0, 3],
+          "text": "|a|"
+        },
+        {
+          "kind": "SoftBreak",
+          "span": [3, 4],
+          "text": "\n"
+        },
+        {
+          "kind": "Text",
+          "span": [4, 10],
+          "text": "|-\\|-|"
+        }
+      ]
+    }
+  ]
+}
+[[test]] a pipe splits a code span in a cell
+|a|b|
+|-|-|
+|`x|y`|
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 19],
+  "text": "|a|b|\n|-|-|\n|`x|y`|",
+  "children": [
+    {
+      "kind": "Table",
+      "span": [0, 19],
+      "text": "|a|b|\n|-|-|\n|`x|y`|",
+      "columnAlignment": ["None", "None"],
+      "header": {
+        "kind": "TableHead",
+        "span": [0, 5],
+        "text": "|a|b|",
+        "cells": [
+          {
+            "kind": "TableCell",
+            "span": [1, 2],
+            "text": "a",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [1, 2],
+                "text": "a"
+              }
+            ]
+          },
+          {
+            "kind": "TableCell",
+            "span": [3, 4],
+            "text": "b",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [3, 4],
+                "text": "b"
+              }
+            ]
+          }
+        ]
+      },
+      "rows": [
+        {
+          "kind": "TableRow",
+          "span": [12, 19],
+          "text": "|`x|y`|",
+          "cells": [
+            {
+              "kind": "TableCell",
+              "span": [13, 15],
+              "text": "`x",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [13, 15],
+                  "text": "`x"
+                }
+              ]
+            },
+            {
+              "kind": "TableCell",
+              "span": [16, 18],
+              "text": "y`",
+              "children": [
+                {
+                  "kind": "Text",
+                  "span": [16, 18],
+                  "text": "y`"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a row of one pipe
+|a|
+|-|
+|
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 9],
+  "text": "|a|\n|-|\n|",
+  "children": [
+    {
+      "kind": "Table",
+      "span": [0, 9],
+      "text": "|a|\n|-|\n|",
+      "columnAlignment": ["None"],
+      "header": {
+        "kind": "TableHead",
+        "span": [0, 3],
+        "text": "|a|",
+        "cells": [
+          {
+            "kind": "TableCell",
+            "span": [1, 2],
+            "text": "a",
+            "children": [
+              {
+                "kind": "Text",
+                "span": [1, 2],
+                "text": "a"
+              }
+            ]
+          }
+        ]
+      },
+      "rows": [
+        {
+          "kind": "TableRow",
+          "span": [8, 9],
+          "text": "|",
+          "cells": [
+            {
+              "kind": "TableCell",
+              "span": [9, 9],
+              "text": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+[[test]] a table row is never lazy within an item
+- |a|
+  |-|
+|b|
+[[ast]]
+{
+  "kind": "SourceFile",
+  "span": [0, 15],
+  "text": "- |a|\n  |-|\n|b|",
+  "children": [
+    {
+      "kind": "List",
+      "span": [0, 11],
+      "text": "- |a|\n  |-|",
+      "markerChar": "-",
+      "listKind": "Bullet",
+      "children": [
+        {
+          "kind": "Item",
+          "span": [0, 11],
+          "text": "- |a|\n  |-|",
+          "markerSpan": [0, 1],
+          "children": [
+            {
+              "kind": "Table",
+              "span": [2, 11],
+              "text": "|a|\n  |-|",
+              "columnAlignment": ["None"],
+              "header": {
+                "kind": "TableHead",
+                "span": [2, 5],
+                "text": "|a|",
+                "cells": [
+                  {
+                    "kind": "TableCell",
+                    "span": [3, 4],
+                    "text": "a",
+                    "children": [
+                      {
+                        "kind": "Text",
+                        "span": [3, 4],
+                        "text": "a"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Paragraph",
+      "span": [12, 15],
+      "text": "|b|",
+      "children": [
+        {
+          "kind": "Text",
+          "span": [12, 15],
+          "text": "|b|"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/specs/BlockQuotes/BlockQuotes_All.txt
+++ b/tests/specs/BlockQuotes/BlockQuotes_All.txt
@@ -68,3 +68,40 @@
 
 [expect]
 >>     a
+
+!! should mark a lazy line !!
+> foo
+bar
+
+[expect]
+> foo
+> bar
+
+!! should drop the empty lines at the edges of a quote !!
+>
+> a
+>
+
+[expect]
+> a
+
+!! should keep an empty quote !!
+>
+
+[expect]
+>
+
+!! should read an underline within a quote as a heading !!
+> a
+> ===
+
+[expect]
+> # a
+
+!! should mark a lazy line of a quote within a list item !!
+- > a
+b
+
+[expect]
+- > a
+  > b

--- a/tests/specs/General/HardBreaks_DoubleSpace_TextWrap_Always.txt
+++ b/tests/specs/General/HardBreaks_DoubleSpace_TextWrap_Always.txt
@@ -16,3 +16,35 @@ next line here
 [expect]
 aaaa bbbb cccc dddd  
 next line here
+
+!! should write a hard break within a link and within strong !!
+[a\
+b](c)
+
+**a\
+b**
+
+[expect]
+[a  
+b](c)
+
+**a  
+b**
+
+!! should drop the indentation after a hard break !!
+aaaa\
+    bbbb
+
+[expect]
+aaaa  
+bbbb
+
+!! should keep a backslash on a line with no text before it !!
+a\
+\
+b
+
+[expect]
+a  
+\
+b

--- a/tests/specs/HorizontalRules/HorizontalRules_All.txt
+++ b/tests/specs/HorizontalRules/HorizontalRules_All.txt
@@ -67,3 +67,28 @@ asdf
 - a
 
   ---
+
+!! should read an underline within an item as a heading !!
+- a
+  ---
+
+[expect]
+- ## a
+
+!! should separate a rule from the paragraph above it within a block quote !!
+> foo
+> ***
+
+[expect]
+> foo
+>
+> ---
+
+!! should read a rule where a list item would be !!
+- a
+- - -
+
+[expect]
+- a
+
+---

--- a/tests/specs/IgnoreComments/IgnoreComments_All.txt
+++ b/tests/specs/IgnoreComments/IgnoreComments_All.txt
@@ -182,3 +182,127 @@ testing    this    out
    <!-- dprint-ignore-end -->
 
 2. Next
+
+!! should write the block quote markers of an ignored block once !!
+> <!-- dprint-ignore -->
+> a   b
+> c   d
+
+> <!-- dprint-ignore-start -->
+> a   b
+> <!-- dprint-ignore-end -->
+
+> > <!-- dprint-ignore -->
+> > a   b
+> > c   d
+
+[expect]
+> <!-- dprint-ignore -->
+> a   b
+> c   d
+
+> <!-- dprint-ignore-start -->
+> a   b
+> <!-- dprint-ignore-end -->
+
+>> <!-- dprint-ignore -->
+>> a   b
+>> c   d
+
+!! should write the indentation of an ignored block within a list item once !!
+- <!-- dprint-ignore -->
+  b   c
+  d   e
+
+- - <!-- dprint-ignore -->
+    b   c
+
+- <!-- dprint-ignore-start -->
+  b   c
+  d   e
+  <!-- dprint-ignore-end -->
+
+- <!-- dprint-ignore -->
+      b   c
+      d   e
+
+[expect]
+- <!-- dprint-ignore -->
+  b   c
+  d   e
+
+- - <!-- dprint-ignore -->
+    b   c
+
+- <!-- dprint-ignore-start -->
+  b   c
+  d   e
+  <!-- dprint-ignore-end -->
+
+- <!-- dprint-ignore -->
+      b   c
+      d   e
+
+!! should ignore a block within a list item within a block quote and the other way around !!
+> - <!-- dprint-ignore -->
+>   b   c
+>   d   e
+
+> - <!-- dprint-ignore-start -->
+>   b   c
+>   d   e
+>   <!-- dprint-ignore-end -->
+> - f   g
+
+- > <!-- dprint-ignore -->
+  > b   c
+  > d   e
+
+[expect]
+> - <!-- dprint-ignore -->
+>   b   c
+>   d   e
+
+> - <!-- dprint-ignore-start -->
+>   b   c
+>   d   e
+>   <!-- dprint-ignore-end -->
+> - f g
+
+- > <!-- dprint-ignore -->
+  > b   c
+  > d   e
+
+!! should ignore a code block within a list item !!
+- <!-- dprint-ignore -->
+  ```
+  a   b
+  ```
+  c   d
+
+[expect]
+- <!-- dprint-ignore -->
+  ```
+  a   b
+  ```
+  c d
+
+!! should ignore to the end of the container the start comment is within !!
+- <!-- dprint-ignore-start -->
+  b   c
+- d   e
+
+> <!-- dprint-ignore-start -->
+> b   c
+
+d   e
+
+[expect]
+- <!-- dprint-ignore-start -->
+  b   c
+- d e
+
+> <!-- dprint-ignore-start -->
+> b   c
+
+d e

--- a/tests/specs/Links/Links_All.txt
+++ b/tests/specs/Links/Links_All.txt
@@ -254,3 +254,39 @@ title"
 [foo][ref\[]
 
 [ref\[]: /uri
+
+!! should wrap a destination holding an escaped parenthesis in angle brackets !!
+[d](e\)f)
+
+[expect]
+[d](<e)f>)
+
+!! should write every title with double quotes !!
+[a](<b c> "t") [d](e 't') [f](g (h))
+
+[a](b 'say "hi"')
+
+[a]: b (title)
+
+[expect]
+[a](<b c> "t") [d](e "t") [f](g "h")
+
+[a](b "say \"hi\"")
+
+[a]: b "title"
+
+!! should write an empty destination as nothing !!
+[a]() [b](<>)
+
+[expect]
+[a]() [b]()
+
+!! should keep the case of a reference label !!
+[Foo][BAR]
+
+[bar]: /u
+
+[expect]
+[Foo][BAR]
+
+[bar]: /u

--- a/tests/specs/Lists/Lists_All.txt
+++ b/tests/specs/Lists/Lists_All.txt
@@ -242,3 +242,59 @@ Here is a paragraph
 [expect]
 - ​
 - a
+
+!! should keep the numbers of a list that counting would take past nine digits !!
+999999999. a
+999999999. b
+
+[expect]
+999999999. a
+999999999. b
+
+!! should count a list up to nine digits !!
+999999998. a
+999999998. b
+
+[expect]
+999999998. a
+999999999. b
+
+!! should keep a list starting at zero !!
+0. a
+1. b
+
+[expect]
+0. a
+1. b
+
+!! should move the content of an item onto the marker line !!
+1.
+   foo
+
+   bar
+
+[expect]
+1. foo
+
+   bar
+
+!! should separate an ordered list from a bullet list before it !!
+- a
+1. b
+
+[expect]
+- a
+
+1. b
+
+!! should indent a nested list by the width of a marker that grew a digit !!
+9. a
+   - x
+9. b
+   - y
+
+[expect]
+9. a
+   - x
+10. b
+    - y

--- a/tests/specs/MathBlocks/MathBlocks_General.txt
+++ b/tests/specs/MathBlocks/MathBlocks_General.txt
@@ -19,3 +19,15 @@ $$
   xy = 3x^2 - 7
 \end{align}
 $$
+
+!! should keep display math written within a paragraph in it !!
+aaa $$y$$ bbb
+
+aaa
+$$y$$
+bbb
+
+[expect]
+aaa $$y$$ bbb
+
+aaa $$y$$ bbb

--- a/tests/specs/Tables/Tables_All.txt
+++ b/tests/specs/Tables/Tables_All.txt
@@ -74,3 +74,66 @@ a|b|c|d
 | Autolinks                               | <http://foo.bar.baz>  |
 | Autolinks (extension)                   | www.commonmark.org    |
 | Raw HTML                                | <a><bab><c2c>         |
+
+!! should keep an escaped pipe in a cell !!
+| a \| b | c |
+|---|---|
+| `x \| y` | z |
+
+[expect]
+| a \| b   | c |
+| -------- | - |
+| `x \| y` | z |
+
+!! should size a column by the width of wide characters !!
+| a | b |
+|---|---|
+| 日本語テキスト | 2 |
+| 😀 | 3 |
+
+[expect]
+| a              | b |
+| -------------- | - |
+| 日本語テキスト | 2 |
+| 😀             | 3 |
+
+!! should pad a row with fewer cells and keep one with more !!
+| a | b |
+|---|---|
+| 1 |
+| 1 | 2 | 3 |
+
+[expect]
+| a | b |
+| - | - |
+| 1 |   |
+| 1 | 2 | 3 |
+
+!! should center a cell !!
+| abcd | a |
+|:----:|:-:|
+| a | abcd |
+
+[expect]
+| abcd |  a   |
+| :--: | :--: |
+|  a   | abcd |
+
+!! should format a table with only a header !!
+| a | b |
+|---|---|
+
+[expect]
+| a | b |
+| - | - |
+
+!! should separate a table from the paragraph above it !!
+para
+| a | b |
+|---|---|
+
+[expect]
+para
+
+| a | b |
+| - | - |

--- a/tests/specs/Text/Text_TextWrap_Never.txt
+++ b/tests/specs/Text/Text_TextWrap_Never.txt
@@ -18,3 +18,42 @@ Foo
 
 [expect]
 Foo ***
+
+!! should join lines where the text could not start a block !!
+aaaa
+2. bbbb
+
+aaaa
+-- bbbb
+
+aaaa
+#bbbb
+
+[expect]
+aaaa 2. bbbb
+
+aaaa -- bbbb
+
+aaaa #bbbb
+
+!! should keep a line whose text would start a block !!
+aaaa
+: bbbb
+
+aaaa
+</span>
+
+[expect]
+aaaa
+: bbbb
+
+aaaa
+</span>
+
+!! should keep a line break between the words of an unspaced script !!
+日本語
+日本語
+
+[expect]
+日本語
+日本語

--- a/tests/specs/TextDecoration/TextDecoration_All.txt
+++ b/tests/specs/TextDecoration/TextDecoration_All.txt
@@ -96,3 +96,59 @@ foo _\__
 
 [expect]
 _a [*b*​](u)_
+
+!! should keep asterisks where underscores would not be read as emphasis !!
+*foo*—bar
+
+“*foo*”
+
+*foo*1
+
+*foo*、*bar*。
+
+**5 * 3**
+
+**_a_**
+
+*x\*
+
+[expect]
+*foo*—bar
+
+“*foo*”
+
+*foo*1
+
+*foo*、*bar*。
+
+**5 * 3**
+
+**_a_**
+
+*x\*
+
+!! should leave underscores that are not emphasis !!
+__太字__テキスト
+
+foo_bar_baz
+
+**a**_b
+
+[expect]
+__太字__テキスト
+
+foo_bar_baz
+
+**a**_b
+
+!! should write strong that is only its delimiters with the configured kind !!
+__init__
+
+[expect]
+**init**
+
+!! should write a single tilde strikethrough with two !!
+~a~
+
+[expect]
+~~a~~

--- a/tests/specs/TextDecoration/TextDecoration_EmphasisKind_Asterisks.txt
+++ b/tests/specs/TextDecoration/TextDecoration_EmphasisKind_Asterisks.txt
@@ -6,3 +6,9 @@ test **strong** or __strong__ test
 [expect]
 test *emphasis* or *emphasis* test
 test **strong** or **strong** test
+
+!! should swap the delimiters of emphasis holding emphasis !!
+*_a_*
+
+[expect]
+_*a*_

--- a/tests/specs/footnotes/Footnotes_TextWrap_Always.txt
+++ b/tests/specs/footnotes/Footnotes_TextWrap_Always.txt
@@ -1,0 +1,11 @@
+~~ textWrap: always, lineWidth: 20 ~~
+!! should wrap before a word a footnote reference is written against !!
+aaaaaaaaaa bbbbbbbbb[^1] cc
+
+[^1]: x
+
+[expect]
+aaaaaaaaaa
+bbbbbbbbb[^1] cc
+
+[^1]: x

--- a/tests/specs/headers/Headers_All_Setext.txt
+++ b/tests/specs/headers/Headers_All_Setext.txt
@@ -155,3 +155,46 @@ term
 
 [expect]
 # <!-- c -->
+
+!! should underline a heading by its width rather than its length !!
+# 日本語
+
+## 😀 foo
+
+[expect]
+日本語
+======
+
+😀 foo
+------
+
+!! should underline a heading that starts with what a block would !!
+## = foo
+
+## | a |
+
+## \- foo
+
+[expect]
+= foo
+-----
+
+| a |
+-----
+
+\- foo
+------
+
+!! should keep a heading that could not be underlined as atx !!
+## - foo
+
+## 2. foo
+
+## [a]: b
+
+[expect]
+## - foo
+
+## 2. foo
+
+## [a]: b

--- a/tests/specs/html/Comments_All.txt
+++ b/tests/specs/html/Comments_All.txt
@@ -17,3 +17,17 @@ Multi
 Line
 Comment
 -->
+
+!! should keep an empty comment closed abruptly !!
+<!-->
+
+<!--->
+
+<div><!-- a --!></div>
+
+[expect]
+<!-->
+
+<!--->
+
+<div><!-- a --!></div>

--- a/tests/specs/html/HtmlFormat_All.txt
+++ b/tests/specs/html/HtmlFormat_All.txt
@@ -151,3 +151,53 @@ After.
 
 [expect]
 <div><svg><circle cx="1" /></svg></div>
+
+!! should lay out a whole document !!
+<!DOCTYPE html>
+<html><body><p>a</p></body></html>
+
+[expect]
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>a</p>
+  </body>
+</html>
+
+!! should keep a non breaking space !!
+<div> </div>
+
+<p>  a  </p>
+
+[expect]
+<div> </div>
+
+<p>  a  </p>
+
+!! should collapse whitespace around entities !!
+<div>a&nbsp;   b &amp;  c</div>
+
+[expect]
+<div>a&nbsp; b &amp; c</div>
+
+!! should drop trailing whitespace within a block !!
+<div>
+a   
+<span>b</span>   
+</div>
+
+[expect]
+<div>
+  a
+  <span>b</span>
+</div>
+
+!! should break content that the indentation pushes past the line width !!
+<div><p>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p></div>
+
+[expect]
+<div>
+  <p>
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  </p>
+</div>

--- a/tests/specs/html/HtmlFormat_Attributes.txt
+++ b/tests/specs/html/HtmlFormat_Attributes.txt
@@ -50,3 +50,43 @@
 <div class="a" id="b">
   <p>x</p>
 </div>
+
+!! should lay out the attributes of an inline element that starts its line and continue after them !!
+<div>
+<a class="button button-primary" href="https://example.com/a/very/long/path/that/goes/on" target="_blank">link</a> and more text
+</div>
+
+<p><a class="button button-primary" href="https://example.com/a/very/long/path/that/goes/on" target="_blank">link</a></p>
+
+[expect]
+<div>
+  <a
+    class="button button-primary"
+    href="https://example.com/a/very/long/path/that/goes/on"
+    target="_blank"
+  >link</a> and more text
+</div>
+
+<p>
+  <a
+    class="button button-primary"
+    href="https://example.com/a/very/long/path/that/goes/on"
+    target="_blank"
+  >link</a>
+</p>
+
+!! should keep a line break within an attribute value !!
+<div class="a
+b"><p>x</p></div>
+
+[expect]
+<div class="a
+b">
+  <p>x</p>
+</div>
+
+!! should keep the case of attribute names and quote a bare value !!
+<div CLASS="a&amp;b" ID=x>y</div>
+
+[expect]
+<div CLASS="a&amp;b" ID="x">y</div>

--- a/tests/specs/html/HtmlFormat_BlockStarts.txt
+++ b/tests/specs/html/HtmlFormat_BlockStarts.txt
@@ -70,3 +70,23 @@
 <div>
   <script>const a = 1</script>
 </div>
+
+!! should lay out a block that starts with an inline element !!
+<span>
+a</span>
+<div>b</div>
+
+[expect]
+<span>
+  a</span>
+<div>b</div>
+
+!! should leave a long svg tag whose attributes cannot be laid out !!
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+<path d="M0 0h24v24H0z"/>
+</svg>
+
+[expect]
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+<path d="M0 0h24v24H0z"/>
+</svg>

--- a/tests/specs/html/HtmlFormat_Containers.txt
+++ b/tests/specs/html/HtmlFormat_Containers.txt
@@ -103,3 +103,27 @@ example-testing-testing
 <!-- dprint-ignore -->
 <p>a    b</p>
 </div>
+
+!! should write blocks within an inline element flat !!
+<div><select><option>a</option><option>b</option></select></div>
+
+<div><span><div>a</div></span></div>
+
+[expect]
+<div>
+  <select><option>a</option><option>b</option></select>
+</div>
+
+<div>
+  <span><div>a</div></span>
+</div>
+
+!! should lay out html written right after a list marker !!
+- <div>
+  <p>a</p>
+  </div>
+
+[expect]
+- <div>
+    <p>a</p>
+  </div>

--- a/tests/specs/html/HtmlFormat_Fragments.txt
+++ b/tests/specs/html/HtmlFormat_Fragments.txt
@@ -97,3 +97,15 @@ Some **markdown** here.
 <div>
   <p>b</p>
 </div>
+
+!! should leave an element whose inline child would be laid out on a line of its own !!
+<div>
+<span>
+</span>
+</div>
+
+[expect]
+<div>
+<span>
+</span>
+</div>

--- a/tests/specs/html/HtmlFormat_KeepLines.txt
+++ b/tests/specs/html/HtmlFormat_KeepLines.txt
@@ -141,3 +141,26 @@ a</div>
 
 [expect]
 <p>text <a href="x" id="y">y</a></p>
+
+!! should break an inline element only at the whitespace edge that was written !!
+<p>x <b>a
+</b>y</p>
+
+[expect]
+<p>
+  x <b>a
+  </b>y
+</p>
+
+!! should keep the lines of a cell holding only whitespace beside one that holds none !!
+<table><tr><td>
+</td><td> </td></tr></table>
+
+[expect]
+<table>
+  <tr>
+    <td>
+    </td>
+    <td></td>
+  </tr>
+</table>

--- a/tests/specs/html/HtmlFormat_PreferSingleLine.txt
+++ b/tests/specs/html/HtmlFormat_PreferSingleLine.txt
@@ -51,3 +51,59 @@
 
 [expect]
 <div></div>
+
+!! should join the attributes of an inline element and a comment onto the line !!
+<div>
+<a
+  href="x"
+  class="y"
+>b</a>
+</div>
+
+<div>
+<!-- a -->
+</div>
+
+[expect]
+<div><a href="x" class="y">b</a></div>
+
+<div><!-- a --></div>
+
+!! should join the attributes of a self closing tag !!
+<svg>
+<circle
+  cx="1"
+/>
+</svg>
+
+[expect]
+<svg>
+  <circle cx="1" />
+</svg>
+
+!! should keep a line break written within an inline element !!
+<div>
+<span>
+ a
+</span>
+</div>
+
+[expect]
+<div>
+  <span>
+    a
+  </span>
+</div>
+
+!! should not read a tag written over lines at the root as an html block !!
+<img
+  src="a"
+  alt="b"
+>
+
+[expect]
+<img
+src="a"
+alt="b"
+
+>

--- a/tests/specs/html/HtmlFormat_RawText.txt
+++ b/tests/specs/html/HtmlFormat_RawText.txt
@@ -65,3 +65,55 @@
 <div>
   <p>a < b</p>
 </div>
+
+!! should end a preformatted block at a close tag written in another case !!
+<pre>
+a</PRE>
+text *x*
+
+[expect]
+<pre>
+a</PRE>
+
+text _x_
+
+!! should end a script block at the first close tag in any case !!
+<script>
+var s = "</SCRIPT>";
+</script>
+
+[expect]
+<script>
+var s = "</SCRIPT>";
+</script>
+
+!! should keep the case a close tag was written in !!
+<DIV>a</div>
+
+<TEXTAREA>
+a</textarea>
+
+<div><P>a</p><Span>b</SPAN></div>
+
+[expect]
+<DIV>a</div>
+
+<TEXTAREA>
+a</textarea>
+
+<div>
+  <P>a</p>
+  <Span>b</SPAN>
+</div>
+
+!! should lay out a preformatted element whose tag is too long !!
+<pre class="language-typescript line-numbers" id="example-listing" data-x="1234567890">  a
+ b</pre>
+
+[expect]
+<pre
+  class="language-typescript line-numbers"
+  id="example-listing"
+  data-x="1234567890"
+>  a
+ b</pre>

--- a/tests/specs/html/HtmlFormat_UseTabs.txt
+++ b/tests/specs/html/HtmlFormat_UseTabs.txt
@@ -18,3 +18,15 @@
 > <div>
 > 	<p>a</p>
 > </div>
+
+!! should indent html within a list with spaces then tabs !!
+- item
+  <div>
+  <p>a</p>
+  </div>
+
+[expect]
+- item
+  <div>
+  	<p>a</p>
+  </div>

--- a/tests/specs/html/Html_All.txt
+++ b/tests/specs/html/Html_All.txt
@@ -59,3 +59,31 @@ a 
 <div>
   a 
 </div>
+
+!! should keep a comment and preformatted content within a block quote !!
+> <div>
+> <!--
+> a
+>   b
+> -->
+> <p>c</p>
+> </div>
+
+> <pre>
+> a
+>   b
+> </pre>
+
+[expect]
+> <div>
+>   <!--
+> a
+>   b
+> -->
+>   <p>c</p>
+> </div>
+
+> <pre>
+> a
+>   b
+> </pre>

--- a/tests/specs/html/Html_TextWrap_Always_WrapUnspacedScripts.txt
+++ b/tests/specs/html/Html_TextWrap_Always_WrapUnspacedScripts.txt
@@ -1,0 +1,10 @@
+~~ lineWidth: 12, textWrap: always, wrapUnspacedScripts: true ~~
+!! should break within the text of inline html but never between a character and a tag !!
+中文中文中文<b>粗体粗体粗体</b>中文中文中文中文
+
+[expect]
+中文中文中
+文<b>粗体粗
+体粗体</b>中
+文中文中文中
+文


### PR DESCRIPTION
## Bugs fixed

**Formatter (`src/generation`)**
- `dprint-ignore` / `ignore-start` inside a block quote or list item doubled the `>` markers / indentation (`> <!-- dprint-ignore -->\n> a   b` became a nested quote; a nested list item became an indented code block). Ignored text is now written line by line with the container prefixes stripped.
- A `dprint-ignore` comment before a code block inside a list item was dropped (the item split its children before the code block); the split now only happens for task list markers.
- Inline `$$y$$` inside a paragraph split the paragraph.
- Renumbering an ordered list could produce a ten digit marker, which is not a list item on the next pass; numbers are kept as written past nine digits.
- A footnote reference glued to a word stopped wrapping before that word, exceeding `lineWidth`.

**Markdown parser (`src/parser`)**
- Lazy continuation reached into an html block inside a container (`> <div>\n> x\ny` swallowed `y`).
- Inline math ate amounts of money (`costs $5 and $10 today`).
- `<@a>`, `<a@>`, `<foo\+@bar.com>` were accepted as email autolinks.
- Quadratic emphasis processing on unmatched closers (`"a* ".repeat(40k)`: 4.8s → 10ms) via cmark's `openers_bottom`.
- `<!-->` / `<!--->` were not read as inline comments.
- `</PRE>` / `</SCRIPT>` end markers were matched case sensitively.

**HTML formatter (`src/html`)**
- A close tag's case was rewritten to the open tag's (`<DIV>a</div>` → `</DIV>`).
- `<!-->`, `<!--->` and `--!>` comments were refused.

**Config / plugin**
- `check_config_updates` never migrated the deprecated `headingKind` / `unorderedListKind` / `listIndentKind` keys.
- ` ```MD ` fences were not treated as nested markdown.
- `strong_kind` builder doc default, the builder coverage test (4 of 29 options missing), `corpus_check.rs` with multiple BOMs.

## Tests added
- Unit tests for `resolve_config` (renames, unknown keys, invalid values, `deno`, global fallbacks) and `format_text` (empty files, CRLF, ignore file, code block callback behaviour, nested markdown, preserve options).
- ~50 parser spec cases (new `lazy_continuation_html.txt` plus math, links, html, emphasis, code, lists, tables, footnotes, headings, escapes).
- ~40 html parser spec cases.
- ~60 formatter spec cases (html, ignore comments in containers, lists, math, footnotes, text decoration, setext, rules, block quotes, tables, links, `textWrap: never`, hard breaks).

## Left as-is
- Nested quotes print as `>>` (an existing spec expects that).
- `MAX_NESTING` off by one vs. its message (cosmetic).
- Two `---` lines are thematic breaks rather than empty front matter.