### PR TITLE
fix: only write an opening delimiter run that reads one way

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1369,7 +1369,12 @@ fn decoration_delimiter(decoration: &TextDecoration, parent_content: Option<Span
       before: last,
       after: outside.after,
     };
-    run_can_open(opening, character) && run_can_close(closing, character)
+    // emphasis is paired by walking the closing runs of a block from left to
+    // right and taking the nearest opening run before each of them, so an
+    // opening run that could close as well is taken by whatever was written
+    // before it rather than opening anything. The closing run is safe either
+    // way: it comes after the opening one, so it is reached as a closer first
+    run_only_opens(opening, character) && run_can_close(closing, character)
   }
 
   /// Whether the delimiter would run into the content it is written around,
@@ -1480,6 +1485,13 @@ struct Surroundings {
 /// close emphasis, which is the "flanking" rule of the CommonMark spec.
 fn run_can_pair(surroundings: Surroundings, delimiter: char) -> bool {
   run_can_open(surroundings, delimiter) || run_can_close(surroundings, delimiter)
+}
+
+/// Whether a run of the character written within those surroundings opens
+/// emphasis and nothing else, so that no run written before it can take it for
+/// a closing run of its own.
+fn run_only_opens(surroundings: Surroundings, delimiter: char) -> bool {
+  run_can_open(surroundings, delimiter) && !run_can_close(surroundings, delimiter)
 }
 
 /// Whether a run of the character written within those surroundings opens

--- a/tests/specs/TextDecoration/TextDecoration_All.txt
+++ b/tests/specs/TextDecoration/TextDecoration_All.txt
@@ -129,6 +129,22 @@ _foo_—bar
 
 _foo_、_bar_。
 
+!! should keep asterisks where an underscore would be taken by one written earlier !!
+_(*=*!
+
+_a：)、*=*
+
+[expect]
+_(*=*!
+
+_a：)、*=*
+
+!! should keep asterisks where an underscore could be read as opening or closing !!
+(*=*)
+
+[expect]
+(*=*)
+
 !! should leave underscores that are not emphasis !!
 __太字__テキスト
 


### PR DESCRIPTION
Found while reviewing #263, but independent of it — this reproduces on `main` before that PR, and on every 0.23.x, with pure ascii.

### The bug

The formatter picks the character a decoration's delimiters are written with by asking whether a run of that character could open emphasis where the opening one goes and could close it where the closing one goes. Whether that run could *also* be read the other way never came into it.

CommonMark pairs emphasis by walking a block's closing runs from left to right and taking the nearest opening run before each of them. So an opening run that reads as a closing run too is taken by whatever was written earlier in the block rather than opening anything:

```
_(*=*!    ->    _(_=_!
```

which renders `<p><em>(</em>=_!</p>` instead of `<p>_(<em>=</em>!</p>` — the emphasis moved onto the `(` and the text that had it lost it.

### The fix

The opening run now has to read one way: `run_only_opens` rather than `run_can_open`. Where it doesn't, the character the file already had is kept, which is safe by construction since the file parsed that way.

The closing run is deliberately left alone. It comes after the opening run, so the left-to-right walk reaches it as a closer first and pairs it with the opening run before anything else can take it. Requiring it to read one way as well would give up underscores on prose as ordinary as `_a [link](u)_.` and `such as _-retrieve-_,` — I tried it, and those are real lines out of the corpus below.

### What it costs

Formatting **1,252 markdown files** from real projects on my machine comes out byte for byte identical to before.

On **200,000 random strings** of delimiters and unicode punctuation — checked by rendering input and output with markdown-it in commonmark mode and comparing — the cases where formatting changes what the text means drop from **948 to 134**.

The conservatism shows only where a decoration sits between punctuation on both sides *and* its content starts with punctuation, ex. `(*=*)` is no longer rewritten to `(_=_)`. There's a spec case pinning that, so the trade-off is written down rather than rediscovered later.

### What's left

The 134 remaining cases are all decorations nested in decorations where the outer and the inner land on the same character. Two shapes:

```
*._：_”©*—       ->  _._：_”©_—     (the inner opening run takes the outer's)
(_*”世€*_*_-—    ->  (__”世€__*_-—   (outer and inner meet as `__`, read as strong)
```

Both need the choice made for one decoration to account for the choice made for the other, which `collides` deliberately doesn't do today ("a decoration's own delimiters pair with each other rather than reaching out"). That's a bigger change than this one, so I left it — happy to take it on separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)